### PR TITLE
feat: drag and drop multiple files

### DIFF
--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -13,9 +13,10 @@ import { fetchNewsFeedData } from "./newsFeed";
 import { verifyIso } from "./verifyIso";
 
 export function setupListeners() {
-  ipcMain.on("onDragStart", (event, filePath: string) => {
+  ipcMain.on("onDragStart", (event, filePaths: string[]) => {
+    console.log(filePaths);
     event.sender.startDrag({
-      file: filePath,
+      files: filePaths, // if this shows an error, its due to the development api being outdated
       icon: nativeImage.createFromPath(path.join(__static, "images", "file.png")),
     });
   });

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -14,10 +14,12 @@ import { verifyIso } from "./verifyIso";
 
 export function setupListeners() {
   ipcMain.on("onDragStart", (event, filePaths: string[]) => {
-    event.sender.startDrag({
+    const dragArguments: any = {
       files: filePaths, // if this shows an error, its due to the development api being outdated
       icon: nativeImage.createFromPath(path.join(__static, "images", "file.png")),
-    });
+    };
+
+    event.sender.startDrag(dragArguments);
   });
 
   ipcMain.on("getAppSettingsSync", (event) => {

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -14,7 +14,6 @@ import { verifyIso } from "./verifyIso";
 
 export function setupListeners() {
   ipcMain.on("onDragStart", (event, filePaths: string[]) => {
-    console.log(filePaths);
     event.sender.startDrag({
       files: filePaths, // if this shows an error, its due to the development api being outdated
       icon: nativeImage.createFromPath(path.join(__static, "images", "file.png")),

--- a/src/renderer/components/DraggableFiles.tsx
+++ b/src/renderer/components/DraggableFiles.tsx
@@ -11,8 +11,8 @@ const DraggableLink = styled.a`
   -webkit-app-region: drag;
 `;
 
-export interface DraggableFileProps {
-  fullPath: string;
+export interface DraggableFilesProps {
+  fullPaths: string[];
   className?: string;
   style?: React.CSSProperties;
 }
@@ -21,10 +21,10 @@ export interface DraggableFileProps {
  * DraggableFile accepts the `fullPath` prop and allows that file to be dragged into other contexts
  * such as copied to a different folder or dragged into web-sites etc.
  */
-export const DraggableFile: React.FC<DraggableFileProps> = ({ fullPath, children, className, style }) => {
+export const DraggableFiles: React.FC<DraggableFilesProps> = ({ fullPaths, children, className, style }) => {
   const handleDragStart = (e: React.DragEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    ipcRenderer.send("onDragStart", fullPath);
+    ipcRenderer.send("onDragStart", fullPaths);
   };
   return (
     <DraggableLink

--- a/src/renderer/containers/ReplayBrowser/FileSelectionToolbar.tsx
+++ b/src/renderer/containers/ReplayBrowser/FileSelectionToolbar.tsx
@@ -58,7 +58,15 @@ export const FileSelectionToolbar: React.FC<FileSelectionToolbarProps> = ({
         </div>
         <div>
           <DraggableFiles fullPaths={filePaths}>
-            <Button color="secondary" variant="contained" size="small" startIcon={<DragIndicatorIcon />}>
+            <Button
+              color="secondary"
+              variant="contained"
+              size="small"
+              startIcon={<DragIndicatorIcon />}
+              css={css`
+                cursor: inherit;
+              `}
+            >
               Drag & Drop Replays
             </Button>
           </DraggableFiles>

--- a/src/renderer/containers/ReplayBrowser/FileSelectionToolbar.tsx
+++ b/src/renderer/containers/ReplayBrowser/FileSelectionToolbar.tsx
@@ -4,14 +4,17 @@ import styled from "@emotion/styled";
 import Button from "@material-ui/core/Button";
 import BlockIcon from "@material-ui/icons/Block";
 import DeleteIcon from "@material-ui/icons/Delete";
+import DragIndicatorIcon from "@material-ui/icons/DragIndicator";
 import PlayArrowIcon from "@material-ui/icons/PlayArrow";
 import SelectAllIcon from "@material-ui/icons/SelectAll";
 import React from "react";
 
 import { ConfirmationModal } from "@/components/ConfirmationModal";
+import { DraggableFiles } from "@/components/DraggableFiles";
 
 export interface FileSelectionToolbarProps {
   totalSelected: number;
+  filePaths: string[];
   onSelectAll: () => void;
   onPlay: () => void;
   onClear: () => void;
@@ -20,6 +23,7 @@ export interface FileSelectionToolbarProps {
 
 export const FileSelectionToolbar: React.FC<FileSelectionToolbarProps> = ({
   totalSelected,
+  filePaths,
   onSelectAll,
   onPlay,
   onClear,
@@ -53,13 +57,12 @@ export const FileSelectionToolbar: React.FC<FileSelectionToolbarProps> = ({
           {totalSelected} files selected
         </div>
         <div>
-          <Button
-            color="secondary"
-            variant="contained"
-            size="small"
-            onClick={() => setShowDeletePrompt(true)}
-            startIcon={<DeleteIcon />}
-          >
+          <DraggableFiles fullPaths={filePaths}>
+            <Button color="secondary" variant="contained" size="small" startIcon={<DragIndicatorIcon />}>
+              Drag & Drop Replays
+            </Button>
+          </DraggableFiles>
+          <Button color="secondary" variant="contained" size="small" startIcon={<DeleteIcon />}>
             Delete
           </Button>
           <Button color="secondary" variant="contained" size="small" onClick={onClear} startIcon={<BlockIcon />}>

--- a/src/renderer/containers/ReplayBrowser/FileSelectionToolbar.tsx
+++ b/src/renderer/containers/ReplayBrowser/FileSelectionToolbar.tsx
@@ -67,7 +67,7 @@ export const FileSelectionToolbar: React.FC<FileSelectionToolbarProps> = ({
                 cursor: inherit;
               `}
             >
-              Drag & Drop Replays
+              Share
             </Button>
           </DraggableFiles>
           <Button color="secondary" variant="contained" size="small" startIcon={<DeleteIcon />}>

--- a/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
@@ -164,6 +164,7 @@ export const ReplayBrowser: React.FC = () => {
               )}
               <FileSelectionToolbar
                 totalSelected={selectedFiles.length}
+                filePaths={selectedFiles}
                 onSelectAll={fileSelection.selectAll}
                 onPlay={() => playFiles(selectedFiles.map((path) => ({ path })))}
                 onClear={fileSelection.clearSelection}

--- a/src/renderer/containers/ReplayBrowser/ReplayFile.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayFile.tsx
@@ -17,7 +17,7 @@ import _ from "lodash";
 import moment from "moment";
 import React from "react";
 
-import { DraggableFile } from "@/components/DraggableFile";
+import { DraggableFiles } from "@/components/DraggableFiles";
 import { getStageImage } from "@/lib/utils";
 
 import { TeamElements } from "./TeamElements";
@@ -115,8 +115,8 @@ export const ReplayFile: React.FC<ReplayFileProps> = ({
               )}
               <InfoItem label={<LandscapeIcon />}>{stageName}</InfoItem>
             </div>
-            <DraggableFile
-              fullPath={fullPath}
+            <DraggableFiles
+              fullPaths={[fullPath]}
               css={css`
                 opacity: 0.6;
                 transition: opacity 0.2s ease-in-out;
@@ -127,7 +127,7 @@ export const ReplayFile: React.FC<ReplayFileProps> = ({
               `}
             >
               {name}
-            </DraggableFile>
+            </DraggableFiles>
           </div>
         </div>
       </Outer>


### PR DESCRIPTION
This allows you to drag & drop multiple files when being in the selection mode in the replay browser.
To do this, simply drag the new added button "Drag & Drop Replays" to the place you want to drop it to. (maybe there is a better/cleaner/more user-friendly way but this was the first idea i came up with)

Successfully tested on Windows 10, worked perfectly with 3914 replay files being selected and dropped over in Windows Explorer.

Fixes #174
![image](https://user-images.githubusercontent.com/33455186/123513419-6f3e0380-d68d-11eb-9a40-2cd344d588c2.png)
