### PR TITLE
feat/driver install button

### DIFF
--- a/src/renderer/containers/Settings/DriverOptions.tsx
+++ b/src/renderer/containers/Settings/DriverOptions.tsx
@@ -1,0 +1,60 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+import Button from "@material-ui/core/Button";
+import { isLinux, isMac } from "common/constants";
+import React from "react";
+
+import { DevGuard } from "@/components/DevGuard";
+
+import { SettingItem } from "./SettingItem";
+
+export const DriverOptions: React.FC = () => {
+  return (
+    <div>
+      <DevGuard show={!isMac && !isLinux}>
+        <SettingItem
+          name="Install GC Adapter Drivers"
+          description="Automatically install drivers for the GameCube controller adapter. This only needs to be done once."
+        >
+          <div
+            css={css`
+              display: flex;
+              & > button {
+                margin-right: 10px;
+              }
+            `}
+          >
+            <Button variant="contained" color="primary" /* onClick={} */ disabled={false}>
+              Install drivers
+            </Button>
+            <Button variant="outlined" color="primary" /* onClick={} */ disabled={false}>
+              Manual install
+            </Button>
+          </div>
+        </SettingItem>
+      </DevGuard>
+      <DevGuard show={isMac}>
+        <SettingItem
+          name="Install GC Adapter Drivers"
+          description="Automatic installation not available for Mac devices. Open the link below for manual instructions."
+        >
+          <Button variant="contained" color="primary" /* onClick={} */ disabled={false}>
+            Open Instructions
+          </Button>
+        </SettingItem>
+      </DevGuard>
+      <DevGuard show={isLinux}>
+        <SettingItem
+          name="Install GC Adapter Drivers"
+          description="Automatic installation not available for linux devices. You can execute the command below in a terminal to install drivers."
+        >
+          <code>
+            {
+              'sudo rm -f /etc/udev/rules.d/51-gcadapter.rules && sudo touch /etc/udev/rules.d/51-gcadapter.rules && echo \'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0666"\' | sudo tee /etc/udev/rules.d/51-gcadapter.rules > /dev/null && sudo udevadm control --reload-rules'
+            }
+          </code>
+        </SettingItem>
+      </DevGuard>
+    </div>
+  );
+};

--- a/src/renderer/containers/Settings/index.tsx
+++ b/src/renderer/containers/Settings/index.tsx
@@ -2,6 +2,7 @@ import { DolphinLaunchType } from "@dolphin/types";
 import React from "react";
 
 import { DolphinSettings } from "./DolphinSettings";
+import { DriverOptions } from "./DriverOptions";
 import { HelpPage } from "./HelpPage";
 import { MeleeOptions } from "./MeleeOptions";
 import { ReplayOptions } from "./ReplayOptions";
@@ -35,6 +36,11 @@ export const settings: SettingSection[] = [
         name: "Playback",
         path: "playback-dolphin-settings",
         component: <DolphinSettings dolphinType={DolphinLaunchType.PLAYBACK} />,
+      },
+      {
+        name: "Drivers",
+        path: "driver-options",
+        component: <DriverOptions />,
       },
     ],
   },


### PR DESCRIPTION
Adds a page to the launcher settings for GCC adapter driver installation. This is automated for windows, but mac and linux users will be redirected to instructions for manual installation. This is a draft PR while I write the auto-install logic.

See #172 for details.