### PR TITLE
feat: update dolphin settings

### DIFF
--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -9,7 +9,7 @@ import { downloadAndInstallDolphin } from "./downloadDolphin";
 import { DolphinInstance, PlaybackDolphinInstance } from "./instance";
 import { DolphinLaunchType, ReplayCommunication } from "./types";
 import { addGamePathToIni, findDolphinExecutable, findUserFolder } from "./util";
-import { updateDolphinReplayPath } from "@dolphin/util";
+import { updateDolphinSettings } from "@dolphin/util";
 
 const log = electronLog.scope("dolphin/manager");
 
@@ -47,7 +47,7 @@ export class DolphinManager extends EventEmitter {
       throw new Error("Netplay dolphin is already open!");
     }
 
-    this.syncDolphinPath();
+    void this.syncDolphinPath();
 
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.NETPLAY);
     log.info(`Launching dolphin at path: ${dolphinPath}`);
@@ -66,7 +66,7 @@ export class DolphinManager extends EventEmitter {
   public async configureDolphin(launchType: DolphinLaunchType) {
     log.debug(`configuring ${launchType} dolphin...`);
 
-    this.syncDolphinPath();
+    void this.syncDolphinPath();
 
     const dolphinPath = await findDolphinExecutable(launchType);
     if (launchType === DolphinLaunchType.NETPLAY && !this.netplayDolphinInstance) {
@@ -135,8 +135,8 @@ export class DolphinManager extends EventEmitter {
 
   private async syncDolphinPath() {
     // It's possible for the Launcher and Dolphin's replay direcories to become
-    // desynced if the user sets the directory via Dolphin, so update Dolphin's to match the launcher
-    updateDolphinReplayPath(settingsManager.getRootSlpPath());
+    // desynced if the user sets settings via Dolphin, so update Dolphin's to match the launcher
+    void updateDolphinSettings(settingsManager.getRootSlpPath(), settingsManager.getUseMonthlySubfolders());
   }
 
   public async clearCache(launchType: DolphinLaunchType) {

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -46,7 +46,7 @@ export class DolphinManager extends EventEmitter {
       throw new Error("Netplay dolphin is already open!");
     }
 
-    void updateDolphinSettings();
+    await updateDolphinSettings();
 
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.NETPLAY);
     log.info(`Launching dolphin at path: ${dolphinPath}`);
@@ -65,7 +65,7 @@ export class DolphinManager extends EventEmitter {
   public async configureDolphin(launchType: DolphinLaunchType) {
     log.debug(`configuring ${launchType} dolphin...`);
 
-    void updateDolphinSettings();
+    await updateDolphinSettings();
 
     const dolphinPath = await findDolphinExecutable(launchType);
     if (launchType === DolphinLaunchType.NETPLAY && !this.netplayDolphinInstance) {

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -1,3 +1,4 @@
+import { addGamePathToIni, findDolphinExecutable, findUserFolder, updateDolphinSettings } from "@dolphin/util";
 import { settingsManager } from "@settings/settingsManager";
 import electronLog from "electron-log";
 import { EventEmitter } from "events";
@@ -8,8 +9,6 @@ import path from "path";
 import { downloadAndInstallDolphin } from "./downloadDolphin";
 import { DolphinInstance, PlaybackDolphinInstance } from "./instance";
 import { DolphinLaunchType, ReplayCommunication } from "./types";
-import { addGamePathToIni, findDolphinExecutable, findUserFolder } from "./util";
-import { updateDolphinSettings } from "@dolphin/util";
 
 const log = electronLog.scope("dolphin/manager");
 
@@ -131,12 +130,6 @@ export class DolphinManager extends EventEmitter {
       const gameDir = path.dirname(isoPath);
       await addGamePathToIni(launchType, gameDir);
     }
-  }
-
-  private async syncDolphinPath() {
-    // It's possible for the Launcher and Dolphin's replay direcories to become
-    // desynced if the user sets settings via Dolphin, so update Dolphin's to match the launcher
-    void updateDolphinSettings(settingsManager.getRootSlpPath(), settingsManager.getUseMonthlySubfolders());
   }
 
   public async clearCache(launchType: DolphinLaunchType) {

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -47,7 +47,7 @@ export class DolphinManager extends EventEmitter {
       throw new Error("Netplay dolphin is already open!");
     }
 
-    void this.syncDolphinPath();
+    void updateDolphinSettings();
 
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.NETPLAY);
     log.info(`Launching dolphin at path: ${dolphinPath}`);
@@ -66,7 +66,7 @@ export class DolphinManager extends EventEmitter {
   public async configureDolphin(launchType: DolphinLaunchType) {
     log.debug(`configuring ${launchType} dolphin...`);
 
-    void this.syncDolphinPath();
+    void updateDolphinSettings();
 
     const dolphinPath = await findDolphinExecutable(launchType);
     if (launchType === DolphinLaunchType.NETPLAY && !this.netplayDolphinInstance) {

--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -126,7 +126,10 @@ export async function addGamePathToIni(type: DolphinLaunchType, gameDir: string)
   log.info(`Finished updating ${type} dolphin...`);
 }
 
-export async function updateDolphinReplayPath(replayPath: string): Promise<void> {
+export async function updateDolphinSettings(
+  replayPath: string | null,
+  useMonthlySubfolders: boolean | null,
+): Promise<void> {
   const userFolder = await findUserFolder(DolphinLaunchType.NETPLAY);
   const iniPath = path.join(userFolder, "Config", "Dolphin.ini");
   const iniFile = new IniFile();
@@ -134,11 +137,21 @@ export async function updateDolphinReplayPath(replayPath: string): Promise<void>
     log.info("Found a Dolphin.ini to update...");
     await iniFile.load(iniPath, false);
     const coreSelection = iniFile.getOrCreateSection("Core");
-    coreSelection.set("SlippiReplayDir", replayPath);
+    if (replayPath != null) {
+      coreSelection.set("SlippiReplayDir", replayPath);
+    }
+    if (useMonthlySubfolders != null) {
+      coreSelection.set("SlippiReplayMonthFolders", useMonthlySubfolders ? "True" : "False");
+    }
   } else {
     log.info("There isn't a Dolphin.ini to update...");
     const coreSelection = iniFile.getOrCreateSection("Core");
-    coreSelection.set("SlippiReplayDir", replayPath);
+    if (replayPath != null) {
+      coreSelection.set("SlippiReplayDir", replayPath);
+    }
+    if (useMonthlySubfolders != null) {
+      coreSelection.set("SlippiReplayMonthFolders", useMonthlySubfolders ? "True" : "False");
+    }
   }
   iniFile.save(iniPath);
   log.info(`Finished updating ${DolphinLaunchType.NETPLAY} dolphin...`);

--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -126,6 +126,24 @@ export async function addGamePathToIni(type: DolphinLaunchType, gameDir: string)
   log.info(`Finished updating ${type} dolphin...`);
 }
 
+export async function updateDolphinReplayPath(replayPath: string): Promise<void> {
+  const userFolder = await findUserFolder(DolphinLaunchType.NETPLAY);
+  const iniPath = path.join(userFolder, "Config", "Dolphin.ini");
+  const iniFile = new IniFile();
+  if (await fileExists(iniPath)) {
+    log.info("Found a Dolphin.ini to update...");
+    await iniFile.load(iniPath, false);
+    const coreSelection = iniFile.getOrCreateSection("Core");
+    coreSelection.set("SlippiReplayDir", replayPath);
+  } else {
+    log.info("There isn't a Dolphin.ini to update...");
+    const coreSelection = iniFile.getOrCreateSection("Core");
+    coreSelection.set("SlippiReplayDir", replayPath);
+  }
+  iniFile.save(iniPath);
+  log.info(`Finished updating ${DolphinLaunchType.NETPLAY} dolphin...`);
+}
+
 export async function updateBootToCssCode(options: { enable: boolean }) {
   // Update vanilla ISO configs
   ["GALE01", "GALJ01"].forEach(async (id) => {

--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -127,19 +127,19 @@ export async function addGamePathToIni(type: DolphinLaunchType, gameDir: string)
 }
 
 export async function updateDolphinSettings(): Promise<void> {
-  const replayPath = settingsManager.getRootSlpPath();
-  const useMonthlySubfolders = settingsManager.getUseMonthlySubfolders() ? "True" : "False";
   const userFolder = await findUserFolder(DolphinLaunchType.NETPLAY);
   const iniPath = path.join(userFolder, "Config", "Dolphin.ini");
   const iniFile = new IniFile();
   const updateSettings = () => {
-    const coreSelection = iniFile.getOrCreateSection("Core");
-    coreSelection.set("SlippiReplayDir", replayPath);
-    coreSelection.set("SlippiReplayMonthFolders", useMonthlySubfolders);
+    const replayPath = settingsManager.getRootSlpPath();
+    const useMonthlySubfolders = settingsManager.getUseMonthlySubfolders() ? "True" : "False";
+    const coreSection = iniFile.getOrCreateSection("Core");
+    coreSection.set("SlippiReplayDir", replayPath);
+    coreSection.set("SlippiReplayMonthFolders", useMonthlySubfolders);
   };
   if (await fileExists(iniPath)) {
     log.info("Found a Dolphin.ini to update...");
-    await iniFile.load(iniPath, false);
+    await iniFile.load(iniPath);
     updateSettings();
   } else {
     log.info("There isn't a Dolphin.ini to update...");

--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -126,35 +126,27 @@ export async function addGamePathToIni(type: DolphinLaunchType, gameDir: string)
   log.info(`Finished updating ${type} dolphin...`);
 }
 
-export async function updateDolphinSettings(
-  replayPath: string | null,
-  useMonthlySubfolders: boolean | null,
-): Promise<void> {
+export async function updateDolphinSettings(): Promise<void> {
+  const replayPath = settingsManager.getRootSlpPath();
+  const useMonthlySubfolders = settingsManager.getUseMonthlySubfolders() ? "True" : "False";
   const userFolder = await findUserFolder(DolphinLaunchType.NETPLAY);
   const iniPath = path.join(userFolder, "Config", "Dolphin.ini");
   const iniFile = new IniFile();
+  const updateSettings = () => {
+    const coreSelection = iniFile.getOrCreateSection("Core");
+    coreSelection.set("SlippiReplayDir", replayPath);
+    coreSelection.set("SlippiReplayMonthFolders", useMonthlySubfolders);
+  };
   if (await fileExists(iniPath)) {
     log.info("Found a Dolphin.ini to update...");
     await iniFile.load(iniPath, false);
-    const coreSelection = iniFile.getOrCreateSection("Core");
-    if (replayPath != null) {
-      coreSelection.set("SlippiReplayDir", replayPath);
-    }
-    if (useMonthlySubfolders != null) {
-      coreSelection.set("SlippiReplayMonthFolders", useMonthlySubfolders ? "True" : "False");
-    }
+    updateSettings();
   } else {
     log.info("There isn't a Dolphin.ini to update...");
-    const coreSelection = iniFile.getOrCreateSection("Core");
-    if (replayPath != null) {
-      coreSelection.set("SlippiReplayDir", replayPath);
-    }
-    if (useMonthlySubfolders != null) {
-      coreSelection.set("SlippiReplayMonthFolders", useMonthlySubfolders ? "True" : "False");
-    }
+    updateSettings();
   }
   iniFile.save(iniPath);
-  log.info(`Finished updating ${DolphinLaunchType.NETPLAY} dolphin...`);
+  log.info(`Finished updating ${DolphinLaunchType.NETPLAY} dolphin settings...`);
 }
 
 export async function updateBootToCssCode(options: { enable: boolean }) {

--- a/src/renderer/components/PathInput.tsx
+++ b/src/renderer/components/PathInput.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import Button from "@material-ui/core/Button";
 import InputBase from "@material-ui/core/InputBase";
 import Paper from "@material-ui/core/Paper";
+import Tooltip from "@material-ui/core/Tooltip";
 import { OpenDialogOptions, remote } from "electron";
 import React from "react";
 
@@ -30,9 +31,13 @@ export const PathInput = React.forwardRef<HTMLInputElement, PathInputProps>((pro
         <CustomInput inputRef={ref} disabled={true} value={value} placeholder={placeholder} />
         {endAdornment}
       </InputContainer>
-      <Button color="secondary" variant="contained" onClick={onClick} disabled={disabled}>
-        Select
-      </Button>
+      <Tooltip title={disabled ? "Can't change this setting while Dolphin is open." : ""}>
+        <span>
+          <Button color="secondary" variant="contained" onClick={onClick} disabled={disabled}>
+            Select
+          </Button>
+        </span>
+      </Tooltip>
     </Outer>
   );
 });

--- a/src/renderer/components/PathInput.tsx
+++ b/src/renderer/components/PathInput.tsx
@@ -13,10 +13,11 @@ export interface PathInputProps {
   options?: OpenDialogOptions;
   endAdornment?: JSX.Element;
   disabled?: boolean;
+  tooltipText?: string;
 }
 
 export const PathInput = React.forwardRef<HTMLInputElement, PathInputProps>((props, ref) => {
-  const { value, placeholder, endAdornment, onSelect, options, disabled } = props;
+  const { value, placeholder, endAdornment, onSelect, options, disabled, tooltipText } = props;
   const onClick = async () => {
     const result = await remote.dialog.showOpenDialog({ properties: ["openFile"], ...options });
     const res = result.filePaths;
@@ -31,7 +32,7 @@ export const PathInput = React.forwardRef<HTMLInputElement, PathInputProps>((pro
         <CustomInput inputRef={ref} disabled={true} value={value} placeholder={placeholder} />
         {endAdornment}
       </InputContainer>
-      <Tooltip title={disabled ? "Can't change this setting while Dolphin is open." : ""}>
+      <Tooltip title={(disabled && tooltipText) ?? ""}>
         <span>
           <Button color="secondary" variant="contained" onClick={onClick} disabled={disabled}>
             Select

--- a/src/renderer/components/PathInput.tsx
+++ b/src/renderer/components/PathInput.tsx
@@ -32,7 +32,7 @@ export const PathInput = React.forwardRef<HTMLInputElement, PathInputProps>((pro
         <CustomInput inputRef={ref} disabled={true} value={value} placeholder={placeholder} />
         {endAdornment}
       </InputContainer>
-      <Tooltip title={(disabled && tooltipText) ?? ""}>
+      <Tooltip title={tooltipText ?? ""}>
         <span>
           <Button color="secondary" variant="contained" onClick={onClick} disabled={disabled}>
             Select

--- a/src/renderer/containers/Settings/MeleeOptions.tsx
+++ b/src/renderer/containers/Settings/MeleeOptions.tsx
@@ -3,7 +3,6 @@ import { css, jsx } from "@emotion/react";
 import styled from "@emotion/styled";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
 import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
@@ -14,13 +13,7 @@ import React from "react";
 
 import { PathInput } from "@/components/PathInput";
 import { useIsoVerification } from "@/lib/hooks/useIsoVerification";
-import {
-  useIsoPath,
-  useLaunchMeleeOnPlay,
-  useRootSlpPath,
-  useSpectateSlpPath,
-  useMonthlySubfolders,
-} from "@/lib/hooks/useSettings";
+import { useIsoPath, useLaunchMeleeOnPlay } from "@/lib/hooks/useSettings";
 import { SettingItem } from "./SettingItem";
 
 const renderValidityStatus = (isoValidity: IsoValidity) => {
@@ -42,17 +35,10 @@ export const MeleeOptions: React.FC = () => {
   const isoValidity = useIsoVerification((state) => state.validity);
   const [isoPath, setIsoPath] = useIsoPath();
   const [launchMeleeOnPlay, setLaunchMelee] = useLaunchMeleeOnPlay();
-  const [localReplayDir, setLocalReplayDir] = useRootSlpPath();
-  const [enableMonthlySubfolders, setUseMonthlySubfolders] = useMonthlySubfolders();
-  const [spectateDir, setSpectateDir] = useSpectateSlpPath();
 
   const onLaunchMeleeChange = async (value: string) => {
     const launchMelee = value === "true";
     await setLaunchMelee(launchMelee);
-  };
-
-  const onUseMonthlySubfoldersToggle = async () => {
-    await setUseMonthlySubfolders(!enableMonthlySubfolders);
   };
 
   return (
@@ -88,32 +74,6 @@ export const MeleeOptions: React.FC = () => {
           <FormControlLabel value={false} label="Launch Dolphin" control={<Radio />} />
         </RadioGroup>
       </SettingItem>
-      <SettingItem name="Local SLP Directory" description="The folder where your SLP replays should be saved.">
-        <PathInput
-          value={localReplayDir}
-          onSelect={setLocalReplayDir}
-          options={{
-            properties: ["openDirectory"],
-          }}
-          placeholder="No folder set"
-        />
-        <MonthlySubfolders>
-          Save replays to monthly subfolders
-          <CheckboxDiv>
-            <Checkbox onChange={() => onUseMonthlySubfoldersToggle()} checked={enableMonthlySubfolders} />
-          </CheckboxDiv>
-        </MonthlySubfolders>
-      </SettingItem>
-      <SettingItem name="Spectator SLP Directory" description="The folder where spectated games should be saved.">
-        <PathInput
-          value={spectateDir}
-          onSelect={setSpectateDir}
-          options={{
-            properties: ["openDirectory"],
-          }}
-          placeholder="No folder set"
-        />
-      </SettingItem>
     </div>
   );
 };
@@ -129,17 +89,4 @@ const ValidationContainer = styled.div`
   &.valid {
     color: ${({ theme }) => theme.palette.success.main};
   }
-`;
-
-const MonthlySubfolders = styled.div`
-  margin-top: 4px;
-  font-size: 14px;
-  color: ${({ theme }) => theme.palette.text.disabled};
-`;
-
-const CheckboxDiv = styled.div`
-  padding-left: 5px;
-  align-items: right;
-  display: inline-block;
-  height: 50%;
 `;

--- a/src/renderer/containers/Settings/MeleeOptions.tsx
+++ b/src/renderer/containers/Settings/MeleeOptions.tsx
@@ -14,6 +14,7 @@ import React from "react";
 import { PathInput } from "@/components/PathInput";
 import { useIsoVerification } from "@/lib/hooks/useIsoVerification";
 import { useIsoPath, useLaunchMeleeOnPlay } from "@/lib/hooks/useSettings";
+
 import { SettingItem } from "./SettingItem";
 
 const renderValidityStatus = (isoValidity: IsoValidity) => {

--- a/src/renderer/containers/Settings/MeleeOptions.tsx
+++ b/src/renderer/containers/Settings/MeleeOptions.tsx
@@ -3,6 +3,7 @@ import { css, jsx } from "@emotion/react";
 import styled from "@emotion/styled";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
@@ -13,6 +14,14 @@ import React from "react";
 
 import { PathInput } from "@/components/PathInput";
 import { useIsoVerification } from "@/lib/hooks/useIsoVerification";
+import {
+  useExtraSlpPaths,
+  useIsoPath,
+  useLaunchMeleeOnPlay,
+  useRootSlpPath,
+  useSpectateSlpPath,
+  useMonthlySubfolders,
+} from "@/lib/hooks/useSettings";
 import { useIsoPath, useLaunchMeleeOnPlay } from "@/lib/hooks/useSettings";
 
 import { SettingItem } from "./SettingItem";
@@ -36,10 +45,18 @@ export const MeleeOptions: React.FC = () => {
   const isoValidity = useIsoVerification((state) => state.validity);
   const [isoPath, setIsoPath] = useIsoPath();
   const [launchMeleeOnPlay, setLaunchMelee] = useLaunchMeleeOnPlay();
+  const [localReplayDir, setLocalReplayDir] = useRootSlpPath();
+  const [enableMonthlySubfolders, setUseMonthlySubfolders] = useMonthlySubfolders();
+  const [replayDirs, setReplayDirs] = useExtraSlpPaths();
+  const [spectateDir, setSpectateDir] = useSpectateSlpPath();
 
   const onLaunchMeleeChange = async (value: string) => {
     const launchMelee = value === "true";
     await setLaunchMelee(launchMelee);
+  };
+
+  const onUseMonthlySubfoldersToggle = async () => {
+    await setUseMonthlySubfolders(!enableMonthlySubfolders);
   };
 
   return (
@@ -75,6 +92,42 @@ export const MeleeOptions: React.FC = () => {
           <FormControlLabel value={false} label="Launch Dolphin" control={<Radio />} />
         </RadioGroup>
       </SettingItem>
+      <SettingItem name="Local SLP Directory" description="The folder where your SLP replays should be saved.">
+        <PathInput
+          value={localReplayDir}
+          onSelect={setLocalReplayDir}
+          options={{
+            properties: ["openDirectory"],
+          }}
+          placeholder="No folder set"
+        />
+        <MonthlySubfolders>
+          Save replays to monthly subfolders
+          <CheckboxDiv>
+            <Checkbox onChange={() => onUseMonthlySubfoldersToggle()} checked={enableMonthlySubfolders} />
+          </CheckboxDiv>
+        </MonthlySubfolders>
+      </SettingItem>
+      <SettingItem name="Spectator SLP Directory" description="The folder where spectated games should be saved.">
+        <PathInput
+          value={spectateDir}
+          onSelect={setSpectateDir}
+          options={{
+            properties: ["openDirectory"],
+          }}
+          placeholder="No folder set"
+        />
+      </SettingItem>
+      <SettingItem name="Extra SLP Directories" description="The folders where any other SLP replays are stored.">
+        <PathInputMultiple
+          paths={replayDirs}
+          updatePaths={setReplayDirs}
+          options={{
+            properties: ["openDirectory"],
+          }}
+          placeholder="No folder set"
+        />
+      </SettingItem>
     </div>
   );
 };
@@ -90,4 +143,17 @@ const ValidationContainer = styled.div`
   &.valid {
     color: ${({ theme }) => theme.palette.success.main};
   }
+`;
+
+const MonthlySubfolders = styled.div`
+  margin-top: 4px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.palette.text.disabled};
+`;
+
+const CheckboxDiv = styled.div`
+  padding-left: 5px;
+  align-items: right;
+  display: inline-block;
+  height: 50%;
 `;

--- a/src/renderer/containers/Settings/MeleeOptions.tsx
+++ b/src/renderer/containers/Settings/MeleeOptions.tsx
@@ -15,15 +15,12 @@ import React from "react";
 import { PathInput } from "@/components/PathInput";
 import { useIsoVerification } from "@/lib/hooks/useIsoVerification";
 import {
-  useExtraSlpPaths,
   useIsoPath,
   useLaunchMeleeOnPlay,
   useRootSlpPath,
   useSpectateSlpPath,
   useMonthlySubfolders,
 } from "@/lib/hooks/useSettings";
-import { useIsoPath, useLaunchMeleeOnPlay } from "@/lib/hooks/useSettings";
-
 import { SettingItem } from "./SettingItem";
 
 const renderValidityStatus = (isoValidity: IsoValidity) => {
@@ -47,7 +44,6 @@ export const MeleeOptions: React.FC = () => {
   const [launchMeleeOnPlay, setLaunchMelee] = useLaunchMeleeOnPlay();
   const [localReplayDir, setLocalReplayDir] = useRootSlpPath();
   const [enableMonthlySubfolders, setUseMonthlySubfolders] = useMonthlySubfolders();
-  const [replayDirs, setReplayDirs] = useExtraSlpPaths();
   const [spectateDir, setSpectateDir] = useSpectateSlpPath();
 
   const onLaunchMeleeChange = async (value: string) => {
@@ -112,16 +108,6 @@ export const MeleeOptions: React.FC = () => {
         <PathInput
           value={spectateDir}
           onSelect={setSpectateDir}
-          options={{
-            properties: ["openDirectory"],
-          }}
-          placeholder="No folder set"
-        />
-      </SettingItem>
-      <SettingItem name="Extra SLP Directories" description="The folders where any other SLP replays are stored.">
-        <PathInputMultiple
-          paths={replayDirs}
-          updatePaths={setReplayDirs}
           options={{
             properties: ["openDirectory"],
           }}

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -36,7 +36,6 @@ export const ReplayOptions: React.FC = () => {
         />
       </SettingItem>
       <MonthlySubfolders>
-        Save replays to monthly subfolders
         <Tooltip title={netplayDolphinOpen ? "Can't change this setting while Dolphin is open" : ""}>
           <CheckboxDiv>
             <Checkbox
@@ -46,6 +45,7 @@ export const ReplayOptions: React.FC = () => {
             />
           </CheckboxDiv>
         </Tooltip>
+        Save replays to monthly subfolders
       </MonthlySubfolders>
       <SettingItem name="Spectator SLP Directory" description="The folder where spectated games should be saved.">
         <PathInput
@@ -80,7 +80,7 @@ const MonthlySubfolders = styled.div`
 `;
 
 const CheckboxDiv = styled.div`
-  padding-left: 5px;
+  padding-right: 5px;
   align-items: right;
   display: inline-block;
   height: 50%;

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -1,8 +1,12 @@
 import React from "react";
+import Checkbox from "@material-ui/core/Checkbox";
+import Tooltip from "@material-ui/core/Tooltip";
+import styled from "@emotion/styled";
 
 import { MultiPathInput } from "@/components/MultiPathInput";
 import { PathInput } from "@/components/PathInput";
-import { useExtraSlpPaths, useRootSlpPath, useSpectateSlpPath } from "@/lib/hooks/useSettings";
+import { useExtraSlpPaths, useRootSlpPath, useSpectateSlpPath, useMonthlySubfolders } from "@/lib/hooks/useSettings";
+import { useDolphinStore } from "@/lib/hooks/useDolphin";
 
 import { SettingItem } from "./SettingItem";
 
@@ -10,11 +14,18 @@ export const ReplayOptions: React.FC = () => {
   const [localReplayDir, setLocalReplayDir] = useRootSlpPath();
   const [replayDirs, setReplayDirs] = useExtraSlpPaths();
   const [spectateDir, setSpectateDir] = useSpectateSlpPath();
+  const [enableMonthlySubfolders, setUseMonthlySubfolders] = useMonthlySubfolders();
+  const netplayDolphinOpen = useDolphinStore((store) => store.netplayDolphinOpen);
+
+  const onUseMonthlySubfoldersToggle = async () => {
+    await setUseMonthlySubfolders(!enableMonthlySubfolders);
+  };
 
   return (
     <div>
       <SettingItem name="Root SLP Directory" description="The folder where your SLP replays should be saved.">
         <PathInput
+          disabled={netplayDolphinOpen}
           value={localReplayDir}
           onSelect={setLocalReplayDir}
           options={{
@@ -23,6 +34,18 @@ export const ReplayOptions: React.FC = () => {
           placeholder="No folder set"
         />
       </SettingItem>
+      <MonthlySubfolders>
+        Save replays to monthly subfolders
+        <Tooltip title={netplayDolphinOpen ? "Can't change this setting while Dolphin is open." : ""}>
+          <CheckboxDiv>
+            <Checkbox
+              onChange={() => onUseMonthlySubfoldersToggle()}
+              checked={enableMonthlySubfolders}
+              disabled={netplayDolphinOpen}
+            />
+          </CheckboxDiv>
+        </Tooltip>
+      </MonthlySubfolders>
       <SettingItem name="Spectator SLP Directory" description="The folder where spectated games should be saved.">
         <PathInput
           value={spectateDir}
@@ -48,3 +71,16 @@ export const ReplayOptions: React.FC = () => {
     </div>
   );
 };
+
+const MonthlySubfolders = styled.div`
+  margin-top: 4px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.palette.text.disabled};
+`;
+
+const CheckboxDiv = styled.div`
+  padding-left: 5px;
+  align-items: right;
+  display: inline-block;
+  height: 50%;
+`;

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -26,6 +26,7 @@ export const ReplayOptions: React.FC = () => {
       <SettingItem name="Root SLP Directory" description="The folder where your SLP replays should be saved.">
         <PathInput
           disabled={netplayDolphinOpen}
+          tooltipText="Can't change this setting while Dolphin is open"
           value={localReplayDir}
           onSelect={setLocalReplayDir}
           options={{
@@ -36,7 +37,7 @@ export const ReplayOptions: React.FC = () => {
       </SettingItem>
       <MonthlySubfolders>
         Save replays to monthly subfolders
-        <Tooltip title={netplayDolphinOpen ? "Can't change this setting while Dolphin is open." : ""}>
+        <Tooltip title={netplayDolphinOpen ? "Can't change this setting while Dolphin is open" : ""}>
           <CheckboxDiv>
             <Checkbox
               onChange={() => onUseMonthlySubfoldersToggle()}
@@ -73,7 +74,7 @@ export const ReplayOptions: React.FC = () => {
 };
 
 const MonthlySubfolders = styled.div`
-  margin-top: 4px;
+  margin-top: -20px;
   font-size: 14px;
   color: ${({ theme }) => theme.palette.text.disabled};
 `;

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -1,12 +1,12 @@
-import React from "react";
+import styled from "@emotion/styled";
 import Checkbox from "@material-ui/core/Checkbox";
 import Tooltip from "@material-ui/core/Tooltip";
-import styled from "@emotion/styled";
+import React from "react";
 
 import { MultiPathInput } from "@/components/MultiPathInput";
 import { PathInput } from "@/components/PathInput";
-import { useExtraSlpPaths, useRootSlpPath, useSpectateSlpPath, useMonthlySubfolders } from "@/lib/hooks/useSettings";
 import { useDolphinStore } from "@/lib/hooks/useDolphin";
+import { useExtraSlpPaths, useMonthlySubfolders, useRootSlpPath, useSpectateSlpPath } from "@/lib/hooks/useSettings";
 
 import { SettingItem } from "./SettingItem";
 

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -80,7 +80,7 @@ const MonthlySubfolders = styled.div`
 `;
 
 const CheckboxDiv = styled.div`
-  padding-right: 5px;
+  margin-left: -10px;
   align-items: right;
   display: inline-block;
   height: 50%;

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -1,8 +1,9 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
 import styled from "@emotion/styled";
-import Checkbox from "@material-ui/core/Checkbox";
-import Tooltip from "@material-ui/core/Tooltip";
 import React from "react";
 
+import { Checkbox } from "@/components/FormInputs/Checkbox";
 import { MultiPathInput } from "@/components/MultiPathInput";
 import { PathInput } from "@/components/PathInput";
 import { useDolphinStore } from "@/lib/hooks/useDolphin";
@@ -26,7 +27,7 @@ export const ReplayOptions: React.FC = () => {
       <SettingItem name="Root SLP Directory" description="The folder where your SLP replays should be saved.">
         <PathInput
           disabled={netplayDolphinOpen}
-          tooltipText={netplayDolphinOpen ? "Can't change this setting while Dolphin is open" : ""}
+          tooltipText={netplayDolphinOpen ? "Close Dolphin to change this setting" : ""}
           value={localReplayDir}
           onSelect={setLocalReplayDir}
           options={{
@@ -34,19 +35,17 @@ export const ReplayOptions: React.FC = () => {
           }}
           placeholder="No folder set"
         />
+        <Checkbox
+          css={css`
+            margin-top: 5px;
+          `}
+          onChange={() => onUseMonthlySubfoldersToggle()}
+          checked={enableMonthlySubfolders}
+          disabled={netplayDolphinOpen}
+          hoverText={netplayDolphinOpen ? "Close Dolphin to change this setting" : ""}
+          label={<CheckboxDescription>Save replays to monthly subfolders</CheckboxDescription>}
+        />
       </SettingItem>
-      <MonthlySubfolders>
-        <Tooltip title={netplayDolphinOpen ? "Can't change this setting while Dolphin is open" : ""}>
-          <CheckboxDiv>
-            <Checkbox
-              onChange={() => onUseMonthlySubfoldersToggle()}
-              checked={enableMonthlySubfolders}
-              disabled={netplayDolphinOpen}
-            />
-          </CheckboxDiv>
-        </Tooltip>
-        Save replays to monthly subfolders
-      </MonthlySubfolders>
       <SettingItem name="Spectator SLP Directory" description="The folder where spectated games should be saved.">
         <PathInput
           value={spectateDir}
@@ -73,15 +72,7 @@ export const ReplayOptions: React.FC = () => {
   );
 };
 
-const MonthlySubfolders = styled.div`
-  margin-top: -20px;
+const CheckboxDescription = styled.span`
   font-size: 14px;
   color: ${({ theme }) => theme.palette.text.disabled};
-`;
-
-const CheckboxDiv = styled.div`
-  margin-left: -10px;
-  align-items: right;
-  display: inline-block;
-  height: 50%;
 `;

--- a/src/renderer/containers/Settings/ReplayOptions.tsx
+++ b/src/renderer/containers/Settings/ReplayOptions.tsx
@@ -26,7 +26,7 @@ export const ReplayOptions: React.FC = () => {
       <SettingItem name="Root SLP Directory" description="The folder where your SLP replays should be saved.">
         <PathInput
           disabled={netplayDolphinOpen}
-          tooltipText="Can't change this setting while Dolphin is open"
+          tooltipText={netplayDolphinOpen ? "Can't change this setting while Dolphin is open" : ""}
           value={localReplayDir}
           onSelect={setLocalReplayDir}
           options={{

--- a/src/renderer/lib/hooks/useSettings.ts
+++ b/src/renderer/lib/hooks/useSettings.ts
@@ -7,6 +7,7 @@ import {
   ipc_setRootSlpPath,
   ipc_setSpectateSlpPath,
   ipc_setExtraSlpPaths,
+  ipc_setUseMonthlySubfolders,
 } from "@settings/ipc";
 import { AppSettings } from "@settings/types";
 import { ipcRenderer } from "electron";
@@ -47,6 +48,17 @@ export const useRootSlpPath = () => {
     }
   };
   return [rootSlpPath, setReplayDir] as const;
+};
+
+export const useMonthlySubfolders = () => {
+  const useMonthlySubfolders = useSettings((store) => store.settings.useMonthlySubfolders);
+  const setUseMonthlySubfolders = async (toggle: boolean) => {
+    const setResult = await ipc_setUseMonthlySubfolders.renderer!.trigger({ toggle });
+    if (!setResult.result) {
+      throw new Error("Error setting use monthly subfolders");
+    }
+  };
+  return [useMonthlySubfolders, setUseMonthlySubfolders] as const;
 };
 
 export const useSpectateSlpPath = () => {

--- a/src/renderer/lib/hooks/useSettings.ts
+++ b/src/renderer/lib/hooks/useSettings.ts
@@ -1,12 +1,12 @@
 import { DolphinLaunchType } from "@dolphin/types";
 import {
+  ipc_setExtraSlpPaths,
   ipc_setIsoPath,
   ipc_setLaunchMeleeOnPlay,
   ipc_setNetplayDolphinPath,
   ipc_setPlaybackDolphinPath,
   ipc_setRootSlpPath,
   ipc_setSpectateSlpPath,
-  ipc_setExtraSlpPaths,
   ipc_setUseMonthlySubfolders,
 } from "@settings/ipc";
 import { AppSettings } from "@settings/types";

--- a/src/settings/defaultSettings.ts
+++ b/src/settings/defaultSettings.ts
@@ -16,6 +16,7 @@ export const defaultAppSettings: AppSettings = {
   settings: {
     isoPath: null,
     rootSlpPath: getDefaultRootSlpPath(),
+    useMonthlySubfolders: false,
     spectateSlpPath: path.join(getDefaultRootSlpPath(), "Spectate"),
     extraSlpPaths: [],
     netplayDolphinPath: path.join(app.getPath("userData"), "netplay"),

--- a/src/settings/ipc.ts
+++ b/src/settings/ipc.ts
@@ -7,6 +7,12 @@ export const ipc_setIsoPath = makeEndpoint.main("setIsoPath", <{ isoPath: string
 
 export const ipc_setRootSlpPath = makeEndpoint.main("setRootSlpPath", <{ path: string }>_, <SuccessPayload>_);
 
+export const ipc_setUseMonthlySubfolders = makeEndpoint.main(
+  "setUseMonthlySubfolders",
+  <{ toggle: boolean }>_,
+  <SuccessPayload>_,
+);
+
 export const ipc_setSpectateSlpPath = makeEndpoint.main("setSpectateSlpPath", <{ path: string }>_, <SuccessPayload>_);
 
 export const ipc_setExtraSlpPaths = makeEndpoint.main("setExtraSlpPaths", <{ paths: string[] }>_, <SuccessPayload>_);

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -12,6 +12,7 @@ import {
   ipc_setRootSlpPath,
   ipc_setSpectateSlpPath,
   ipc_setExtraSlpPaths,
+  ipc_setUseMonthlySubfolders,
 } from "./ipc";
 import { settingsManager } from "./settingsManager";
 
@@ -31,6 +32,11 @@ ipc_setIsoPath.main!.handle(async ({ isoPath }) => {
 
 ipc_setRootSlpPath.main!.handle(async ({ path }) => {
   await settingsManager.setRootSlpPath(path);
+  return { success: true };
+});
+
+ipc_setUseMonthlySubfolders.main!.handle(async ({ toggle }) => {
+  await settingsManager.setUseMonthlySubfolders(toggle);
   return { success: true };
 });
 

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -5,13 +5,13 @@ import {
   ipc_addNewConnection,
   ipc_deleteConnection,
   ipc_editConnection,
+  ipc_setExtraSlpPaths,
   ipc_setIsoPath,
   ipc_setLaunchMeleeOnPlay,
   ipc_setNetplayDolphinPath,
   ipc_setPlaybackDolphinPath,
   ipc_setRootSlpPath,
   ipc_setSpectateSlpPath,
-  ipc_setExtraSlpPaths,
   ipc_setUseMonthlySubfolders,
 } from "./ipc";
 import { settingsManager } from "./settingsManager";

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -1,4 +1,5 @@
 import { DolphinLaunchType } from "@dolphin/types";
+import { updateDolphinSettings } from "@dolphin/util";
 import electronSettings from "electron-settings";
 import fs from "fs";
 import merge from "lodash/merge";
@@ -7,7 +8,6 @@ import set from "lodash/set";
 import { defaultAppSettings } from "./defaultSettings";
 import { ipc_settingsUpdatedEvent } from "./ipc";
 import { AppSettings, StoredConnection } from "./types";
-import { updateDolphinSettings } from "@dolphin/util";
 
 electronSettings.configure({
   fileName: "Settings",
@@ -59,13 +59,13 @@ export class SettingsManager {
   }
 
   public async setRootSlpPath(slpPath: string): Promise<void> {
-    await updateDolphinSettings(slpPath, null);
     await this._set("settings.rootSlpPath", slpPath);
+    await updateDolphinSettings();
   }
 
   public async setUseMonthlySubfolders(toggle: boolean): Promise<void> {
-    await updateDolphinSettings(null, toggle);
     await this._set("settings.useMonthlySubfolders", toggle);
+    await updateDolphinSettings();
   }
 
   public async setSpectateSlpPath(slpPath: string): Promise<void> {

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -7,7 +7,7 @@ import set from "lodash/set";
 import { defaultAppSettings } from "./defaultSettings";
 import { ipc_settingsUpdatedEvent } from "./ipc";
 import { AppSettings, StoredConnection } from "./types";
-import { updateDolphinReplayPath } from "@dolphin/util";
+import { updateDolphinSettings } from "@dolphin/util";
 
 electronSettings.configure({
   fileName: "Settings",
@@ -50,13 +50,22 @@ export class SettingsManager {
     return this.appSettings.settings?.rootSlpPath as string;
   }
 
+  public getUseMonthlySubfolders(): boolean {
+    return this.appSettings.settings?.useMonthlySubfolders as boolean;
+  }
+
   public async setIsoPath(isoPath: string | null): Promise<void> {
     await this._set("settings.isoPath", isoPath);
   }
 
   public async setRootSlpPath(slpPath: string): Promise<void> {
-    await updateDolphinReplayPath(slpPath);
+    await updateDolphinSettings(slpPath, null);
     await this._set("settings.rootSlpPath", slpPath);
+  }
+
+  public async setUseMonthlySubfolders(toggle: boolean): Promise<void> {
+    await updateDolphinSettings(null, toggle);
+    await this._set("settings.useMonthlySubfolders", toggle);
   }
 
   public async setSpectateSlpPath(slpPath: string): Promise<void> {

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -7,6 +7,7 @@ import set from "lodash/set";
 import { defaultAppSettings } from "./defaultSettings";
 import { ipc_settingsUpdatedEvent } from "./ipc";
 import { AppSettings, StoredConnection } from "./types";
+import { updateDolphinReplayPath } from "@dolphin/util";
 
 electronSettings.configure({
   fileName: "Settings",
@@ -45,11 +46,16 @@ export class SettingsManager {
     }
   }
 
+  public getRootSlpPath(): string {
+    return this.appSettings.settings?.rootSlpPath as string;
+  }
+
   public async setIsoPath(isoPath: string | null): Promise<void> {
     await this._set("settings.isoPath", isoPath);
   }
 
   public async setRootSlpPath(slpPath: string): Promise<void> {
+    await updateDolphinReplayPath(slpPath);
     await this._set("settings.rootSlpPath", slpPath);
   }
 

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -47,11 +47,11 @@ export class SettingsManager {
   }
 
   public getRootSlpPath(): string {
-    return this.appSettings.settings?.rootSlpPath as string;
+    return this.get().settings.rootSlpPath;
   }
 
   public getUseMonthlySubfolders(): boolean {
-    return this.appSettings.settings?.useMonthlySubfolders as boolean;
+    return this.get().settings.useMonthlySubfolders;
   }
 
   public async setIsoPath(isoPath: string | null): Promise<void> {

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -18,6 +18,7 @@ export type AppSettings = {
   settings: {
     isoPath: string | null;
     rootSlpPath: string;
+    useMonthlySubfolders: boolean;
     spectateSlpPath: string;
     extraSlpPaths: string[];
     netplayDolphinPath: string;


### PR DESCRIPTION
Pushes settings from Launcher to Dolphin when Dolphin is launched. Launcher settings are preferred and used to overwrite Dolphin settings when reasonable (time to launch dolphin is not noticeably affected).
- Replay root directory
- Use monthly subfolders

Users that don't use the Launcher will be able to change their settings as normal. However, if everyone is eventually required to use the Launcher, the ability to change settings via Dolphin should either be removed or synced with the Launcher.

![image](https://user-images.githubusercontent.com/6331403/133925342-df5cc188-885d-4950-816a-3012b1715bf5.png)
