### PR TITLE
fix: sticky shift key bug when starting a recording with ShareX

### DIFF
--- a/src/renderer/containers/ReplayBrowser/FileList.tsx
+++ b/src/renderer/containers/ReplayBrowser/FileList.tsx
@@ -20,7 +20,7 @@ const FileListResults: React.FC<{
   files: FileResult[];
   scrollRowItem: number;
   selectedFiles: Array<string>;
-  onClick: (index: number) => void;
+  onClick: (index: number, isShiftHeld: boolean) => void;
   onOpenMenu: (index: number, element: HTMLElement) => void;
   onSelect: (index: number) => void;
   onPlay: (index: number) => void;
@@ -45,7 +45,7 @@ const FileListResults: React.FC<{
             index={props.index}
             style={props.style}
             onSelect={() => onSelect(props.index)}
-            onClick={() => onClick(props.index)}
+            onClick={(e) => onClick(props.index, e.shiftKey)}
             selectedFiles={selectedFiles}
             selectedIndex={selectedIndex}
             onPlay={() => onPlay(props.index)}
@@ -101,7 +101,7 @@ export const FileList: React.FC<{
   setScrollRowItem: (row: number) => void;
   onDelete: (filepath: string) => void;
   onSelect: (index: number) => void;
-  onFileClick: (index: number) => void;
+  onFileClick: (index: number, isShiftHeld: boolean) => void;
   selectedFiles: Array<string>;
   onPlay: (index: number) => void;
 }> = ({

--- a/src/renderer/containers/ReplayBrowser/ReplayFile.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayFile.tsx
@@ -28,7 +28,7 @@ export interface ReplayFileProps extends FileResult {
   onSelect: () => void;
   onPlay: () => void;
   onOpenMenu: (index: number, element: HTMLElement) => void;
-  onClick: () => void;
+  onClick: React.MouseEventHandler<HTMLDivElement>;
   selectedFiles: string[];
   selectedIndex: number;
 }

--- a/src/renderer/lib/hooks/useReplays.ts
+++ b/src/renderer/lib/hooks/useReplays.ts
@@ -8,7 +8,6 @@ import create from "zustand";
 import { useSettings } from "@/lib/hooks/useSettings";
 
 import { findChild, generateSubFolderTree } from "../folderTree";
-import { useMousetrap } from "./useMousetrap";
 import { useReplayBrowserList } from "./useReplayBrowserList";
 
 type StoreState = {
@@ -240,9 +239,6 @@ export const useReplaySelection = () => {
   const setSelectedFiles = useReplays((store) => store.setSelectedFiles);
 
   const [lastClickIndex, setLastClickIndex] = useState<number | null>(null);
-  const [shiftHeld, setShiftHeld] = useState(false);
-  useMousetrap("shift", () => setShiftHeld(true));
-  useMousetrap("shift", () => setShiftHeld(false), "keyup");
 
   const toggleFiles = (fileNames: string[], mode: "toggle" | "select" | "deselect" = "toggle") => {
     const newSelection = Array.from(selectedFiles);
@@ -276,9 +272,9 @@ export const useReplaySelection = () => {
     setSelectedFiles(newSelection);
   };
 
-  const onFileClick = (index: number) => {
+  const onFileClick = (index: number, isShiftHeld: boolean) => {
     const isCurrentSelected = selectedFiles.includes(files[index].fullPath);
-    if (lastClickIndex !== null && shiftHeld) {
+    if (lastClickIndex !== null && isShiftHeld) {
       // Shift is held
       // Find all the files between the last clicked file and the current one
       const startIndex = Math.min(index, lastClickIndex);


### PR DESCRIPTION
This could have further implications for `useMouseTrap`. It seems like under certain conditions, the program may not pick up a key making it a pretty bad choice for managing an "isShiftHeld" state.

In this case, I was activating my ShareX recording software which records the screen by pressing `Shift + PrntScrn`. I was not pressing shift any other time. My guess is because ShareX freezes the screen when taking a screenshot, electron does not pick up the release of the key? May be other scenarios where this can happen though.

https://user-images.githubusercontent.com/1534726/132077505-38455ce4-5170-45ac-9c9c-e320f25dc245.mp4

