### PR TITLE
macOS child process deadlock workaround

### DIFF
--- a/src/dolphin/instance.ts
+++ b/src/dolphin/instance.ts
@@ -1,20 +1,19 @@
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { randomBytes } from "crypto";
-import { app } from "electron";
 import log from "electron-log";
 import { EventEmitter } from "events";
 import * as fs from "fs-extra";
 import path from "path";
 
 import { fileExists } from "../main/fileExists";
+import { isMac } from "../common/constants";
 import { ReplayCommunication } from "./types";
+import { generateTempCommsDirectoryPath } from "../main/util";
 
 const generateTempCommunicationFile = (): string => {
-  const tmpDir = app.getPath("temp");
+  const commsDirectory = generateTempCommsDirectoryPath();
   const uniqueId = randomBytes(12).toString("hex");
-  const commFileName = `slippi-comms-${uniqueId}.json`;
-  const commFileFullPath = path.join(tmpDir, commFileName);
-  return commFileFullPath;
+  return path.join(commsDirectory, `${uniqueId}.json`);
 };
 
 export class DolphinInstance extends EventEmitter {
@@ -32,7 +31,23 @@ export class DolphinInstance extends EventEmitter {
    * Spawns the Dolphin instance with any additional command line parameters
    */
   public start(additionalParams?: string[]) {
+    let executablePath = this.executablePath;
     const params: string[] = [];
+
+    // On macOS, spawning Dolphin as a child process seems to cause deadlocks to occur
+    // when rendering the game. This notably happens with (MoltenVK/Vulkan/Metal), but has
+    // exhibited itself under OpenGL as well. Modern macOS really needs to run Vulkan, though,
+    // so we need to work around the issue here.
+    //
+    // Ultimately this needs a better solution for the long term, but for now, we'll just route
+    // through the `open` command and ferry the args along. This is a little less nice than other
+    // platforms, but keeps macOS performant and... working.
+    if (isMac) {
+      executablePath = "open";
+
+      // Open needs the bundle path, not the executable path.
+      params.push(this.executablePath.replace("/Contents/MacOS/Slippi Dolphin", ""), "--args");
+    }
 
     // Auto-start the ISO if provided
     if (this.isoPath) {
@@ -44,13 +59,22 @@ export class DolphinInstance extends EventEmitter {
       params.push(...additionalParams);
     }
 
-    this.process = spawn(this.executablePath, params);
-    this.process.on("close", () => {
-      this.emit("close");
-    });
-    this.process.on("error", (err) => {
-      this.emit("error", err);
-    });
+    this.process = spawn(executablePath, params); //, { detached: isMac ? true : false });
+
+    // Since macOS routes through the `open` command, the child process will return immediately.
+    // This means that the `close` event triggers immediately, and playback won't work due to the
+    // comms file being deleted from underneath it.
+    //
+    // Thus, attach these on non-macOS platforms, and have macOS clean up temp comms files at
+    // app start. Less graceful, but works.
+    if (!isMac) {
+      this.process.on("close", () => {
+        this.emit("close");
+      });
+      this.process.on("error", (err) => {
+        this.emit("error", err);
+      });
+    }
   }
 }
 
@@ -62,16 +86,20 @@ export class PlaybackDolphinInstance extends DolphinInstance {
     this.commPath = generateTempCommunicationFile();
 
     // Delete the comm file once Dolphin is closed
-    this.on("close", async () => {
-      try {
-        const exists = await fileExists(this.commPath);
-        if (exists) {
-          await fs.unlink(this.commPath);
+    // See notes elsewhere in this file regarding why this isn't attached
+    // for macOS.
+    if (!isMac) {
+      this.on("close", async () => {
+        try {
+          const exists = await fileExists(this.commPath);
+          if (exists) {
+            await fs.unlink(this.commPath);
+          }
+        } catch (err) {
+          log.warn(err);
         }
-      } catch (err) {
-        log.warn(err);
-      }
-    });
+      });
+    }
   }
 
   /***
@@ -83,8 +111,10 @@ export class PlaybackDolphinInstance extends DolphinInstance {
       options.commandId = Math.random().toString(36).slice(2);
     }
 
-    // Write out the comms file
-    await fs.writeFile(this.commPath, JSON.stringify(options));
+    // Write out the comms file.
+    // Note that `outputFile` will create an intermediate directory if
+    // necessary, which fits the cleanup model for temp comms files.
+    await fs.outputFile(this.commPath, JSON.stringify(options));
 
     if (!this.process) {
       const params: string[] = [];

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,9 +16,14 @@ import { download } from "./download";
 import { fileExists } from "./fileExists";
 import { setupListeners } from "./listeners";
 import { menu } from "./menu";
+import { clearTempCommsDirectory } from "./util";
 
 // use console.log as log.debug for easier access to debug logging
 console.log = log.debug;
+
+// Clearing this should be a quick operation, but do it before anything else
+// can work with the temp comms directory.
+clearTempCommsDirectory();
 
 // Check for updates
 autoUpdater.logger = log;

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,4 +1,33 @@
+import { app } from "electron";
 import * as fs from "fs-extra";
+import path from "path";
+
+// Returns a standard location for the temporary slippi comms files used to
+// communicate with and instruct Slippi Dolphin.
+export const generateTempCommsDirectoryPath = (): string => {
+  const tmpDir = app.getPath("temp");
+  return path.join(tmpDir, "slippi-comms");
+};
+
+// Cleans up any temp comms files that have been written to the temp
+// folder that might still be lingering around, and reinitializes the directory.
+//
+// This really only needs to happen on macOS due to the way that the subprocess handling
+// of Dolphin playback instances works - there's no graceful way at the moment to detect
+// Dolphin close, so we just leave the files in there and expect that either:
+//
+// - The temp directory will be cleared at some point, as macOS eventually does
+// - The eventual restart of this app will clear them up
+//
+// As this is a filesystem call it should be fine to happen relatively immediately
+// and not require being a part of anything Electron-ready.
+export const clearTempCommsDirectory = () => {
+  const tempCommsDirectoryPath = generateTempCommsDirectoryPath();
+
+  try {
+    fs.removeSync(tempCommsDirectoryPath);
+  } catch (err) {}
+};
 
 // Implemenation taken from https://github.com/alexbbt/read-last-lines/blob/11945800b013fe5016c4ea36e49d28c67aa75e7c/src/index.js
 export async function readLastLines(

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -26,7 +26,10 @@ export const clearTempCommsDirectory = () => {
 
   try {
     fs.removeSync(tempCommsDirectoryPath);
-  } catch (err) {}
+  } catch (err) {
+    // Silence the linter; this is probably fine if it fails (e.g, it doesn't exist).
+    console.log("");
+  }
 };
 
 // Implemenation taken from https://github.com/alexbbt/read-last-lines/blob/11945800b013fe5016c4ea36e49d28c67aa75e7c/src/index.js


### PR DESCRIPTION
On macOS, running Slippi Dolphin as a child process via Node seems to cause deadlocking issues when running the game. This was discovered during the `2.3.2/2.3.6` Slippi Dolphin release, where some improvements to the Vulkan (Metal) driver had to be rolled back due to hanging on start. After researching this further, I found I'm able to reproduce this in OpenGL as well, and with Slippi Dolphin `2.3.1` set to Vulkan... so I don't _think_ it was those changes.

If I had to theorize, it's some oddity with Node's child process module not separating the event loop for the processes on macOS. At any rate, this PR has a workaround (not a long term solution, but does make the Launcher a better experience on macOS).

- `dolphin/manager.ts` and `dolphin/instance.ts` now pass through the macOS `open` command, which ensures it's separate and can do its own thing.
- `dolphin/manager.ts` avoids tracking open Dolphin instances on macOS. This isn't really necessary there as `open` will pop a user back to the currently open `(netplay|playback)` build. It does mean that users on macOS can only watch one replay at a time, but given that limitation versus being able to play without issue... I'd take that compromise.
- macOS avoids attaching `close` event handlers since it can't own the process this way, but in practice this isn't too bad. It loses the `error` handler as well, but this might be fine to keep actually - it'd just be an error for `open` instead of the playback instance itself (so it'd catch cases where the app is inexplicably missing).
- Playback comms files are written to a subfolder in the `temp` directory, which gets cleared out and recreated on app startup. This is due to macOS needing a way to "reliably" clean these, since it can't auto clean them on Dolphin close like Windows/Linux can.

This should also head off any issues with bumping Electron and running as a universal/native app on M1 processors - without this change, I'm fairly certain we'd need to make changes to check the architecture and start Dolphin explicitly with Rosetta 2... but by passing through `open`, the system can just do whatever it needs to.

I believe this should also fix the issues some users have reported where Slippi Dolphin stuttered more when running via the Launcher, but that's not confirmed without more user testing.

I've tested this on my machines by building a local copy of Slippi Dolphin with the Metal changes that were reverted, and playback no longer hangs on a black screen. I can round up some more tests for macOS if need be.