### PR TITLE
feat: multi drag drop - file count on drag icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "firebase": "^8.1.2",
     "fs-extra": "^9.0.1",
     "graphql": "^15.4.0",
+    "html-to-image": "^1.6.2",
     "immer": "^8.0.0",
     "lodash": "^4.17.20",
     "medium-json-feed": "^0.0.3",

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -21,12 +21,17 @@ import { verifyIso } from "./verifyIso";
 const LINES_TO_READ = 200;
 
 export function setupListeners() {
-  ipcMain.on("onDragStart", (event, files: string[]) => {
+  ipcMain.on("onDragStart", (event, files: string[], imageURL: string) => {
+    const icon =
+      imageURL.length > 0
+        ? nativeImage.createFromDataURL(imageURL)
+        : nativeImage.createFromPath(path.join(__static, "images", "file.png"));
+
     // The Electron.Item type declaration is missing the files attribute
     // so we'll just cast it as unknown for now.
     event.sender.startDrag(({
       files,
-      icon: nativeImage.createFromPath(path.join(__static, "images", "file.png")),
+      icon: icon,
     } as unknown) as Electron.Item);
   });
 

--- a/src/renderer/components/DraggableFile.tsx
+++ b/src/renderer/components/DraggableFile.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { ipcRenderer } from "electron";
 import React from "react";
+import * as htmlToImage from "html-to-image";
 
 const Outer = styled.div`
   color: inherit;
@@ -23,19 +24,29 @@ export interface DraggableFileProps {
 export const DraggableFile: React.FC<DraggableFileProps> = ({ children, filePaths, className, style }) => {
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+
     if (filePaths.length > 0) {
-      ipcRenderer.send("onDragStart", filePaths);
+      // If we have selected non-zero files for dragging, update the count and then convert the div to a dataURL to send
+      document.getElementById("dragCount")!.innerHTML = filePaths.length.toString();
+
+      htmlToImage.toPng(document.getElementById("dragCountParent") as HTMLDivElement).then(function (dataURL) {
+        ipcRenderer.send("onDragStart", filePaths, dataURL);
+      });
     }
   };
 
   return (
-    <Outer
-      className={className}
-      style={style}
-      onDragStart={(e) => handleDragStart(e)}
-      onClick={(e) => e.preventDefault()}
-    >
-      {children}
-    </Outer>
+    <div>
+      {
+        <Outer
+          className={className}
+          style={style}
+          onDragStart={(e) => handleDragStart(e)}
+          onClick={(e) => e.preventDefault()}
+        >
+          {children}
+        </Outer>
+      }
+    </div>
   );
 };

--- a/src/renderer/components/DraggableFile.tsx
+++ b/src/renderer/components/DraggableFile.tsx
@@ -27,7 +27,7 @@ export const DraggableFile: React.FC<DraggableFileProps> = ({ children, filePath
 
     if (filePaths.length > 0) {
       // If we have selected non-zero files for dragging, update the count and then convert the div to a dataURL to send
-      document.getElementById("dragCount")!.innerHTML = filePaths.length.toString();
+      document.getElementById("dragCount")!.innerHTML = filePaths.length > 1 ? filePaths.length.toString() : "";
 
       void htmlToImage.toPng(document.getElementById("dragCountParent") as HTMLDivElement).then(function (dataURL) {
         ipcRenderer.send("onDragStart", filePaths, dataURL);

--- a/src/renderer/components/DraggableFile.tsx
+++ b/src/renderer/components/DraggableFile.tsx
@@ -29,7 +29,7 @@ export const DraggableFile: React.FC<DraggableFileProps> = ({ children, filePath
       // If we have selected non-zero files for dragging, update the count and then convert the div to a dataURL to send
       document.getElementById("dragCount")!.innerHTML = filePaths.length.toString();
 
-      htmlToImage.toPng(document.getElementById("dragCountParent") as HTMLDivElement).then(function (dataURL) {
+      void htmlToImage.toPng(document.getElementById("dragCountParent") as HTMLDivElement).then(function (dataURL) {
         ipcRenderer.send("onDragStart", filePaths, dataURL);
       });
     }

--- a/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
@@ -8,6 +8,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import FolderIcon from "@material-ui/icons/Folder";
 import SearchIcon from "@material-ui/icons/Search";
+import FileIcon from "../../../../static/images/file.png";
 import { colors } from "common/colors";
 import { shell } from "electron";
 import React from "react";
@@ -174,6 +175,44 @@ export const ReplayBrowser: React.FC = () => {
             </div>
           }
         />
+      </div>
+
+      <div
+        id={"dragCountGrandParent"}
+        style={{
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          id={"dragCountParent"}
+          style={{
+            display: "inline-block",
+            border: "0px solid red",
+            position: "absolute",
+          }}
+        >
+          <img src={FileIcon} />
+          <div
+            style={{
+              color: "white",
+              background: "red",
+              fontSize: "15px",
+              display: "inline-block",
+              borderRadius: "11px",
+              paddingLeft: "4.77px" /* derived from π lol */,
+              paddingRight: "4.77px",
+              marginRight: "5px",
+              marginTop: "1px",
+              position: "absolute",
+              right: 0,
+              top: 0,
+            }}
+            id={"dragCount"}
+          >
+            7124
+          </div>
+        </div>
       </div>
 
       <Footer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6858,6 +6858,11 @@ html-minifier-terser@^5.0.1, html-minifier-terser@^5.1.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-to-image@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.6.2.tgz#9d444424cc638df13db5c7be810ac0d2962f5edd"
+  integrity sha512-X6X7wJW2KQ+AGqMeBITdntCcQnxBgZY62MdGOi042Y70+0SMe8/iJCzUv8RNaUoXqUjWw5FPyoTDmdGoapTQIQ==
+
 html-to-react@^1.3.4:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.5.tgz#59091c11021d1ef315ef738460abb6a4a41fe1ce"


### PR DESCRIPTION
This is an addition to #199 that adds an indicator of how many files are selected while dragging, even when dragging out of the application window.

The process for dynamically updating the count is to first update the div that will be used for the icon. The div can be located anywhere as long as it is not visible to the user (currently it is in ReplayBrowser.tsx). The div is then converted to a dataURL which then gets passed over with the file list and then used as a nativeImage for the drag icon.