### PR TITLE
feat: add import button to DolphinSettings

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -12,7 +12,7 @@ export const ipc_checkValidIso = makeEndpoint.main(
 export const ipc_getDesktopAppPath = makeEndpoint.main(
   "getDesktopAppPath",
   <EmptyPayload>_,
-  <{ path: string; exists: boolean }>_,
+  <{ dolphinPath: string; exists: boolean }>_,
 );
 
 export const ipc_deleteDesktopAppPath = makeEndpoint.main("deleteDesktopAppPath", <EmptyPayload>_, <SuccessPayload>_);

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -9,10 +9,4 @@ export const ipc_checkValidIso = makeEndpoint.main(
   <{ path: string; valid: IsoValidity }>_,
 );
 
-export const ipc_getDesktopAppPath = makeEndpoint.main(
-  "getDesktopAppPath",
-  <EmptyPayload>_,
-  <{ dolphinPath: string; exists: boolean }>_,
-);
-
 export const ipc_deleteDesktopAppPath = makeEndpoint.main("deleteDesktopAppPath", <EmptyPayload>_, <SuccessPayload>_);

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -1,4 +1,4 @@
-import { _, EmptyPayload, makeEndpoint } from "../ipc";
+import { _, EmptyPayload, makeEndpoint, SuccessPayload } from "../ipc";
 import { IsoValidity, NewsItem } from "./types";
 
 export const ipc_fetchNewsFeed = makeEndpoint.main("fetchNewsFeed", <EmptyPayload>_, <NewsItem[]>_);
@@ -9,4 +9,10 @@ export const ipc_checkValidIso = makeEndpoint.main(
   <{ path: string; valid: IsoValidity }>_,
 );
 
-export const ipc_getDesktopAppPath = makeEndpoint.main("getDesktopAppPath", <EmptyPayload>_, <{ exists: boolean }>_);
+export const ipc_getDesktopAppPath = makeEndpoint.main(
+  "getDesktopAppPath",
+  <EmptyPayload>_,
+  <{ path: string; exists: boolean }>_,
+);
+
+export const ipc_deleteDesktopAppPath = makeEndpoint.main("deleteDesktopAppPath", <EmptyPayload>_, <SuccessPayload>_);

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -35,7 +35,7 @@ export const ipc_launchNetplayDolphin = makeEndpoint.main("launchNetplayDolphin"
 
 export const ipc_migrateDolphin = makeEndpoint.main(
   "migrateDolphin",
-  <{ migrateNetplay: string | null; migratePlayback: boolean }>_,
+  <{ migrateNetplay: string | null; migratePlayback: boolean; migratePlaybackPath?: string }>_,
   <SuccessPayload>_,
 );
 

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -33,7 +33,7 @@ export const ipc_viewSlpReplay = makeEndpoint.main("viewSlpReplay", <{ files: Re
 
 export const ipc_launchNetplayDolphin = makeEndpoint.main("launchNetplayDolphin", <EmptyPayload>_, <SuccessPayload>_);
 
-export const ipc_getDesktopAppDolphinInfo = makeEndpoint.main(
+export const ipc_checkDesktopAppDolphin = makeEndpoint.main(
   "getDesktopAppDolphinPath",
   <EmptyPayload>_,
   <{ dolphinPath: string; exists: boolean }>_,

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -33,6 +33,12 @@ export const ipc_viewSlpReplay = makeEndpoint.main("viewSlpReplay", <{ files: Re
 
 export const ipc_launchNetplayDolphin = makeEndpoint.main("launchNetplayDolphin", <EmptyPayload>_, <SuccessPayload>_);
 
+export const ipc_getDesktopAppDolphinInfo = makeEndpoint.main(
+  "getDesktopAppDolphinPath",
+  <EmptyPayload>_,
+  <{ dolphinPath: string; exists: boolean }>_,
+);
+
 // toImportDolphin path must point to a "Slippi Dolphin.{exe,app}"
 export const ipc_importDolphinSettings = makeEndpoint.main(
   "importDolphinSettings",

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -33,9 +33,10 @@ export const ipc_viewSlpReplay = makeEndpoint.main("viewSlpReplay", <{ files: Re
 
 export const ipc_launchNetplayDolphin = makeEndpoint.main("launchNetplayDolphin", <EmptyPayload>_, <SuccessPayload>_);
 
-export const ipc_migrateDolphin = makeEndpoint.main(
-  "migrateDolphin",
-  <{ migrateNetplay: string | null; migratePlayback: boolean; migratePlaybackPath?: string }>_,
+// toImportDolphin path must point to a "Slippi Dolphin.{exe,app}"
+export const ipc_importDolphinSettings = makeEndpoint.main(
+  "importDolphinSettings",
+  <{ toImportDolphinPath: string; type: DolphinLaunchType }>_,
   <SuccessPayload>_,
 );
 

--- a/src/dolphin/main.ts
+++ b/src/dolphin/main.ts
@@ -6,11 +6,11 @@ import path from "path";
 import { fileExists } from "../main/fileExists";
 import { assertDolphinInstallations } from "./downloadDolphin";
 import {
+  ipc_checkDesktopAppDolphin,
   ipc_checkPlayKeyExists,
   ipc_clearDolphinCache,
   ipc_configureDolphin,
   ipc_downloadDolphin,
-  ipc_getDesktopAppDolphinInfo,
   ipc_importDolphinSettings,
   ipc_launchNetplayDolphin,
   ipc_reinstallDolphin,
@@ -87,7 +87,7 @@ ipc_importDolphinSettings.main!.handle(async ({ toImportDolphinPath, type }) => 
   return { success: true };
 });
 
-ipc_getDesktopAppDolphinInfo.main!.handle(async () => {
+ipc_checkDesktopAppDolphin.main!.handle(async () => {
   // get the path and check existence
   const desktopAppPath = path.join(app.getPath("appData"), "Slippi Desktop App");
   let exists = await fs.pathExists(desktopAppPath);

--- a/src/dolphin/main.ts
+++ b/src/dolphin/main.ts
@@ -73,21 +73,31 @@ ipc_launchNetplayDolphin.main!.handle(async () => {
   return { success: true };
 });
 
-ipc_migrateDolphin.main!.handle(async ({ migrateNetplay, migratePlayback }) => {
+ipc_migrateDolphin.main!.handle(async ({ migrateNetplay, migratePlayback, migratePlaybackPath }) => {
   const desktopAppPath = path.join(app.getPath("appData"), "Slippi Desktop App");
 
   if (migrateNetplay) {
     const baseNetplayPath = isMac ? path.join(migrateNetplay, "Contents", "Resources") : path.dirname(migrateNetplay);
     await dolphinManager.copyDolphinConfig(DolphinLaunchType.NETPLAY, baseNetplayPath);
   }
+
   if (migratePlayback) {
+    let oldPlaybackDolphinPath = desktopAppPath;
     const dolphinDir = ["dolphin"];
+
+    if (migratePlaybackPath) {
+      dolphinDir.pop();
+      oldPlaybackDolphinPath = path.dirname(migratePlaybackPath);
+    }
+
     if (isMac) {
       dolphinDir.push("Slippi Dolphin.app", "Contents", "Resources");
     }
-    const oldPlaybackDolphinPath = path.join(desktopAppPath, ...dolphinDir);
+
+    oldPlaybackDolphinPath = path.join(oldPlaybackDolphinPath, ...dolphinDir);
     await dolphinManager.copyDolphinConfig(DolphinLaunchType.PLAYBACK, oldPlaybackDolphinPath);
   }
+
   if (desktopAppPath) {
     await fs.remove(desktopAppPath);
   }

--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -8,9 +8,11 @@ import path from "path";
 
 import { DolphinLaunchType } from "./types";
 
-export async function findDolphinExecutable(type: DolphinLaunchType): Promise<string> {
+export async function findDolphinExecutable(type: DolphinLaunchType, dolphinPath?: string): Promise<string> {
   // Make sure the directory actually exists
-  const dolphinPath = settingsManager.getDolphinPath(type);
+  if (!dolphinPath) {
+    dolphinPath = settingsManager.getDolphinPath(type);
+  }
 
   await fs.ensureDir(dolphinPath);
 

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -4,6 +4,8 @@ import "@replays/main";
 import "@settings/main";
 import "@console/main";
 
+import { DolphinLaunchType } from "@dolphin/types";
+import { findDolphinExecutable } from "@dolphin/util";
 import { settingsManager } from "@settings/settingsManager";
 import { isLinux } from "common/constants";
 import { ipc_checkValidIso, ipc_deleteDesktopAppPath, ipc_fetchNewsFeed, ipc_getDesktopAppPath } from "common/ipc";
@@ -58,14 +60,24 @@ export function setupListeners() {
   ipc_getDesktopAppPath.main!.handle(async () => {
     // get the path and check existence
     const desktopAppPath = path.join(app.getPath("appData"), "Slippi Desktop App");
-    const exists = await fs.pathExists(desktopAppPath);
+    let exists = await fs.pathExists(desktopAppPath);
 
-    if (isLinux && exists) {
-      await fs.remove(desktopAppPath);
-      return { path: desktopAppPath, exists: false };
+    if (!exists) {
+      return { dolphinPath: "", exists: false };
     }
 
-    return { path: desktopAppPath, exists: exists };
+    // Linux doesn't need to do anything because their dolphin settings are in a user config dir
+    if (isLinux && exists) {
+      await fs.remove(desktopAppPath);
+      return { dolphinPath: "", exists: false };
+    }
+
+    const dolphinFolderPath = path.join(desktopAppPath, "dolphin");
+    exists = await fs.pathExists(dolphinFolderPath);
+
+    const dolphinExecutablePath = await findDolphinExecutable(DolphinLaunchType.NETPLAY, dolphinFolderPath);
+
+    return { dolphinPath: dolphinExecutablePath, exists: exists };
   });
 
   ipc_deleteDesktopAppPath.main!.handle(async () => {

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -4,11 +4,8 @@ import "@replays/main";
 import "@settings/main";
 import "@console/main";
 
-import { DolphinLaunchType } from "@dolphin/types";
-import { findDolphinExecutable } from "@dolphin/util";
 import { settingsManager } from "@settings/settingsManager";
-import { isLinux } from "common/constants";
-import { ipc_checkValidIso, ipc_deleteDesktopAppPath, ipc_fetchNewsFeed, ipc_getDesktopAppPath } from "common/ipc";
+import { ipc_checkValidIso, ipc_deleteDesktopAppPath, ipc_fetchNewsFeed } from "common/ipc";
 import { IsoValidity } from "common/types";
 import { app, ipcMain, nativeImage } from "electron";
 import * as fs from "fs-extra";
@@ -55,29 +52,6 @@ export function setupListeners() {
     } catch (err) {
       return { path, valid: IsoValidity.INVALID };
     }
-  });
-
-  ipc_getDesktopAppPath.main!.handle(async () => {
-    // get the path and check existence
-    const desktopAppPath = path.join(app.getPath("appData"), "Slippi Desktop App");
-    let exists = await fs.pathExists(desktopAppPath);
-
-    if (!exists) {
-      return { dolphinPath: "", exists: false };
-    }
-
-    // Linux doesn't need to do anything because their dolphin settings are in a user config dir
-    if (isLinux && exists) {
-      await fs.remove(desktopAppPath);
-      return { dolphinPath: "", exists: false };
-    }
-
-    const dolphinFolderPath = path.join(desktopAppPath, "dolphin");
-    exists = await fs.pathExists(dolphinFolderPath);
-
-    const dolphinExecutablePath = await findDolphinExecutable(DolphinLaunchType.NETPLAY, dolphinFolderPath);
-
-    return { dolphinPath: dolphinExecutablePath, exists: exists };
   });
 
   ipc_deleteDesktopAppPath.main!.handle(async () => {

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -6,7 +6,7 @@ import "@console/main";
 
 import { settingsManager } from "@settings/settingsManager";
 import { isLinux } from "common/constants";
-import { ipc_checkValidIso, ipc_fetchNewsFeed, ipc_getDesktopAppPath } from "common/ipc";
+import { ipc_checkValidIso, ipc_deleteDesktopAppPath, ipc_fetchNewsFeed, ipc_getDesktopAppPath } from "common/ipc";
 import { IsoValidity } from "common/types";
 import { app, ipcMain, nativeImage } from "electron";
 import * as fs from "fs-extra";
@@ -62,9 +62,17 @@ export function setupListeners() {
 
     if (isLinux && exists) {
       await fs.remove(desktopAppPath);
-      return { exists: false };
+      return { path: desktopAppPath, exists: false };
     }
 
-    return { exists: exists };
+    return { path: desktopAppPath, exists: exists };
+  });
+
+  ipc_deleteDesktopAppPath.main!.handle(async () => {
+    // get the path and remove
+    const desktopAppPath = path.join(app.getPath("appData"), "Slippi Desktop App");
+    await fs.remove(desktopAppPath);
+
+    return { success: true };
   });
 }

--- a/src/renderer/components/ConfirmationModal.tsx
+++ b/src/renderer/components/ConfirmationModal.tsx
@@ -52,7 +52,7 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
         <StyledDialogTitle id="responsive-dialog-title">{title}</StyledDialogTitle>
         <DialogContent>{children}</DialogContent>
         <DialogActions>
-          <Button onClick={onClose} color="secondary" {...cancelProps}>
+          <Button type="submit" onClick={onClose} color="secondary" {...cancelProps}>
             {cancelText}
           </Button>
           <Button color="primary" type="submit" {...confirmProps}>

--- a/src/renderer/components/ConfirmationModal.tsx
+++ b/src/renderer/components/ConfirmationModal.tsx
@@ -52,7 +52,7 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
         <StyledDialogTitle id="responsive-dialog-title">{title}</StyledDialogTitle>
         <DialogContent>{children}</DialogContent>
         <DialogActions>
-          <Button type="submit" onClick={onClose} color="secondary" {...cancelProps}>
+          <Button onClick={onClose} color="secondary" {...cancelProps}>
             {cancelText}
           </Button>
           <Button color="primary" type="submit" {...confirmProps}>

--- a/src/renderer/containers/QuickStart/ImportDolphinSettingsStep.tsx
+++ b/src/renderer/containers/QuickStart/ImportDolphinSettingsStep.tsx
@@ -8,7 +8,6 @@ import Container from "@material-ui/core/Container";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import { isMac } from "common/constants";
 import { ipc_deleteDesktopAppPath } from "common/ipc";
-import path from "path";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useToasts } from "react-toast-notifications";
@@ -27,7 +26,7 @@ type FormValues = {
 
 export const ImportDolphinSettingsStep: React.FC = () => {
   const setExists = useDesktopApp((store) => store.setExists);
-  const desktopAppPath = useDesktopApp((store) => store.path);
+  const desktopAppDolphinPath = useDesktopApp((store) => store.dolphinPath);
   const { addToast } = useToasts();
 
   const migrateDolphin = async (values: FormValues) => {
@@ -38,11 +37,8 @@ export const ImportDolphinSettingsStep: React.FC = () => {
       });
     }
     if (values.shouldImportPlayback) {
-      const binaryName = isMac ? "Slippi Dolphin.app" : "Slippi Dolphin.exe";
-      const playbackPath = path.join(desktopAppPath, "dolphin", binaryName);
-
       await ipc_importDolphinSettings.renderer!.trigger({
-        toImportDolphinPath: playbackPath,
+        toImportDolphinPath: desktopAppDolphinPath,
         type: DolphinLaunchType.PLAYBACK,
       });
     }

--- a/src/renderer/containers/QuickStart/ImportDolphinSettingsStep.tsx
+++ b/src/renderer/containers/QuickStart/ImportDolphinSettingsStep.tsx
@@ -1,11 +1,14 @@
 /** @jsx jsx */
-import { ipc_migrateDolphin } from "@dolphin/ipc";
+import { ipc_importDolphinSettings } from "@dolphin/ipc";
+import { DolphinLaunchType } from "@dolphin/types";
 import { css, jsx } from "@emotion/react";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Container from "@material-ui/core/Container";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import { isMac } from "common/constants";
+import { ipc_deleteDesktopAppPath } from "common/ipc";
+import path from "path";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useToasts } from "react-toast-notifications";
@@ -24,21 +27,32 @@ type FormValues = {
 
 export const ImportDolphinSettingsStep: React.FC = () => {
   const setExists = useDesktopApp((store) => store.setExists);
+  const desktopAppPath = useDesktopApp((store) => store.path);
   const { addToast } = useToasts();
 
   const migrateDolphin = async (values: FormValues) => {
-    await ipc_migrateDolphin.renderer!.trigger({
-      migrateNetplay: values.shouldImportNetplay ? values.netplayPath : null,
-      migratePlayback: values.shouldImportPlayback,
-    });
-    setExists(false);
+    if (values.shouldImportNetplay) {
+      await ipc_importDolphinSettings.renderer!.trigger({
+        toImportDolphinPath: values.netplayPath,
+        type: DolphinLaunchType.NETPLAY,
+      });
+    }
+    if (values.shouldImportPlayback) {
+      const binaryName = isMac ? "Slippi Dolphin.app" : "Slippi Dolphin.exe";
+      const playbackPath = path.join(desktopAppPath, "dolphin", binaryName);
+
+      await ipc_importDolphinSettings.renderer!.trigger({
+        toImportDolphinPath: playbackPath,
+        type: DolphinLaunchType.PLAYBACK,
+      });
+    }
+
+    await finishMigration();
   };
 
-  const skipMigration = async () => {
-    await ipc_migrateDolphin.renderer!.trigger({
-      migrateNetplay: null,
-      migratePlayback: false,
-    });
+  const finishMigration = async () => {
+    // delete desktop app path
+    await ipc_deleteDesktopAppPath.renderer!.trigger({});
     setExists(false);
   };
 
@@ -146,7 +160,7 @@ export const ImportDolphinSettingsStep: React.FC = () => {
               </Button>
               <Button
                 color="secondary"
-                onClick={() => skipMigration().catch(handleError)}
+                onClick={() => finishMigration().catch(handleError)}
                 css={css`
                   text-transform: initial;
                   margin-top: 10px;

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -1,5 +1,10 @@
 /** @jsx jsx */
-import { ipc_clearDolphinCache, ipc_configureDolphin, ipc_migrateDolphin, ipc_reinstallDolphin } from "@dolphin/ipc";
+import {
+  ipc_clearDolphinCache,
+  ipc_configureDolphin,
+  ipc_importDolphinSettings,
+  ipc_reinstallDolphin,
+} from "@dolphin/ipc";
 import { DolphinLaunchType } from "@dolphin/types";
 import { css, jsx } from "@emotion/react";
 import Button from "@material-ui/core/Button";
@@ -80,12 +85,8 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
 
   const importDolphinHandler = async (importPath: string) => {
     log.info(`importing dolphin from ${importPath}`);
-    const importObj =
-      dolphinType === DolphinLaunchType.NETPLAY
-        ? { migrateNetplay: importPath }
-        : { migratePlayback: true, migratePlaybackPath: importPath };
-    const importSettings = Object.assign({ migrateNetplay: null, migratePlayback: false }, importObj);
-    await ipc_migrateDolphin.renderer!.trigger(importSettings);
+
+    await ipc_importDolphinSettings.renderer!.trigger({ toImportDolphinPath: importPath, type: dolphinType });
     setImportModalOpen(false);
   };
 

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -15,7 +15,7 @@ import Typography from "@material-ui/core/Typography";
 import { isLinux, isMac } from "common/constants";
 import { shell } from "electron";
 import log from "electron-log";
-import _ from "lodash";
+import capitalize from "lodash/capitalize";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useToasts } from "react-toast-notifications";
@@ -183,7 +183,7 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
             confirmText="Import"
             closeOnSubmit={false}
           >
-            Select the location of your old {_.capitalize(dolphinType)} Dolphin app.
+            Select the location of your old {capitalize(dolphinType)} Dolphin app.
             <div
               css={css`
                 margin-top: 20px;
@@ -198,7 +198,7 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
                     {...field}
                     value={importPath}
                     onSelect={(newPath) => setValue("importPath", newPath)}
-                    placeholder={`No ${_.capitalize(dolphinType)} Dolphin selected`}
+                    placeholder={`No ${capitalize(dolphinType)} Dolphin selected`}
                     options={{
                       properties: ["openFile"],
                       filters: [{ name: "Slippi Dolphin", extensions: [isMac ? "app" : "exe"] }],

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -197,7 +197,7 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
                     {...field}
                     value={importPath}
                     onSelect={(newPath) => setValue("importPath", newPath)}
-                    placeholder="No Netplay Dolphin selected"
+                    placeholder={`No ${_.capitalize(dolphinType)} Dolphin selected`}
                     options={{
                       properties: ["openFile"],
                       filters: [{ name: "Slippi Dolphin", extensions: [isMac ? "app" : "exe"] }],

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -31,6 +31,7 @@ export const useAppInitialization = () => {
   const setUser = useAccount((store) => store.setUser);
   const setPlayKey = useAccount((store) => store.setPlayKey);
   const setDesktopAppExists = useDesktopApp((store) => store.setExists);
+  const setDesktopAppPath = useDesktopApp((store) => store.setPath);
 
   const initialize = async () => {
     if (initialized) {
@@ -89,6 +90,7 @@ export const useAppInitialization = () => {
             throw new Error("Could not get old desktop app path");
           }
           setDesktopAppExists(result.exists);
+          setDesktopAppPath(result.path);
         })
         .catch(console.error),
     );

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -1,5 +1,4 @@
-import { ipc_getDesktopAppPath } from "common/ipc";
-import { ipc_dolphinDownloadFinishedEvent, ipc_downloadDolphin } from "dolphin/ipc";
+import { ipc_dolphinDownloadFinishedEvent, ipc_downloadDolphin, ipc_getDesktopAppDolphinInfo } from "dolphin/ipc";
 import log from "electron-log";
 import firebase from "firebase";
 import create from "zustand";
@@ -83,7 +82,7 @@ export const useAppInitialization = () => {
     promises.push(ipc_downloadDolphin.renderer!.trigger({}));
 
     promises.push(
-      ipc_getDesktopAppPath
+      ipc_getDesktopAppDolphinInfo
         .renderer!.trigger({})
         .then(({ result }) => {
           if (!result) {

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -31,7 +31,7 @@ export const useAppInitialization = () => {
   const setUser = useAccount((store) => store.setUser);
   const setPlayKey = useAccount((store) => store.setPlayKey);
   const setDesktopAppExists = useDesktopApp((store) => store.setExists);
-  const setDesktopAppPath = useDesktopApp((store) => store.setPath);
+  const setDesktopAppDolphinPath = useDesktopApp((store) => store.setDolphinPath);
 
   const initialize = async () => {
     if (initialized) {
@@ -90,7 +90,7 @@ export const useAppInitialization = () => {
             throw new Error("Could not get old desktop app path");
           }
           setDesktopAppExists(result.exists);
-          setDesktopAppPath(result.path);
+          setDesktopAppDolphinPath(result.dolphinPath);
         })
         .catch(console.error),
     );

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -1,4 +1,4 @@
-import { ipc_dolphinDownloadFinishedEvent, ipc_downloadDolphin, ipc_getDesktopAppDolphinInfo } from "dolphin/ipc";
+import { ipc_checkDesktopAppDolphin, ipc_dolphinDownloadFinishedEvent, ipc_downloadDolphin } from "dolphin/ipc";
 import log from "electron-log";
 import firebase from "firebase";
 import create from "zustand";
@@ -82,7 +82,7 @@ export const useAppInitialization = () => {
     promises.push(ipc_downloadDolphin.renderer!.trigger({}));
 
     promises.push(
-      ipc_getDesktopAppDolphinInfo
+      ipc_checkDesktopAppDolphin
         .renderer!.trigger({})
         .then(({ result }) => {
           if (!result) {

--- a/src/renderer/lib/hooks/useQuickStart.ts
+++ b/src/renderer/lib/hooks/useQuickStart.ts
@@ -114,9 +114,11 @@ export const useDesktopApp = create(
   combine(
     {
       exists: false,
+      path: "",
     },
     (set) => ({
       setExists: (exists: boolean) => set({ exists }),
+      setPath: (path: string) => set({ path }),
     }),
   ),
 );

--- a/src/renderer/lib/hooks/useQuickStart.ts
+++ b/src/renderer/lib/hooks/useQuickStart.ts
@@ -114,11 +114,11 @@ export const useDesktopApp = create(
   combine(
     {
       exists: false,
-      path: "",
+      dolphinPath: "",
     },
     (set) => ({
       setExists: (exists: boolean) => set({ exists }),
-      setPath: (path: string) => set({ path }),
+      setDolphinPath: (dolphinPath: string) => set({ dolphinPath }),
     }),
   ),
 );


### PR DESCRIPTION
Lets users import dolphin settings on macOS and Windows. Linux stores settings in a user config dir so we don't need to worry about them.