### PR TITLE
fix: mirroring failures caused by use of OBS websocket

### DIFF
--- a/src/console/autoSwitcher.ts
+++ b/src/console/autoSwitcher.ts
@@ -57,13 +57,11 @@ export class AutoSwitcher extends EventEmitter {
           password: this.obsPassword,
         });
       } catch (err) {
-        if (err) {
-          this.emit(
-            MirrorEvent.ERROR,
-            "Could not connect to OBS, ensure you have OBS websocket installed and OBS is open.",
-          );
-          return;
-        }
+        this.emit(
+          MirrorEvent.ERROR,
+          "Could not connect to OBS, ensure you have OBS websocket installed and OBS is open.",
+        );
+        return;
       }
 
       this.obs.on("SceneItemAdded", async () => this._getSceneSources());

--- a/src/console/autoSwitcher.ts
+++ b/src/console/autoSwitcher.ts
@@ -51,17 +51,21 @@ export class AutoSwitcher extends EventEmitter {
   public async connect() {
     if (this.obsIP && this.obsSourceName) {
       // if you send a password when authentication is disabled, OBS will still connect
-      await this.obs.connect(
-        {
+      try {
+        await this.obs.connect({
           address: this.obsIP,
           password: this.obsPassword,
-        },
-        (err) => {
-          if (err) {
-            this.emit(MirrorEvent.ERROR, err);
-          }
-        },
-      );
+        });
+      } catch (err) {
+        if (err) {
+          this.emit(
+            MirrorEvent.ERROR,
+            "Could not connect to OBS, ensure you have OBS websocket installed and OBS is open.",
+          );
+          return;
+        }
+      }
+
       this.obs.on("SceneItemAdded", async () => this._getSceneSources());
       this.obs.on("SceneItemRemoved", async () => this._getSceneSources());
       await this._getSceneSources();

--- a/src/console/workerInterface.ts
+++ b/src/console/workerInterface.ts
@@ -20,7 +20,12 @@ export const mirrorWorker: Promise<Thread & MirrorWorkerMethods> = new Promise((
       });
       worker.getErrorObservable().subscribe((errorMessage) => {
         mirrorLog.error(errorMessage);
-        const message = errorMessage instanceof Error ? errorMessage.message : errorMessage;
+        const message =
+          errorMessage instanceof Error
+            ? errorMessage.message
+            : typeof errorMessage === "string"
+            ? errorMessage
+            : JSON.stringify(errorMessage);
         ipc_consoleMirrorErrorMessageEvent.main!.trigger({ message }).catch(mirrorLog.error);
       });
       worker.getMirrorDetailsObservable().subscribe(({ playbackId, filePath, isRealtime }) => {


### PR DESCRIPTION
This PR attempts to fix 2 known bugs surrounding the auto switcher.

Current Behavior
1. If OBS is not open, attempting to mirror will provide a toast that just says `some stuff [object Object]`, which is useless to the end user
2. If OBS closes while the auto switcher is connected, when the auto switcher triggers the UI will crash.