### PR TITLE
deps: upgrade Electron to 13.1.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,13 @@ jobs:
       matrix:
         node-version: [14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - os: windows-latest
+            package_command: yarn run package --publish never
+          - os: ubuntu-latest
+            package_command: yarn run package --publish never
+          - os: macOS-latest
+            package_command: yarn run package-mac --publish never
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
@@ -56,7 +63,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           echo ${{ secrets.ENVFILE }} > .env
-          yarn run package --publish never
+          ${{ matrix.package_command }}
         env:
           CI: true
       - name: Prepare artifacts

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "electron-webpack dev",
     "build": "electron-webpack",
     "package": "yarn run build && electron-builder",
+    "package-mac": "yarn run build && electron-builder --mac --universal",
     "package:dir": "yarn run package --dir -c.compression=store -c.mac.identity=null",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "yarn run lint --fix",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "dotenv-webpack": "^6.0.0",
-    "electron": "7.3.3",
+    "electron": "13.1.8",
     "electron-builder": "^22.11.7",
     "electron-notarize": "^1.0.0",
     "electron-webpack": "^2.8.2",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,6 +46,7 @@ function createMainWindow() {
     minWidth: isDevelopment ? undefined : 900,
     backgroundColor: colors.purpleDarker,
     webPreferences: {
+      contextIsolation: false,
       nodeIntegration: true,
       nodeIntegrationInWorker: true,
       enableRemoteModule: true,

--- a/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
@@ -75,13 +75,14 @@ export const ReplayBrowser: React.FC = () => {
   const deleteFiles = (filePaths: string[]) => {
     let errCount = 0;
     filePaths.forEach((filePath) => {
-      const success = shell.moveItemToTrash(filePath);
-      if (success) {
-        // Remove the file from the store
-        removeFile(filePath);
-      } else {
-        errCount += 1;
-      }
+      shell.trashItem(filePath).then(
+        () => {
+          removeFile(filePath);
+        },
+        () => {
+          errCount += 1;
+        },
+      );
     });
 
     let message = `${filePaths.length - errCount} file(s) deleted successfully.`;
@@ -190,7 +191,7 @@ export const ReplayBrowser: React.FC = () => {
         >
           <div>
             <Tooltip title="Reveal location">
-              <IconButton onClick={() => shell.openItem(currentFolder)} size="small">
+              <IconButton onClick={() => shell.openPath(currentFolder)} size="small">
                 <FolderIcon
                   css={css`
                     color: ${colors.purpleLight};

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -31,7 +31,7 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
   const { addToast } = useToasts();
 
   const openDolphinDirectoryHandler = async () => {
-    shell.openItem(dolphinPath);
+    await shell.openPath(dolphinPath);
   };
 
   const configureDolphinHandler = async () => {

--- a/src/renderer/containers/SpectatePage/Footer.tsx
+++ b/src/renderer/containers/SpectatePage/Footer.tsx
@@ -29,7 +29,7 @@ export const Footer: React.FC = () => {
       <Tooltip title="Reveal location">
         <IconButton
           size="small"
-          onClick={() => shell.openItem(spectateSlpFolder)}
+          onClick={async () => await shell.openPath(spectateSlpFolder)}
           css={css`
             color: ${colors.purpleLight};
           `}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,7 +2551,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
   integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
 
-"@types/node@^12.0.12", "@types/node@^12.12.47":
+"@types/node@^12.12.47":
   version "12.19.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.9.tgz#990ad687ad8b26ef6dcc34a4f69c33d40c95b679"
   integrity sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q==
@@ -2560,6 +2560,11 @@
   version "13.13.36"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.36.tgz#0c4d3c4e365396c84b1c595524e2faff7dd45b26"
   integrity sha512-ctzZJ+XsmHQwe3xp07gFUq4JxBaRSYzKHPgblR76//UanGST7vfFNF0+ty5eEbgTqsENopzoDK090xlha9dccQ==
+
+"@types/node@^14.6.2":
+  version "14.17.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.4.tgz#218712242446fc868d0e007af29a4408c7765bc0"
+  integrity sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -5338,13 +5343,13 @@ electron-webpack@^2.8.2:
     webpack-merge "^4.2.2"
     yargs "^15.3.1"
 
-electron@7.3.3:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.3.tgz#f61502a3d42d85adfecd8e37f98da449b591f8af"
-  integrity sha512-PrJEsuRiaAhTDHtbH3EM+RIne+nZ6ifGChUadmtmPqHUQ+rIhf4jSi2ZN768IgBDw4SidMJiCrvQRiuDha9+Ew==
+electron@13.1.8:
+  version "13.1.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.8.tgz#a6def6eca7cafc7b068a8f71a069e521ba803182"
+  integrity sha512-ei2ZyyG81zUOlvm5Zxri668TdH5GNLY0wF+XrC2FRCqa8AABAPjJIWTRkhFEr/H6PDVPNZjMPvSs3XhHyVVk2g==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
+    "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
 elliptic@^6.5.3:


### PR DESCRIPTION
This is a pretty big jump, but functionality doesn't require many fixes.

Main reasons to upgrade are:
* Launcher will run native on M1 and we still only ship a single app bundle.
* Revealing location of replays on Linux will select the file (tested on Ubuntu).

The only issue is that during dev we see a lot more `DevTools failed to load source map` warnings.

![image](https://user-images.githubusercontent.com/6331403/123528181-6b64ae00-d69a-11eb-882e-e0a33aaf83b6.png)

It would be ideal if we could fix this, but we haven't had much success. I'm making this PR in hopes that someone might poke their head in and have a solution.