### PR TITLE
Check for updates to background, window sooner (macOS).

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -13,6 +13,8 @@ export const ipc_deleteDesktopAppPath = makeEndpoint.main("deleteDesktopAppPath"
 
 export const ipc_copyLogsToClipboard = makeEndpoint.main("copyLogsToClipboard", <EmptyPayload>_, <SuccessPayload>_);
 
+export const ipc_checkForUpdate = makeEndpoint.main("checkForUpdate", <EmptyPayload>_, <SuccessPayload>_);
+
 export const ipc_installUpdate = makeEndpoint.main("installUpdate", <EmptyPayload>_, <SuccessPayload>_);
 
 // Events

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -102,9 +102,12 @@ function createMainWindow() {
 
   window.once("ready-to-show", () => {
     didFinishLoad = true;
-    window.show();
-    window.focus();
+    //window.show();
+    //window.focus();
   });
+
+  window.show();
+  window.focus();
 
   setupListeners();
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -102,12 +102,20 @@ function createMainWindow() {
 
   window.once("ready-to-show", () => {
     didFinishLoad = true;
-    //window.show();
-    //window.focus();
+
+    // Avoid paint flash in Windows by showing when ready.
+    if (!isMac) {
+      window.show();
+      window.focus();
+    }
   });
 
-  window.show();
-  window.focus();
+  // macOS doesn't seem to suffer from the paint flash, and since a user can close and reopen the
+  // window without killing the process, this should be a bit faster.
+  if (isMac) {
+    window.show();
+    window.focus();
+  }
 
   setupListeners();
 

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -7,6 +7,7 @@ import "@console/main";
 import { settingsManager } from "@settings/settingsManager";
 import { isDevelopment } from "common/constants";
 import {
+  ipc_checkForUpdate,
   ipc_checkValidIso,
   ipc_copyLogsToClipboard,
   ipc_deleteDesktopAppPath,
@@ -129,5 +130,8 @@ export function setupListeners() {
     autoUpdater.quitAndInstall(false, true);
     return { success: true };
   });
-  autoUpdater.checkForUpdatesAndNotify().catch(log.warn);
+  ipc_checkForUpdate.main!.handle(async () => {
+    autoUpdater.checkForUpdatesAndNotify().catch(log.warn);
+    return { success: true };
+  });
 }

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -1,3 +1,4 @@
+import { ipc_checkForUpdate } from "common/ipc";
 import { ipc_checkDesktopAppDolphin, ipc_dolphinDownloadFinishedEvent, ipc_downloadDolphin } from "dolphin/ipc";
 import log from "electron-log";
 import firebase from "firebase";
@@ -99,6 +100,9 @@ export const useAppInitialization = () => {
         })
         .catch(console.error),
     );
+
+    // Check if there is an update to the launcher
+    promises.push(ipc_checkForUpdate.renderer!.trigger({}));
 
     // Wait for all the promises to complete before completing
     try {


### PR DESCRIPTION
On macOS, prior to this change creating a new main window after having
closed it would take a few seconds. Forcing this check to the background
and showing the window sooner results in a quicker feeling load process.

I believe this should result in quicker appearance on other platforms as
well, but someone would need to test there.

This can be tested as of this commit by commenting out the `app.quit()`
call on `all-windows-closed`. Combined with some other PRs in the
pipeline it should work as expected.

(A good chunk of this patch was authored by Nikki; I just swapped some
window focus calls and tested on macOS)