### PR TITLE
Fix (for now): Quit Mac app on all windows closed

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,10 +95,7 @@ function createMainWindow() {
 
 // quit application when all windows are closed
 app.on("window-all-closed", () => {
-  // on macOS it is common for applications to stay open until the user explicitly quits
-  if (!isMac) {
     app.quit();
-  }
 });
 
 app.on("activate", () => {


### PR DESCRIPTION
Right now, if the app is closed by clicking the top-left red close button on macOS, it doesn't quit the app. Normally this is the right behavior on macOS, but there's no corresponding menu item to make the window reappear, so this leads to a confusing state.

I'm down to look at the top-level macos menu later if you want, but this is at least slightly less confusing.