### PR TITLE
refactor: add better ipc endpoint naming scheme

### DIFF
--- a/src/broadcast/ipc.ts
+++ b/src/broadcast/ipc.ts
@@ -3,35 +3,41 @@ import { BroadcasterItem, StartBroadcastConfig } from "./types";
 
 // Handlers
 
-export const refreshBroadcastList = makeEndpoint.main(
+export const ipc_refreshBroadcastList = makeEndpoint.main(
   "refreshBroadcastList",
   <{ authToken: string }>_,
   <SuccessPayload>_,
 );
 
-export const watchBroadcast = makeEndpoint.main("watchBroadcast", <{ broadcasterId: string }>_, <SuccessPayload>_);
+export const ipc_watchBroadcast = makeEndpoint.main("watchBroadcast", <{ broadcasterId: string }>_, <SuccessPayload>_);
 
-export const startBroadcast = makeEndpoint.main("startBroadcast", <StartBroadcastConfig>_, <SuccessPayload>_);
+export const ipc_startBroadcast = makeEndpoint.main("startBroadcast", <StartBroadcastConfig>_, <SuccessPayload>_);
 
-export const stopBroadcast = makeEndpoint.main("stopBroadcast", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_stopBroadcast = makeEndpoint.main("stopBroadcast", <EmptyPayload>_, <SuccessPayload>_);
 
 // Events
 
-export const broadcastListUpdated = makeEndpoint.renderer(
+export const ipc_broadcastListUpdatedEvent = makeEndpoint.renderer(
   "broadcast_broadcastListUpdated",
   <{ items: BroadcasterItem[] }>_,
 );
 
-export const spectateErrorOccurred = makeEndpoint.renderer(
+export const ipc_spectateErrorOccurredEvent = makeEndpoint.renderer(
   "broadcast_spectateErrorOccurred",
   <{ errorMessage: string | null }>_,
 );
 
-export const broadcastErrorOccurred = makeEndpoint.renderer(
+export const ipc_broadcastErrorOccurredEvent = makeEndpoint.renderer(
   "broadcast_broadcastErrorOccurred",
   <{ errorMessage: string | null }>_,
 );
 
-export const slippiStatusChanged = makeEndpoint.renderer("broadcast_slippiStatusChanged", <{ status: number }>_);
+export const ipc_slippiStatusChangedEvent = makeEndpoint.renderer(
+  "broadcast_slippiStatusChanged",
+  <{ status: number }>_,
+);
 
-export const dolphinStatusChanged = makeEndpoint.renderer("broadcast_dolphinStatusChanged", <{ status: number }>_);
+export const ipc_dolphinStatusChangedEvent = makeEndpoint.renderer(
+  "broadcast_dolphinStatusChanged",
+  <{ status: number }>_,
+);

--- a/src/broadcast/main.ts
+++ b/src/broadcast/main.ts
@@ -1,27 +1,27 @@
 import { settingsManager } from "@settings/settingsManager";
 
 import { broadcastManager } from "./broadcastManager";
-import { refreshBroadcastList, startBroadcast, stopBroadcast, watchBroadcast } from "./ipc";
+import { ipc_refreshBroadcastList, ipc_startBroadcast, ipc_stopBroadcast, ipc_watchBroadcast } from "./ipc";
 import { spectateManager } from "./spectateManager";
 
-refreshBroadcastList.main!.handle(async ({ authToken }) => {
+ipc_refreshBroadcastList.main!.handle(async ({ authToken }) => {
   await spectateManager.connect(authToken);
   await spectateManager.refreshBroadcastList();
   return { success: true };
 });
 
-watchBroadcast.main!.handle(async ({ broadcasterId }) => {
+ipc_watchBroadcast.main!.handle(async ({ broadcasterId }) => {
   const folderPath = settingsManager.get().settings.spectateSlpPath;
   spectateManager.watchBroadcast(broadcasterId, folderPath, true);
   return { success: true };
 });
 
-startBroadcast.main!.handle(async (config) => {
+ipc_startBroadcast.main!.handle(async (config) => {
   await broadcastManager.start(config);
   return { success: true };
 });
 
-stopBroadcast.main!.handle(async () => {
+ipc_stopBroadcast.main!.handle(async () => {
   broadcastManager.stop();
   return { success: true };
 });

--- a/src/broadcast/spectateManager.ts
+++ b/src/broadcast/spectateManager.ts
@@ -7,7 +7,7 @@ import _ from "lodash";
 import { client as WebSocketClient, connection, IMessage } from "websocket";
 
 import { dolphinManager, ReplayCommunication } from "../dolphin";
-import { broadcastListUpdated, spectateErrorOccurred } from "./ipc";
+import { ipc_broadcastListUpdatedEvent, ipc_spectateErrorOccurredEvent } from "./ipc";
 import { BroadcasterItem } from "./types";
 
 const SLIPPI_WS_SERVER = process.env.SLIPPI_WS_SERVER;
@@ -335,9 +335,9 @@ export const spectateManager = new SpectateManager();
 
 // Forward the events to the renderer
 spectateManager.on(SpectateManagerEvent.BROADCAST_LIST_UPDATE, async (data: BroadcasterItem[]) => {
-  await broadcastListUpdated.main!.trigger({ items: data });
+  await ipc_broadcastListUpdatedEvent.main!.trigger({ items: data });
 });
 
 spectateManager.on(SpectateManagerEvent.ERROR, async (error) => {
-  await spectateErrorOccurred.main!.trigger({ errorMessage: error.message ?? JSON.stringify(error) });
+  await ipc_spectateErrorOccurredEvent.main!.trigger({ errorMessage: error.message ?? JSON.stringify(error) });
 });

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -1,9 +1,9 @@
 import { _, EmptyPayload, makeEndpoint } from "../ipc";
 import { NewsItem } from "./types";
 
-export const fetchNewsFeed = makeEndpoint.main("fetchNewsFeed", <EmptyPayload>_, <NewsItem[]>_);
+export const ipc_fetchNewsFeed = makeEndpoint.main("fetchNewsFeed", <EmptyPayload>_, <NewsItem[]>_);
 
-export const checkValidIso = makeEndpoint.main(
+export const ipc_checkValidIso = makeEndpoint.main(
   "checkValidIso",
   <{ path: string }>_,
   <{ path: string; valid: boolean }>_,

--- a/src/console/connectionScanner.ts
+++ b/src/console/connectionScanner.ts
@@ -2,7 +2,7 @@ import dgram from "dgram";
 import log from "electron-log";
 import moment from "moment";
 
-import { discoveredConsolesUpdated } from "./ipc";
+import { ipc_discoveredConsolesUpdatedEvent } from "./ipc";
 import { DiscoveredConsoleInfo } from "./types";
 
 const SECONDS = 1000;
@@ -85,7 +85,7 @@ export class ConnectionScanner {
 
   private _emitConsoleListUpdatedEvent() {
     const consoleList = Object.values(this.availableConnectionsByIp) as DiscoveredConsoleInfo[];
-    discoveredConsolesUpdated.main!.trigger({ consoles: consoleList }).catch(log.warn);
+    ipc_discoveredConsolesUpdatedEvent.main!.trigger({ consoles: consoleList }).catch(log.warn);
   }
 
   private _handleError = (err: Error) => {

--- a/src/console/ipc.ts
+++ b/src/console/ipc.ts
@@ -1,30 +1,34 @@
 import { _, EmptyPayload, makeEndpoint, SuccessPayload } from "../ipc";
 import { ConsoleMirrorStatusUpdate, DiscoveredConsoleInfo, MirrorConfig } from "./types";
 
-export const connectToConsoleMirror = makeEndpoint.main(
+// Endpoints
+
+export const ipc_connectToConsoleMirror = makeEndpoint.main(
   "connectToConsoleMirror",
   <{ config: MirrorConfig }>_,
   <SuccessPayload>_,
 );
 
-export const disconnectFromConsoleMirror = makeEndpoint.main(
+export const ipc_disconnectFromConsoleMirror = makeEndpoint.main(
   "disconnectFromConsoleMirror",
   <{ ip: string }>_,
   <SuccessPayload>_,
 );
 
-export const startMirroring = makeEndpoint.main("startMirroring", <{ ip: string }>_, <SuccessPayload>_);
+export const ipc_startMirroring = makeEndpoint.main("startMirroring", <{ ip: string }>_, <SuccessPayload>_);
 
-export const startDiscovery = makeEndpoint.main("startDiscovery", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_startDiscovery = makeEndpoint.main("startDiscovery", <EmptyPayload>_, <SuccessPayload>_);
 
-export const stopDiscovery = makeEndpoint.main("stopDiscovery", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_stopDiscovery = makeEndpoint.main("stopDiscovery", <EmptyPayload>_, <SuccessPayload>_);
 
-export const discoveredConsolesUpdated = makeEndpoint.renderer(
+// Events
+
+export const ipc_discoveredConsolesUpdatedEvent = makeEndpoint.renderer(
   "console_discoveredConsolesUpdated",
   <{ consoles: DiscoveredConsoleInfo[] }>_,
 );
 
-export const consoleMirrorStatusUpdated = makeEndpoint.renderer(
+export const ipc_consoleMirrorStatusUpdatedEvent = makeEndpoint.renderer(
   "console_consoleMirrorStatusUpdated",
   <{ ip: string; info: Partial<ConsoleMirrorStatusUpdate> }>_,
 );

--- a/src/console/main.ts
+++ b/src/console/main.ts
@@ -1,34 +1,34 @@
 import { connectionScanner } from "./connectionScanner";
 import {
-  connectToConsoleMirror,
-  disconnectFromConsoleMirror,
-  startDiscovery,
-  startMirroring,
-  stopDiscovery,
+  ipc_connectToConsoleMirror,
+  ipc_disconnectFromConsoleMirror,
+  ipc_startDiscovery,
+  ipc_startMirroring,
+  ipc_stopDiscovery,
 } from "./ipc";
 import { mirrorManager } from "./mirrorManager";
 
-connectToConsoleMirror.main!.handle(async ({ config }) => {
+ipc_connectToConsoleMirror.main!.handle(async ({ config }) => {
   await mirrorManager.connect(config);
   return { success: true };
 });
 
-disconnectFromConsoleMirror.main!.handle(async ({ ip }) => {
+ipc_disconnectFromConsoleMirror.main!.handle(async ({ ip }) => {
   mirrorManager.disconnect(ip);
   return { success: true };
 });
 
-startMirroring.main!.handle(async ({ ip }) => {
+ipc_startMirroring.main!.handle(async ({ ip }) => {
   await mirrorManager.startMirroring(ip);
   return { success: true };
 });
 
-startDiscovery.main!.handle(async () => {
+ipc_startDiscovery.main!.handle(async () => {
   await connectionScanner.startScanning();
   return { success: true };
 });
 
-stopDiscovery.main!.handle(async () => {
+ipc_stopDiscovery.main!.handle(async () => {
   connectionScanner.stopScanning();
   return { success: true };
 });

--- a/src/console/mirrorManager.ts
+++ b/src/console/mirrorManager.ts
@@ -18,7 +18,7 @@ import path from "path";
 
 import { AutoSwitcher } from "./autoSwitcher";
 import { ConsoleRelay } from "./consoleRelay";
-import { consoleMirrorStatusUpdated } from "./ipc";
+import { ipc_consoleMirrorStatusUpdatedEvent } from "./ipc";
 import { MirrorConfig, MirrorDetails } from "./types";
 
 /**
@@ -63,7 +63,7 @@ export class MirrorManager {
       this._playFile(currFilePath, config.ipAddress).catch(log.warn);
 
       // Let the front-end know of the new file that we're writing too
-      consoleMirrorStatusUpdated
+      ipc_consoleMirrorStatusUpdatedEvent
         .main!.trigger({
           ip: config.ipAddress,
           info: {
@@ -75,7 +75,7 @@ export class MirrorManager {
 
     // Clear the current writing file
     fileWriter.on(SlpFileWriterEvent.FILE_COMPLETE, () => {
-      consoleMirrorStatusUpdated
+      ipc_consoleMirrorStatusUpdatedEvent
         .main!.trigger({
           ip: config.ipAddress,
           info: {
@@ -99,7 +99,7 @@ export class MirrorManager {
         log.info(details);
         fileWriter.updateSettings({ consoleNickname: details.consoleNick });
 
-        consoleMirrorStatusUpdated
+        ipc_consoleMirrorStatusUpdatedEvent
           .main!.trigger({
             ip: config.ipAddress,
             info: {
@@ -111,7 +111,7 @@ export class MirrorManager {
 
       connection.on(ConnectionEvent.STATUS_CHANGE, (status) => {
         log.info(`${config.ipAddress} status changed: ${status}`);
-        consoleMirrorStatusUpdated
+        ipc_consoleMirrorStatusUpdatedEvent
           .main!.trigger({
             ip: config.ipAddress,
             info: {
@@ -195,7 +195,7 @@ export class MirrorManager {
 
     // FIXME: Not sure why the disconnected status update isn't working
     // For now let's just manually show the disconnected status
-    consoleMirrorStatusUpdated
+    ipc_consoleMirrorStatusUpdatedEvent
       .main!.trigger({
         ip,
         info: {

--- a/src/dolphin/downloadDolphin.ts
+++ b/src/dolphin/downloadDolphin.ts
@@ -10,12 +10,12 @@ import { lt } from "semver";
 
 import { fileExists } from "../main/fileExists";
 import { getLatestRelease } from "../main/github";
-import { dolphinDownloadFinished, dolphinDownloadLogReceived } from "./ipc";
+import { ipc_dolphinDownloadFinishedEvent, ipc_dolphinDownloadLogReceivedEvent } from "./ipc";
 import { DolphinLaunchType } from "./types";
 import { findDolphinExecutable } from "./util";
 
 function logDownloadInfo(message: string): void {
-  void dolphinDownloadLogReceived.main!.trigger({ message });
+  void ipc_dolphinDownloadLogReceivedEvent.main!.trigger({ message });
 }
 
 export async function assertDolphinInstallation(
@@ -57,10 +57,10 @@ export async function assertDolphinInstallations(): Promise<void> {
   try {
     await assertDolphinInstallation(DolphinLaunchType.NETPLAY, logDownloadInfo);
     await assertDolphinInstallation(DolphinLaunchType.PLAYBACK, logDownloadInfo);
-    await dolphinDownloadFinished.main!.trigger({ error: null });
+    await ipc_dolphinDownloadFinishedEvent.main!.trigger({ error: null });
   } catch (err) {
     console.error(err);
-    await dolphinDownloadFinished.main!.trigger({ error: err.message });
+    await ipc_dolphinDownloadFinishedEvent.main!.trigger({ error: err.message });
   }
   return;
 }

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -3,44 +3,44 @@ import { DolphinLaunchType, PlayKey, ReplayQueueItem } from "./types";
 
 // Handlers
 
-export const downloadDolphin = makeEndpoint.main("downloadDolphin", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_downloadDolphin = makeEndpoint.main("downloadDolphin", <EmptyPayload>_, <SuccessPayload>_);
 
-export const configureDolphin = makeEndpoint.main(
+export const ipc_configureDolphin = makeEndpoint.main(
   "configureDolphin",
   <{ dolphinType: DolphinLaunchType }>_,
   <SuccessPayload>_,
 );
 
-export const reinstallDolphin = makeEndpoint.main(
+export const ipc_reinstallDolphin = makeEndpoint.main(
   "reinstallDolphin",
   <{ dolphinType: DolphinLaunchType }>_,
   <SuccessPayload>_,
 );
 
-export const clearDolphinCache = makeEndpoint.main(
+export const ipc_clearDolphinCache = makeEndpoint.main(
   "clearDolphinCache",
   <{ dolphinType: DolphinLaunchType }>_,
   <SuccessPayload>_,
 );
 
-export const storePlayKeyFile = makeEndpoint.main("storePlayKeyFile", <{ key: PlayKey }>_, <SuccessPayload>_);
+export const ipc_storePlayKeyFile = makeEndpoint.main("storePlayKeyFile", <{ key: PlayKey }>_, <SuccessPayload>_);
 
-export const checkPlayKeyExists = makeEndpoint.main("checkPlayKeyExists", <EmptyPayload>_, <{ exists: boolean }>_);
+export const ipc_checkPlayKeyExists = makeEndpoint.main("checkPlayKeyExists", <EmptyPayload>_, <{ exists: boolean }>_);
 
-export const removePlayKeyFile = makeEndpoint.main("removePlayKeyFile", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_removePlayKeyFile = makeEndpoint.main("removePlayKeyFile", <EmptyPayload>_, <SuccessPayload>_);
 
-export const viewSlpReplay = makeEndpoint.main("viewSlpReplay", <{ files: ReplayQueueItem[] }>_, <SuccessPayload>_);
+export const ipc_viewSlpReplay = makeEndpoint.main("viewSlpReplay", <{ files: ReplayQueueItem[] }>_, <SuccessPayload>_);
 
-export const launchNetplayDolphin = makeEndpoint.main("launchNetplayDolphin", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_launchNetplayDolphin = makeEndpoint.main("launchNetplayDolphin", <EmptyPayload>_, <SuccessPayload>_);
 
 // Events
 
-export const dolphinDownloadFinished = makeEndpoint.renderer(
+export const ipc_dolphinDownloadFinishedEvent = makeEndpoint.renderer(
   "dolphin_dolphinDownloadFinished",
   <{ error: string | null }>_,
 );
 
-export const dolphinDownloadLogReceived = makeEndpoint.renderer(
+export const ipc_dolphinDownloadLogReceivedEvent = makeEndpoint.renderer(
   "dolphin_dolphinDownloadLogReceived",
   <{ message: string }>_,
 );

--- a/src/dolphin/main.ts
+++ b/src/dolphin/main.ts
@@ -1,59 +1,59 @@
 import { fileExists } from "../main/fileExists";
 import { assertDolphinInstallations } from "./downloadDolphin";
 import {
-  checkPlayKeyExists,
-  clearDolphinCache,
-  configureDolphin,
-  downloadDolphin,
-  launchNetplayDolphin,
-  reinstallDolphin,
-  removePlayKeyFile,
-  storePlayKeyFile,
-  viewSlpReplay,
+  ipc_checkPlayKeyExists,
+  ipc_clearDolphinCache,
+  ipc_configureDolphin,
+  ipc_downloadDolphin,
+  ipc_launchNetplayDolphin,
+  ipc_reinstallDolphin,
+  ipc_removePlayKeyFile,
+  ipc_storePlayKeyFile,
+  ipc_viewSlpReplay,
 } from "./ipc";
 import { dolphinManager } from "./manager";
 import { deletePlayKeyFile, findPlayKey, writePlayKeyFile } from "./playkey";
 
-downloadDolphin.main!.handle(async () => {
+ipc_downloadDolphin.main!.handle(async () => {
   await assertDolphinInstallations();
   return { success: true };
 });
 
-configureDolphin.main!.handle(async ({ dolphinType }) => {
+ipc_configureDolphin.main!.handle(async ({ dolphinType }) => {
   console.log("configuring dolphin...");
   await dolphinManager.configureDolphin(dolphinType);
   return { success: true };
 });
 
-reinstallDolphin.main!.handle(async ({ dolphinType }) => {
+ipc_reinstallDolphin.main!.handle(async ({ dolphinType }) => {
   console.log("reinstalling dolphin...");
   await dolphinManager.reinstallDolphin(dolphinType);
   return { success: true };
 });
 
-clearDolphinCache.main!.handle(async ({ dolphinType }) => {
+ipc_clearDolphinCache.main!.handle(async ({ dolphinType }) => {
   console.log("clearing dolphin cache...");
   await dolphinManager.clearCache(dolphinType);
   return { success: true };
 });
 
-storePlayKeyFile.main!.handle(async ({ key }) => {
+ipc_storePlayKeyFile.main!.handle(async ({ key }) => {
   await writePlayKeyFile(key);
   return { success: true };
 });
 
-checkPlayKeyExists.main!.handle(async () => {
+ipc_checkPlayKeyExists.main!.handle(async () => {
   const keyPath = await findPlayKey();
   const exists = await fileExists(keyPath);
   return { exists };
 });
 
-removePlayKeyFile.main!.handle(async () => {
+ipc_removePlayKeyFile.main!.handle(async () => {
   await deletePlayKeyFile();
   return { success: true };
 });
 
-viewSlpReplay.main!.handle(async ({ files }) => {
+ipc_viewSlpReplay.main!.handle(async ({ files }) => {
   await dolphinManager.launchPlaybackDolphin("playback", {
     mode: "queue",
     queue: files,
@@ -61,7 +61,7 @@ viewSlpReplay.main!.handle(async ({ files }) => {
   return { success: true };
 });
 
-launchNetplayDolphin.main!.handle(async () => {
+ipc_launchNetplayDolphin.main!.handle(async () => {
   await dolphinManager.launchNetplayDolphin();
   return { success: true };
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { dolphinManager } from "@dolphin/manager";
-import { showStatsPage } from "@replays/ipc";
+import { ipc_statsPageRequestedEvent } from "@replays/ipc";
 import { colors } from "common/colors";
 import { isDevelopment, isMac } from "common/constants";
 import { delay } from "common/delay";
@@ -263,5 +263,5 @@ const playReplayAndShowStats = async (filePath: string) => {
     mode: "normal",
     replay: filePath,
   });
-  await showStatsPage.main!.trigger({ filePath });
+  await ipc_statsPageRequestedEvent.main!.trigger({ filePath });
 };

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -5,7 +5,7 @@ import "@settings/main";
 import "@console/main";
 
 import { settingsManager } from "@settings/settingsManager";
-import { checkValidIso, fetchNewsFeed } from "common/ipc";
+import { ipc_checkValidIso, ipc_fetchNewsFeed } from "common/ipc";
 import { ipcMain, nativeImage } from "electron";
 import path from "path";
 
@@ -25,12 +25,12 @@ export function setupListeners() {
     event.returnValue = settings;
   });
 
-  fetchNewsFeed.main!.handle(async () => {
+  ipc_fetchNewsFeed.main!.handle(async () => {
     const result = await fetchNewsFeedData();
     return result;
   });
 
-  checkValidIso.main!.handle(async ({ path }) => {
+  ipc_checkValidIso.main!.handle(async ({ path }) => {
     // Make sure we have a valid path
     if (!path) {
       return { path, valid: false };

--- a/src/renderer/containers/Console/index.tsx
+++ b/src/renderer/containers/Console/index.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { startDiscovery, stopDiscovery } from "@console/ipc";
+import { ipc_startDiscovery, ipc_stopDiscovery } from "@console/ipc";
 import { css, jsx } from "@emotion/react";
 import styled from "@emotion/styled";
 import AddIcon from "@material-ui/icons/Add";
@@ -44,7 +44,7 @@ export const Console: React.FC = () => {
   React.useEffect(() => {
     // Start scanning for new consoles
     setIsScanning(false);
-    startDiscovery
+    ipc_startDiscovery
       .renderer!.trigger({})
       .then(() => setIsScanning(true))
       .catch((err) => {
@@ -53,7 +53,7 @@ export const Console: React.FC = () => {
 
     // Stop scanning on component unmount
     return () => {
-      void stopDiscovery.renderer!.trigger({});
+      void ipc_stopDiscovery.renderer!.trigger({});
     };
   }, [addToast]);
 

--- a/src/renderer/containers/Header/index.tsx
+++ b/src/renderer/containers/Header/index.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { launchNetplayDolphin } from "@dolphin/ipc";
+import { ipc_launchNetplayDolphin } from "@dolphin/ipc";
 import { css, jsx } from "@emotion/react";
 import styled from "@emotion/styled";
 import Box from "@material-ui/core/Box";
@@ -79,7 +79,7 @@ export const Header: React.FC<HeaderProps> = ({ path, menuItems }) => {
     }
 
     try {
-      const launchResult = await launchNetplayDolphin.renderer!.trigger({});
+      const launchResult = await ipc_launchNetplayDolphin.renderer!.trigger({});
       if (!launchResult.result) {
         log.info("Error launching netplay dolphin", launchResult.errors);
         throw new Error("Error launching netplay dolphin");

--- a/src/renderer/containers/QuickStart/IsoSelectionStep.tsx
+++ b/src/renderer/containers/QuickStart/IsoSelectionStep.tsx
@@ -11,7 +11,7 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import { useTheme } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { colors } from "common/colors";
-import { checkValidIso } from "common/ipc";
+import { ipc_checkValidIso } from "common/ipc";
 import React from "react";
 import { useDropzone } from "react-dropzone";
 import { useToasts } from "react-toast-notifications";
@@ -56,7 +56,7 @@ const Container = styled.div`
 
 export const IsoSelectionStep: React.FC = () => {
   const [tempIsoPath, setTempIsoPath] = React.useState("");
-  const verification = checkValidIso.renderer!.useValue({ path: tempIsoPath }, { path: tempIsoPath, valid: false });
+  const verification = ipc_checkValidIso.renderer!.useValue({ path: tempIsoPath }, { path: tempIsoPath, valid: false });
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("xs"));
   const loading = verification.isUpdating;

--- a/src/renderer/containers/ReplayFileStats/index.tsx
+++ b/src/renderer/containers/ReplayFileStats/index.tsx
@@ -6,7 +6,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import ErrorIcon from "@material-ui/icons/Error";
 import FolderIcon from "@material-ui/icons/Folder";
 import HelpIcon from "@material-ui/icons/Help";
-import { calculateGameStats } from "@replays/ipc";
+import { ipc_calculateGameStats } from "@replays/ipc";
 import { FileResult } from "@replays/types";
 import { colors } from "common/colors";
 import { shell } from "electron";
@@ -52,7 +52,7 @@ export const ReplayFileStats: React.FC<ReplayFileStatsProps> = (props) => {
   const { filePath } = props;
 
   const gameStatsQuery = useQuery(["loadStatsQuery", filePath], async () => {
-    const queryRes = await calculateGameStats.renderer!.trigger({ filePath: filePath });
+    const queryRes = await ipc_calculateGameStats.renderer!.trigger({ filePath: filePath });
     if (!queryRes.result) {
       console.error(`Error calculating game stats: ${filePath}`, queryRes.errors);
       throw new Error(`Error calculating game stats ${filePath}`);

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { clearDolphinCache, configureDolphin, reinstallDolphin } from "@dolphin/ipc";
+import { ipc_clearDolphinCache, ipc_configureDolphin, ipc_reinstallDolphin } from "@dolphin/ipc";
 import { DolphinLaunchType } from "@dolphin/types";
 import { css, jsx } from "@emotion/react";
 import Button from "@material-ui/core/Button";
@@ -58,16 +58,16 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
         autoDismiss: true,
       });
     }
-    await configureDolphin.renderer!.trigger({ dolphinType });
+    await ipc_configureDolphin.renderer!.trigger({ dolphinType });
   };
 
   const reinstallDolphinHandler = async () => {
     console.log("reinstall button clicked");
-    await reinstallDolphin.renderer!.trigger({ dolphinType });
+    await ipc_reinstallDolphin.renderer!.trigger({ dolphinType });
   };
 
   const clearDolphinCacheHandler = async () => {
-    await clearDolphinCache.renderer!.trigger({ dolphinType });
+    await ipc_clearDolphinCache.renderer!.trigger({ dolphinType });
   };
 
   return (

--- a/src/renderer/containers/SpectatePage/index.tsx
+++ b/src/renderer/containers/SpectatePage/index.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { watchBroadcast } from "@broadcast/ipc";
+import { ipc_watchBroadcast } from "@broadcast/ipc";
 import { css, jsx } from "@emotion/react";
 import styled from "@emotion/styled";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
@@ -31,7 +31,7 @@ export const SpectatePage: React.FC = () => {
         autoDismiss: true,
       });
     }
-    await watchBroadcast.renderer!.trigger({ broadcasterId: id });
+    await ipc_watchBroadcast.renderer!.trigger({ broadcasterId: id });
   };
 
   if (!user) {

--- a/src/renderer/lib/consoleConnection.ts
+++ b/src/renderer/lib/consoleConnection.ts
@@ -1,6 +1,6 @@
-import { connectToConsoleMirror, disconnectFromConsoleMirror, startMirroring } from "@console/ipc";
+import { ipc_connectToConsoleMirror, ipc_disconnectFromConsoleMirror, ipc_startMirroring } from "@console/ipc";
 import { MirrorConfig } from "@console/types";
-import { addNewConnection, deleteConnection, editConnection } from "@settings/ipc";
+import { ipc_addNewConnection, ipc_deleteConnection, ipc_editConnection } from "@settings/ipc";
 import { StoredConnection } from "@settings/types";
 import { Ports } from "@slippi/slippi-js";
 import * as fs from "fs-extra";
@@ -8,7 +8,7 @@ import * as fs from "fs-extra";
 export type EditConnectionType = Omit<StoredConnection, "id">;
 
 export const addConsoleConnection = async (connection: EditConnectionType) => {
-  const res = await addNewConnection.renderer!.trigger({ connection });
+  const res = await ipc_addNewConnection.renderer!.trigger({ connection });
   if (!res.result) {
     console.error("Error adding console: ", res.errors);
     throw new Error("Error adding console");
@@ -16,7 +16,7 @@ export const addConsoleConnection = async (connection: EditConnectionType) => {
 };
 
 export const editConsoleConnection = async (id: number, connection: EditConnectionType) => {
-  const res = await editConnection.renderer!.trigger({ id, connection });
+  const res = await ipc_editConnection.renderer!.trigger({ id, connection });
   if (!res.result) {
     console.error("Error editing console: ", res.errors);
     throw new Error("Error editing console");
@@ -24,7 +24,7 @@ export const editConsoleConnection = async (id: number, connection: EditConnecti
 };
 
 export const deleteConsoleConnection = async (id: number) => {
-  const res = await deleteConnection.renderer!.trigger({ id });
+  const res = await ipc_deleteConnection.renderer!.trigger({ id });
   if (!res.result) {
     console.error("Error removing console: ", res.errors);
     throw new Error("Error removing console");
@@ -51,7 +51,7 @@ export const connectToConsole = async (conn: StoredConnection) => {
 
   fs.ensureDirSync(config.folderPath);
 
-  const res = await connectToConsoleMirror.renderer!.trigger({ config });
+  const res = await ipc_connectToConsoleMirror.renderer!.trigger({ config });
   if (!res.result) {
     console.error("Error connecting to console: ", res.errors);
     throw new Error("Error connecting to console");
@@ -59,7 +59,7 @@ export const connectToConsole = async (conn: StoredConnection) => {
 };
 
 export const startConsoleMirror = async (ip: string) => {
-  const res = await startMirroring.renderer!.trigger({ ip });
+  const res = await ipc_startMirroring.renderer!.trigger({ ip });
   if (!res.result) {
     console.error("Error starting console mirror: ", res.errors);
     throw new Error("Error starting console mirror");
@@ -67,7 +67,7 @@ export const startConsoleMirror = async (ip: string) => {
 };
 
 export const disconnectFromConsole = async (ip: string) => {
-  const res = await disconnectFromConsoleMirror.renderer!.trigger({ ip });
+  const res = await ipc_disconnectFromConsoleMirror.renderer!.trigger({ ip });
   if (!res.result) {
     console.error("Error disconnecting from console mirror: ", res.errors);
     throw new Error("Error disconnecting from console mirror");

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -1,4 +1,4 @@
-import { dolphinDownloadFinished, downloadDolphin } from "dolphin/ipc";
+import { ipc_dolphinDownloadFinishedEvent, ipc_downloadDolphin } from "dolphin/ipc";
 import log from "electron-log";
 import firebase from "firebase";
 import create from "zustand";
@@ -60,7 +60,7 @@ export const useAppInitialization = () => {
 
     promises.push(
       new Promise<void>((resolve) => {
-        const handler = dolphinDownloadFinished.renderer!.handle(async ({ error }) => {
+        const handler = ipc_dolphinDownloadFinishedEvent.renderer!.handle(async ({ error }) => {
           // We only want to handle this event once so immediately destroy
           handler.destroy();
 
@@ -75,7 +75,7 @@ export const useAppInitialization = () => {
     );
 
     // Download Dolphin if necessary
-    promises.push(downloadDolphin.renderer!.trigger({}));
+    promises.push(ipc_downloadDolphin.renderer!.trigger({}));
 
     // Wait for all the promises to complete before completing
     try {

--- a/src/renderer/lib/hooks/useAppListeners.ts
+++ b/src/renderer/lib/hooks/useAppListeners.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
-  broadcastErrorOccurred,
-  broadcastListUpdated,
-  dolphinStatusChanged,
-  slippiStatusChanged,
+  ipc_broadcastErrorOccurredEvent,
+  ipc_broadcastListUpdatedEvent,
+  ipc_dolphinStatusChangedEvent,
+  ipc_slippiStatusChangedEvent,
 } from "@broadcast/ipc";
-import { consoleMirrorStatusUpdated, discoveredConsolesUpdated } from "@console/ipc";
-import { dolphinDownloadLogReceived } from "@dolphin/ipc";
-import { loadProgressUpdated, showStatsPage } from "@replays/ipc";
-import { settingsUpdated } from "@settings/ipc";
-import { checkValidIso } from "common/ipc";
+import { ipc_consoleMirrorStatusUpdatedEvent, ipc_discoveredConsolesUpdatedEvent } from "@console/ipc";
+import { ipc_dolphinDownloadLogReceivedEvent } from "@dolphin/ipc";
+import { ipc_loadProgressUpdatedEvent, ipc_statsPageRequestedEvent } from "@replays/ipc";
+import { ipc_settingsUpdatedEvent } from "@settings/ipc";
+import { ipc_checkValidIso } from "common/ipc";
 import log from "electron-log";
 import firebase from "firebase";
 import throttle from "lodash/throttle";
@@ -63,52 +63,52 @@ export const useAppListeners = () => {
   }, [initialized]);
 
   const setLogMessage = useAppStore((store) => store.setLogMessage);
-  dolphinDownloadLogReceived.renderer!.useEvent(async ({ message }) => {
+  ipc_dolphinDownloadLogReceivedEvent.renderer!.useEvent(async ({ message }) => {
     log.info(message);
     setLogMessage(message);
   }, []);
 
   const setSlippiConnectionStatus = useConsole((store) => store.setSlippiConnectionStatus);
-  slippiStatusChanged.renderer!.useEvent(async ({ status }) => {
+  ipc_slippiStatusChangedEvent.renderer!.useEvent(async ({ status }) => {
     setSlippiConnectionStatus(status);
   }, []);
 
   const setDolphinConnectionStatus = useConsole((store) => store.setDolphinConnectionStatus);
-  dolphinStatusChanged.renderer!.useEvent(async ({ status }) => {
+  ipc_dolphinStatusChangedEvent.renderer!.useEvent(async ({ status }) => {
     setDolphinConnectionStatus(status);
   }, []);
 
   const setBroadcastError = useConsole((store) => store.setBroadcastError);
-  broadcastErrorOccurred.renderer!.useEvent(async ({ errorMessage }) => {
+  ipc_broadcastErrorOccurredEvent.renderer!.useEvent(async ({ errorMessage }) => {
     setBroadcastError(errorMessage);
   }, []);
 
   const updateProgress = useReplays((store) => store.updateProgress);
   const throttledUpdateProgress = throttle(updateProgress, 50);
-  loadProgressUpdated.renderer!.useEvent(async (progress) => {
+  ipc_loadProgressUpdatedEvent.renderer!.useEvent(async (progress) => {
     throttledUpdateProgress(progress);
   }, []);
 
   const updateSettings = useSettings((store) => store.updateSettings);
-  settingsUpdated.renderer!.useEvent(async (newSettings) => {
+  ipc_settingsUpdatedEvent.renderer!.useEvent(async (newSettings) => {
     updateSettings(newSettings);
   }, []);
 
   // Listen to when the list of broadcasting users has changed
   const updateBroadcastingList = useBroadcastListStore((store) => store.setItems);
-  broadcastListUpdated.renderer!.useEvent(async ({ items }) => {
+  ipc_broadcastListUpdatedEvent.renderer!.useEvent(async ({ items }) => {
     updateBroadcastingList(items);
   }, []);
 
   // Update the discovered console list
   const updateConsoleItems = useConsoleDiscoveryStore((store) => store.updateConsoleItems);
-  discoveredConsolesUpdated.renderer!.handle(async ({ consoles }) => {
+  ipc_discoveredConsolesUpdatedEvent.renderer!.handle(async ({ consoles }) => {
     updateConsoleItems(consoles);
   });
 
   // Update the mirroring console status
   const updateConsoleStatus = useConsoleDiscoveryStore((store) => store.updateConsoleStatus);
-  consoleMirrorStatusUpdated.renderer!.handle(async ({ ip, info }) => {
+  ipc_consoleMirrorStatusUpdatedEvent.renderer!.handle(async ({ ip, info }) => {
     updateConsoleStatus(ip, info);
   });
 
@@ -125,7 +125,7 @@ export const useAppListeners = () => {
 
     // Start iso validation
     setIsValidating(true);
-    checkValidIso
+    ipc_checkValidIso
       .renderer!.trigger({ path: isoPath })
       .then((isoCheckResult) => {
         if (!isoCheckResult.result) {
@@ -148,7 +148,7 @@ export const useAppListeners = () => {
 
   const clearSelectedFile = useReplays((store) => store.clearSelectedFile);
   const { goToReplayStatsPage } = useReplayBrowserNavigation();
-  showStatsPage.renderer!.handle(async ({ filePath }) => {
+  ipc_statsPageRequestedEvent.renderer!.handle(async ({ filePath }) => {
     await clearSelectedFile();
     goToReplayStatsPage(filePath);
   });

--- a/src/renderer/lib/hooks/useBroadcast.ts
+++ b/src/renderer/lib/hooks/useBroadcast.ts
@@ -1,4 +1,4 @@
-import { startBroadcast, stopBroadcast } from "@broadcast/ipc";
+import { ipc_startBroadcast, ipc_stopBroadcast } from "@broadcast/ipc";
 import { StartBroadcastConfig } from "@broadcast/types";
 import log from "electron-log";
 
@@ -14,7 +14,7 @@ export const useBroadcast = () => {
 
     const authToken = await user.getIdToken();
     log.info("[Broadcast] Starting broadcast");
-    const res = await startBroadcast.renderer!.trigger({
+    const res = await ipc_startBroadcast.renderer!.trigger({
       ...config,
       authToken,
     });
@@ -26,7 +26,7 @@ export const useBroadcast = () => {
   };
 
   const stopBroadcasting = async () => {
-    const res = await stopBroadcast.renderer!.trigger({});
+    const res = await ipc_stopBroadcast.renderer!.trigger({});
     if (!res.result) {
       log.error("Error stopping broadcast", res.errors);
       throw new Error("Error stopping broadcast");

--- a/src/renderer/lib/hooks/useBroadcastList.ts
+++ b/src/renderer/lib/hooks/useBroadcastList.ts
@@ -1,4 +1,4 @@
-import { refreshBroadcastList } from "@broadcast/ipc";
+import { ipc_refreshBroadcastList } from "@broadcast/ipc";
 import { BroadcasterItem } from "@broadcast/types";
 import throttle from "lodash/throttle";
 import create from "zustand";
@@ -26,7 +26,7 @@ export const useBroadcastList = () => {
       throw new Error("User is not logged in");
     }
     const authToken = await currentUser.getIdToken();
-    const broadcastListResult = await refreshBroadcastList.renderer!.trigger({ authToken });
+    const broadcastListResult = await ipc_refreshBroadcastList.renderer!.trigger({ authToken });
     if (!broadcastListResult.result) {
       throw new Error("Error refreshing broadcast list");
     }

--- a/src/renderer/lib/hooks/useNewsFeed.ts
+++ b/src/renderer/lib/hooks/useNewsFeed.ts
@@ -1,4 +1,4 @@
-import { fetchNewsFeed } from "common/ipc";
+import { ipc_fetchNewsFeed } from "common/ipc";
 import { NewsItem } from "common/types";
 import log from "electron-log";
 import create from "zustand";
@@ -16,7 +16,7 @@ export const useNewsFeed = create(
         log.info("Fetching news articles...");
         set({ fetching: true });
 
-        fetchNewsFeed
+        ipc_fetchNewsFeed
           .renderer!.trigger({})
           .then((articlesResult) => {
             if (!articlesResult.result) {

--- a/src/renderer/lib/hooks/usePlayFiles.ts
+++ b/src/renderer/lib/hooks/usePlayFiles.ts
@@ -1,4 +1,4 @@
-import { viewSlpReplay } from "@dolphin/ipc";
+import { ipc_viewSlpReplay } from "@dolphin/ipc";
 import { ReplayQueueItem } from "@dolphin/types";
 import { useToasts } from "react-toast-notifications";
 
@@ -7,7 +7,7 @@ export const usePlayFiles = () => {
 
   const playFiles = async (files: ReplayQueueItem[]) => {
     try {
-      const viewResult = await viewSlpReplay.renderer!.trigger({ files });
+      const viewResult = await ipc_viewSlpReplay.renderer!.trigger({ files });
       if (!viewResult.result) {
         console.error(`Error playing file(s): ${files.join(", ")}`, viewResult.errors);
         throw new Error(`Error playing file(s): ${files.join(", ")}`);

--- a/src/renderer/lib/hooks/useReplays.ts
+++ b/src/renderer/lib/hooks/useReplays.ts
@@ -1,4 +1,4 @@
-import { loadReplayFolder } from "@replays/ipc";
+import { ipc_loadReplayFolder } from "@replays/ipc";
 import { FileLoadResult, FileResult, FolderResult, Progress } from "@replays/types";
 import { produce } from "immer";
 import path from "path";
@@ -192,7 +192,7 @@ export const useReplays = create<StoreState & StoreReducers>((set, get) => ({
 }));
 
 const handleReplayFolderLoading = async (folderPath: string): Promise<FileLoadResult> => {
-  const loadFolderResult = await loadReplayFolder.renderer!.trigger({ folderPath });
+  const loadFolderResult = await ipc_loadReplayFolder.renderer!.trigger({ folderPath });
   if (!loadFolderResult.result) {
     console.error(`Error loading folder: ${folderPath}`, loadFolderResult.errors);
     throw new Error(`Error loading folder: ${folderPath}`);

--- a/src/renderer/lib/hooks/useSettings.ts
+++ b/src/renderer/lib/hooks/useSettings.ts
@@ -1,11 +1,11 @@
 import { DolphinLaunchType } from "@dolphin/types";
 import {
-  setIsoPath,
-  setLaunchMeleeOnPlay,
-  setNetplayDolphinPath,
-  setPlaybackDolphinPath,
-  setRootSlpPath,
-  setSpectateSlpPath,
+  ipc_setIsoPath,
+  ipc_setLaunchMeleeOnPlay,
+  ipc_setNetplayDolphinPath,
+  ipc_setPlaybackDolphinPath,
+  ipc_setRootSlpPath,
+  ipc_setSpectateSlpPath,
 } from "@settings/ipc";
 import { AppSettings } from "@settings/types";
 import { ipcRenderer } from "electron";
@@ -29,7 +29,7 @@ export const useSettings = create(
 export const useIsoPath = () => {
   const isoPath = useSettings((store) => store.settings.isoPath);
   const setPath = async (isoPath: string | null) => {
-    const setResult = await setIsoPath.renderer!.trigger({ isoPath });
+    const setResult = await ipc_setIsoPath.renderer!.trigger({ isoPath });
     if (!setResult.result) {
       throw new Error("Error setting ISO path");
     }
@@ -40,7 +40,7 @@ export const useIsoPath = () => {
 export const useRootSlpPath = () => {
   const rootSlpPath = useSettings((store) => store.settings.rootSlpPath);
   const setReplayDir = async (path: string) => {
-    const setResult = await setRootSlpPath.renderer!.trigger({ path });
+    const setResult = await ipc_setRootSlpPath.renderer!.trigger({ path });
     if (!setResult.result) {
       throw new Error("Error setting root SLP path");
     }
@@ -51,7 +51,7 @@ export const useRootSlpPath = () => {
 export const useSpectateSlpPath = () => {
   const spectateSlpPath = useSettings((store) => store.settings.spectateSlpPath);
   const setSpectateDir = async (path: string) => {
-    const setResult = await setSpectateSlpPath.renderer!.trigger({ path });
+    const setResult = await ipc_setSpectateSlpPath.renderer!.trigger({ path });
     if (!setResult.result) {
       throw new Error("Error setting spectate SLP path");
     }
@@ -62,7 +62,7 @@ export const useSpectateSlpPath = () => {
 export const useDolphinPath = (dolphinType: DolphinLaunchType) => {
   const netplayDolphinPath = useSettings((store) => store.settings.netplayDolphinPath);
   const setNetplayPath = async (path: string) => {
-    const setResult = await setNetplayDolphinPath.renderer!.trigger({ path });
+    const setResult = await ipc_setNetplayDolphinPath.renderer!.trigger({ path });
     if (!setResult.result) {
       throw new Error("Error setting netplay dolphin path");
     }
@@ -70,7 +70,7 @@ export const useDolphinPath = (dolphinType: DolphinLaunchType) => {
 
   const playbackDolphinPath = useSettings((store) => store.settings.playbackDolphinPath);
   const setDolphinPath = async (path: string) => {
-    const setResult = await setPlaybackDolphinPath.renderer!.trigger({ path });
+    const setResult = await ipc_setPlaybackDolphinPath.renderer!.trigger({ path });
     if (!setResult.result) {
       throw new Error("Error setting playback dolphin path");
     }
@@ -89,7 +89,7 @@ export const useDolphinPath = (dolphinType: DolphinLaunchType) => {
 export const useLaunchMeleeOnPlay = () => {
   const launchMeleeOnPlay = useSettings((store) => store.settings.launchMeleeOnPlay);
   const setLaunchMelee = async (launchMelee: boolean) => {
-    const setResult = await setLaunchMeleeOnPlay.renderer!.trigger({ launchMelee });
+    const setResult = await ipc_setLaunchMeleeOnPlay.renderer!.trigger({ launchMelee });
     if (!setResult.result) {
       throw new Error("Error setting launch melee on Play");
     }

--- a/src/renderer/lib/slippiBackend.ts
+++ b/src/renderer/lib/slippiBackend.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, ApolloLink, gql, HttpLink, InMemoryCache } from "@apollo/client";
-import { checkPlayKeyExists, removePlayKeyFile, storePlayKeyFile } from "@dolphin/ipc";
+import { ipc_checkPlayKeyExists, ipc_removePlayKeyFile, ipc_storePlayKeyFile } from "@dolphin/ipc";
 import { PlayKey } from "@dolphin/types";
 import log from "electron-log";
 import firebase from "firebase";
@@ -72,7 +72,7 @@ export async function fetchPlayKey(): Promise<PlayKey> {
 }
 
 export async function assertPlayKey(playKey: PlayKey) {
-  const playKeyExistsResult = await checkPlayKeyExists.renderer!.trigger({});
+  const playKeyExistsResult = await ipc_checkPlayKeyExists.renderer!.trigger({});
   if (!playKeyExistsResult.result) {
     log.error("Error checking for play key.", playKeyExistsResult.errors);
     throw new Error("Error checking for play key");
@@ -82,7 +82,7 @@ export async function assertPlayKey(playKey: PlayKey) {
     return;
   }
 
-  const storeResult = await storePlayKeyFile.renderer!.trigger({ key: playKey });
+  const storeResult = await ipc_storePlayKeyFile.renderer!.trigger({ key: playKey });
   if (!storeResult.result) {
     log.error("Error saving play key", storeResult.errors);
     throw new Error("Error saving play key");
@@ -90,7 +90,7 @@ export async function assertPlayKey(playKey: PlayKey) {
 }
 
 export async function deletePlayKey(): Promise<void> {
-  const deleteResult = await removePlayKeyFile.renderer!.trigger({});
+  const deleteResult = await ipc_removePlayKeyFile.renderer!.trigger({});
   if (!deleteResult.result) {
     log.error("Error deleting play key", deleteResult.errors);
     throw new Error("Error deleting play key");

--- a/src/replays/ipc.ts
+++ b/src/replays/ipc.ts
@@ -5,9 +5,9 @@ import { FileLoadResult, FileResult, Progress } from "./types";
 
 // Handlers
 
-export const loadReplayFolder = makeEndpoint.main("loadReplayFolder", <{ folderPath: string }>_, <FileLoadResult>_);
+export const ipc_loadReplayFolder = makeEndpoint.main("loadReplayFolder", <{ folderPath: string }>_, <FileLoadResult>_);
 
-export const calculateGameStats = makeEndpoint.main(
+export const ipc_calculateGameStats = makeEndpoint.main(
   "calculateGameStats",
   <{ filePath: string }>_,
   <{ file: FileResult; stats: StatsType | null }>_,
@@ -15,6 +15,6 @@ export const calculateGameStats = makeEndpoint.main(
 
 // Events
 
-export const loadProgressUpdated = makeEndpoint.renderer("replays_loadProgressUpdated", <Progress>_);
+export const ipc_loadProgressUpdatedEvent = makeEndpoint.renderer("replays_loadProgressUpdated", <Progress>_);
 
-export const showStatsPage = makeEndpoint.renderer("replays_showStatsPage", <{ filePath: string }>_);
+export const ipc_statsPageRequestedEvent = makeEndpoint.renderer("replays_showStatsPage", <{ filePath: string }>_);

--- a/src/replays/main.ts
+++ b/src/replays/main.ts
@@ -1,16 +1,16 @@
-import { calculateGameStats, loadProgressUpdated, loadReplayFolder } from "./ipc";
+import { ipc_calculateGameStats, ipc_loadProgressUpdatedEvent, ipc_loadReplayFolder } from "./ipc";
 import { worker as replayBrowserWorker } from "./workerInterface";
 
-loadReplayFolder.main!.handle(async ({ folderPath }) => {
+ipc_loadReplayFolder.main!.handle(async ({ folderPath }) => {
   const w = await replayBrowserWorker;
   w.getProgressObservable().subscribe((progress) => {
-    loadProgressUpdated.main!.trigger(progress).catch(console.warn);
+    ipc_loadProgressUpdatedEvent.main!.trigger(progress).catch(console.warn);
   });
   const result = await w.loadReplayFolder(folderPath);
   return result;
 });
 
-calculateGameStats.main!.handle(async ({ filePath }) => {
+ipc_calculateGameStats.main!.handle(async ({ filePath }) => {
   const w = await replayBrowserWorker;
   const result = await w.calculateGameStats(filePath);
   const fileResult = await w.loadSingleFile(filePath);

--- a/src/settings/ipc.ts
+++ b/src/settings/ipc.ts
@@ -3,42 +3,44 @@ import { AppSettings, StoredConnection } from "./types";
 
 // Handlers
 
-// export const getAppSettings = makeEndpoint.main("getAppSettings", <EmptyPayload>_, <AppSettings>_);
+export const ipc_setIsoPath = makeEndpoint.main("setIsoPath", <{ isoPath: string | null }>_, <SuccessPayload>_);
 
-export const setIsoPath = makeEndpoint.main("setIsoPath", <{ isoPath: string | null }>_, <SuccessPayload>_);
+export const ipc_setRootSlpPath = makeEndpoint.main("setRootSlpPath", <{ path: string }>_, <SuccessPayload>_);
 
-export const setRootSlpPath = makeEndpoint.main("setRootSlpPath", <{ path: string }>_, <SuccessPayload>_);
+export const ipc_setSpectateSlpPath = makeEndpoint.main("setSpectateSlpPath", <{ path: string }>_, <SuccessPayload>_);
 
-export const setSpectateSlpPath = makeEndpoint.main("setSpectateSlpPath", <{ path: string }>_, <SuccessPayload>_);
+export const ipc_setNetplayDolphinPath = makeEndpoint.main(
+  "setNetplayDolphinPath",
+  <{ path: string }>_,
+  <SuccessPayload>_,
+);
 
-export const setNetplayDolphinPath = makeEndpoint.main("setNetplayDolphinPath", <{ path: string }>_, <SuccessPayload>_);
-
-export const setPlaybackDolphinPath = makeEndpoint.main(
+export const ipc_setPlaybackDolphinPath = makeEndpoint.main(
   "setPlaybackDolphinPath",
   <{ path: string }>_,
   <SuccessPayload>_,
 );
 
-export const setLaunchMeleeOnPlay = makeEndpoint.main(
+export const ipc_setLaunchMeleeOnPlay = makeEndpoint.main(
   "setLaunchMeleeOnPlay",
   <{ launchMelee: boolean }>_,
   <SuccessPayload>_,
 );
 
-export const addNewConnection = makeEndpoint.main(
+export const ipc_addNewConnection = makeEndpoint.main(
   "addNewConnection",
   <{ connection: Omit<StoredConnection, "id"> }>_,
   <SuccessPayload>_,
 );
 
-export const editConnection = makeEndpoint.main(
+export const ipc_editConnection = makeEndpoint.main(
   "editConnection",
   <{ id: number; connection: Omit<StoredConnection, "id"> }>_,
   <SuccessPayload>_,
 );
 
-export const deleteConnection = makeEndpoint.main("deleteConnection", <{ id: number }>_, <SuccessPayload>_);
+export const ipc_deleteConnection = makeEndpoint.main("deleteConnection", <{ id: number }>_, <SuccessPayload>_);
 
 // Events
 
-export const settingsUpdated = makeEndpoint.renderer("settings_settingsUpdated", <AppSettings>_);
+export const ipc_settingsUpdatedEvent = makeEndpoint.renderer("settings_settingsUpdated", <AppSettings>_);

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -2,15 +2,15 @@ import { addGamePathToInis } from "@dolphin/util";
 import path from "path";
 
 import {
-  addNewConnection,
-  deleteConnection,
-  editConnection,
-  setIsoPath,
-  setLaunchMeleeOnPlay,
-  setNetplayDolphinPath,
-  setPlaybackDolphinPath,
-  setRootSlpPath,
-  setSpectateSlpPath,
+  ipc_addNewConnection,
+  ipc_deleteConnection,
+  ipc_editConnection,
+  ipc_setIsoPath,
+  ipc_setLaunchMeleeOnPlay,
+  ipc_setNetplayDolphinPath,
+  ipc_setPlaybackDolphinPath,
+  ipc_setRootSlpPath,
+  ipc_setSpectateSlpPath,
 } from "./ipc";
 import { settingsManager } from "./settingsManager";
 
@@ -19,7 +19,7 @@ import { settingsManager } from "./settingsManager";
 //   return settings;
 // });
 
-setIsoPath.main!.handle(async ({ isoPath }) => {
+ipc_setIsoPath.main!.handle(async ({ isoPath }) => {
   await settingsManager.setIsoPath(isoPath);
   if (isoPath) {
     const gameDir = path.dirname(isoPath);
@@ -28,42 +28,42 @@ setIsoPath.main!.handle(async ({ isoPath }) => {
   return { success: true };
 });
 
-setRootSlpPath.main!.handle(async ({ path }) => {
+ipc_setRootSlpPath.main!.handle(async ({ path }) => {
   await settingsManager.setRootSlpPath(path);
   return { success: true };
 });
 
-setSpectateSlpPath.main!.handle(async ({ path }) => {
+ipc_setSpectateSlpPath.main!.handle(async ({ path }) => {
   await settingsManager.setSpectateSlpPath(path);
   return { success: true };
 });
 
-setNetplayDolphinPath.main!.handle(async ({ path }) => {
+ipc_setNetplayDolphinPath.main!.handle(async ({ path }) => {
   await settingsManager.setNetplayDolphinPath(path);
   return { success: true };
 });
 
-setPlaybackDolphinPath.main!.handle(async ({ path }) => {
+ipc_setPlaybackDolphinPath.main!.handle(async ({ path }) => {
   await settingsManager.setPlaybackDolphinPath(path);
   return { success: true };
 });
 
-addNewConnection.main!.handle(async ({ connection }) => {
+ipc_addNewConnection.main!.handle(async ({ connection }) => {
   await settingsManager.addConsoleConnection(connection);
   return { success: true };
 });
 
-editConnection.main!.handle(async ({ id, connection }) => {
+ipc_editConnection.main!.handle(async ({ id, connection }) => {
   await settingsManager.editConsoleConnection(id, connection);
   return { success: true };
 });
 
-deleteConnection.main!.handle(async ({ id }) => {
+ipc_deleteConnection.main!.handle(async ({ id }) => {
   await settingsManager.deleteConsoleConnection(id);
   return { success: true };
 });
 
-setLaunchMeleeOnPlay.main!.handle(async ({ launchMelee }) => {
+ipc_setLaunchMeleeOnPlay.main!.handle(async ({ launchMelee }) => {
   await settingsManager.setLaunchMeleeOnPlay(launchMelee);
   return { success: true };
 });

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -5,7 +5,7 @@ import merge from "lodash/merge";
 import set from "lodash/set";
 
 import { defaultAppSettings } from "./defaultSettings";
-import { settingsUpdated } from "./ipc";
+import { ipc_settingsUpdatedEvent } from "./ipc";
 import { AppSettings, StoredConnection } from "./types";
 
 electronSettings.configure({
@@ -99,7 +99,7 @@ export class SettingsManager {
   private async _set(objectPath: string, value: any) {
     await electronSettings.set(objectPath, value);
     set(this.appSettings, objectPath, value);
-    await settingsUpdated.main!.trigger(this.get());
+    await ipc_settingsUpdatedEvent.main!.trigger(this.get());
   }
 }
 


### PR DESCRIPTION
This PR renames the ipc endpoints to have a consistent naming scheme. All ipc endpoints now should have the prefix `ipc_`. Events from main -> renderer should also have the suffix `Event`. This clears up name space collisions and makes endpoints clearer.

I'm still not entirely convinced the interface for `makeEndpoint` needs to change. Cuz I think it is somewhat intuitive when you call `makEndpoint.main` you're making a main endpoint, and `makeEndpoint.renderer` you're making a renderer endpoint.