### PR TITLE
refactor: shift select respects direction

### DIFF
--- a/src/renderer/lib/hooks/useReplays.ts
+++ b/src/renderer/lib/hooks/useReplays.ts
@@ -255,6 +255,10 @@ export const useReplaySelection = () => {
         filesToToggle.push(files[i].fullPath);
       }
 
+      if (lastClickIndex > index) {
+        filesToToggle.reverse();
+      }
+
       if (isCurrentSelected) {
         toggleFiles(filesToToggle, "deselect");
       } else {


### PR DESCRIPTION
This PR checks the indexes when shift selecting replays, then flips the array if the user has shift selected a newer replay after an older one.

This means it's possible to queue up vods in chronological order with shift select.