### PR TITLE
feat: safer find appimage check

### DIFF
--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -26,8 +26,10 @@ export async function findDolphinExecutable(type: DolphinLaunchType, dolphinPath
         return filename.endsWith("Dolphin.exe");
       case "darwin":
         return filename.endsWith("Dolphin.app");
-      case "linux":
-        return filename.endsWith(".AppImage") || filename.endsWith("dolphin-emu");
+      case "linux": {
+        const userDolphinName = type === DolphinLaunchType.NETPLAY ? "Slippi_Online-x86_64.AppImage" : "Slippi_Playback-x86_64.AppImage";
+        return filename === userDolphinName || filename.endsWith("dolphin-emu");
+      }
       default:
         return false;
     }

--- a/src/dolphin/util.ts
+++ b/src/dolphin/util.ts
@@ -27,8 +27,8 @@ export async function findDolphinExecutable(type: DolphinLaunchType, dolphinPath
       case "darwin":
         return filename.endsWith("Dolphin.app");
       case "linux": {
-        const userDolphinName = type === DolphinLaunchType.NETPLAY ? "Slippi_Online-x86_64.AppImage" : "Slippi_Playback-x86_64.AppImage";
-        return filename === userDolphinName || filename.endsWith("dolphin-emu");
+        const appimagePrefix = type === DolphinLaunchType.NETPLAY ? "Slippi_Online" : "Slippi_Playback";
+        return filename.startsWith(appimagePrefix) || filename.endsWith("dolphin-emu");
       }
       default:
         return false;


### PR DESCRIPTION
Let's not just return the first appimage in any given directory, but use their proper names instead.

A similar check might be favorable in the case of Windows and MacOS (so as not to simply execute "aVirus.Dolphin.exe"), but I'm not familiar with those platforms.