### PR TITLE
fix: show error when dolphin is missing dlls

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -6,7 +6,7 @@ Rollback is a superior netcode implementation to the delay based netcode that ev
 
 We only support NTSC-U/J 1.02.
 
-## Nothing happens when I hit Play/Necessary DLLs are missing
+## It says "Required DLLs are missing" when I hit Play!
 
 You are missing DLLs necessary for Dolphin to run, download and install the file at the link: <https://aka.ms/vs/17/release/vc_redist.x64.exe>
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -6,6 +6,10 @@ Rollback is a superior netcode implementation to the delay based netcode that ev
 
 We only support NTSC-U/J 1.02.
 
+## Nothing happens when I hit Play/Necessary DLLs are missing
+
+You are missing DLLs necessary for Dolphin to run, download and install the file at the link: <https://aka.ms/vs/17/release/vc_redist.x64.exe>
+
 ## How do I setup my GameCube Controller Adapter?
 
 Set your adapter to Wii U/Switch mode and then follow the section for your OS.
@@ -74,10 +78,6 @@ We cannot help you find an ISO, you will need to acquire one yourself. This webs
 ## Can I play Free For All with Slippi Online?
 
 No, only singles (1v1) and teams (2v2, 3v1, 2v1v1) is supported at this time. Free For All won't be added in the near future, but is not off the table entirely.
-
-## I get a VCRUNTIME error whenever I launch Dolphin
-
-Install this: <https://aka.ms/vs/17/release/vc_redist.x64.exe>
 
 ## Some of my inputs aren't going through correctly
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,7 @@ export const isDevelopment = process.env.NODE_ENV !== "production";
 
 export const isMac = process.platform === "darwin";
 export const isLinux = process.platform === "linux";
+export const isWindows = process.platform === "win32";
 
 export const slippiHomepage = "https://slippi.gg";
 export const slippiActivationUrl = "https://slippi.gg/online/enable";

--- a/src/dolphin/instance.ts
+++ b/src/dolphin/instance.ts
@@ -66,8 +66,8 @@ export class DolphinInstance extends EventEmitter {
       this.process = spawn(this.executablePath, params);
     }
 
-    this.process.on("close", () => {
-      this.emit("close");
+    this.process.on("close", (code) => {
+      this.emit("close", code);
     });
     this.process.on("error", (err) => {
       this.emit("error", err);

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -64,5 +64,5 @@ export const ipc_dolphinDownloadLogReceivedEvent = makeEndpoint.renderer(
 
 export const ipc_dolphinClosedEvent = makeEndpoint.renderer(
   "dolphin_dolphinClosed",
-  <{ dolphinType: DolphinLaunchType }>_,
+  <{ dolphinType: DolphinLaunchType; exitCode: number }>_,
 );

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -64,5 +64,5 @@ export const ipc_dolphinDownloadLogReceivedEvent = makeEndpoint.renderer(
 
 export const ipc_dolphinClosedEvent = makeEndpoint.renderer(
   "dolphin_dolphinClosed",
-  <{ dolphinType: DolphinLaunchType; exitCode: number }>_,
+  <{ dolphinType: DolphinLaunchType; exitCode: number | null }>_,
 );

--- a/src/dolphin/main.ts
+++ b/src/dolphin/main.ts
@@ -115,10 +115,10 @@ ipc_checkDesktopAppDolphin.main!.handle(async () => {
   return { dolphinPath: dolphinExecutablePath, exists: exists };
 });
 
-dolphinManager.on("playback-dolphin-closed", async () => {
-  void ipc_dolphinClosedEvent.main!.trigger({ dolphinType: DolphinLaunchType.PLAYBACK });
+dolphinManager.on("playback-dolphin-closed", async (_playbackId: string, code: number) => {
+  void ipc_dolphinClosedEvent.main!.trigger({ dolphinType: DolphinLaunchType.PLAYBACK, exitCode: code });
 });
 
-dolphinManager.on("netplay-dolphin-closed", async () => {
-  void ipc_dolphinClosedEvent.main!.trigger({ dolphinType: DolphinLaunchType.NETPLAY });
+dolphinManager.on("netplay-dolphin-closed", async (code: number) => {
+  void ipc_dolphinClosedEvent.main!.trigger({ dolphinType: DolphinLaunchType.NETPLAY, exitCode: code });
 });

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -29,8 +29,8 @@ export class DolphinManager extends EventEmitter {
     let playbackInstance = this.playbackDolphinInstances.get(id);
     if (!playbackInstance) {
       playbackInstance = new PlaybackDolphinInstance(dolphinPath, meleeIsoPath);
-      playbackInstance.on("close", () => {
-        this.emit("playback-dolphin-closed", id);
+      playbackInstance.on("close", (code) => {
+        this.emit("playback-dolphin-closed", id, code);
 
         // Remove the instance from the map on close
         this.playbackDolphinInstances.delete(id);
@@ -60,9 +60,10 @@ export class DolphinManager extends EventEmitter {
 
     // Create the Dolphin instance and start it
     this.netplayDolphinInstance = new DolphinInstance(dolphinPath, meleeIsoPath);
-    this.netplayDolphinInstance.on("close", () => {
-      this.emit("netplay-dolphin-closed");
+    this.netplayDolphinInstance.on("close", (code) => {
+      this.emit("netplay-dolphin-closed", code);
       this.netplayDolphinInstance = null;
+      log.warn(`Dolphin exit code: ${code}`);
     });
     this.netplayDolphinInstance.on("error", (err: Error) => {
       log.error(err);
@@ -92,8 +93,8 @@ export class DolphinManager extends EventEmitter {
     } else if (launchType === DolphinLaunchType.PLAYBACK && this.playbackDolphinInstances.size === 0) {
       const instance = new PlaybackDolphinInstance(dolphinPath);
       this.playbackDolphinInstances.set("configure", instance);
-      instance.on("close", () => {
-        this.emit("playback-dolphin-closed", "configure");
+      instance.on("close", (code) => {
+        this.emit("playback-dolphin-closed", "configure", code);
 
         // Remove the instance from the map on close
         this.playbackDolphinInstances.delete("configure");

--- a/src/renderer/lib/hooks/useAppListeners.ts
+++ b/src/renderer/lib/hooks/useAppListeners.ts
@@ -229,7 +229,28 @@ export const useAppListeners = () => {
 
   const setDolphinOpen = useDolphinStore((store) => store.setDolphinOpen);
   ipc_dolphinClosedEvent.renderer!.useEvent(
-    async ({ dolphinType }) => {
+    async ({ dolphinType, exitCode }) => {
+      if (exitCode === 0xc0000135) {
+        addToast(
+          `Necessary DLLs for launching Dolphin are missing. Head to the FAQ in the settings to find out how to install them.`,
+          {
+            id: `dolphin-error-0x${exitCode.toString(16)}`,
+            appearance: "error",
+            autoDismiss: false,
+          },
+        );
+      } else if (exitCode) {
+        addToast(
+          `Dolphin encountered an error with code: 0x${exitCode.toString(16)}.
+          If you are having issues, please screenshot this and post it in a support channel in the
+          Slippi Discord.`,
+          {
+            id: `dolphin-error-0x${exitCode.toString(16)}`,
+            appearance: "error",
+            autoDismiss: false,
+          },
+        );
+      }
       setDolphinOpen(dolphinType, false);
     },
     [setDolphinOpen],

--- a/src/renderer/lib/hooks/useAppListeners.ts
+++ b/src/renderer/lib/hooks/useAppListeners.ts
@@ -15,6 +15,7 @@ import {
 import { ipc_dolphinClosedEvent, ipc_dolphinDownloadLogReceivedEvent } from "@dolphin/ipc";
 import { ipc_loadProgressUpdatedEvent, ipc_statsPageRequestedEvent } from "@replays/ipc";
 import { ipc_openSettingsModalEvent, ipc_settingsUpdatedEvent } from "@settings/ipc";
+import { isLinux, isMac } from "common/constants";
 import {
   ipc_checkValidIso,
   ipc_launcherUpdateDownloadingEvent,
@@ -230,20 +231,24 @@ export const useAppListeners = () => {
   const setDolphinOpen = useDolphinStore((store) => store.setDolphinOpen);
   ipc_dolphinClosedEvent.renderer!.useEvent(
     async ({ dolphinType, exitCode }) => {
+      // ignore some situations
+      const ignore = [
+        exitCode === 3 && !isLinux && !isMac, // when selecting Update in game on windows, dolphin returns 3
+      ];
       if (exitCode === 0xc0000135) {
         addToast(
-          `Necessary DLLs for launching Dolphin are missing. Head to the FAQ in the settings to find out how to install them.`,
+          `Necessary DLLs for launching Dolphin are missing. Head to the FAQ in the settings to find out how to install them.
+          Required DLLs for launching Dolphin are missing. Check the Help section in the settings page to fix this issue.`,
           {
             id: `dolphin-error-0x${exitCode.toString(16)}`,
             appearance: "error",
             autoDismiss: false,
           },
         );
-      } else if (exitCode) {
+      } else if (exitCode && !ignore.includes(true)) {
         addToast(
-          `Dolphin encountered an error with code: 0x${exitCode.toString(16)}.
-          If you are having issues, please screenshot this and post it in a support channel in the
-          Slippi Discord.`,
+          `Dolphin exited with error code: 0x${exitCode.toString(16)}.
+          Please screenshot this and post it in a support channel in the Slippi Discord for assistance.`,
           {
             id: `dolphin-error-0x${exitCode.toString(16)}`,
             appearance: "error",

--- a/src/renderer/lib/hooks/useAppListeners.ts
+++ b/src/renderer/lib/hooks/useAppListeners.ts
@@ -15,7 +15,7 @@ import {
 import { ipc_dolphinClosedEvent, ipc_dolphinDownloadLogReceivedEvent } from "@dolphin/ipc";
 import { ipc_loadProgressUpdatedEvent, ipc_statsPageRequestedEvent } from "@replays/ipc";
 import { ipc_openSettingsModalEvent, ipc_settingsUpdatedEvent } from "@settings/ipc";
-import { isLinux, isMac } from "common/constants";
+import { isWindows } from "common/constants";
 import {
   ipc_checkValidIso,
   ipc_launcherUpdateDownloadingEvent,
@@ -230,15 +230,13 @@ export const useAppListeners = () => {
 
   const setDolphinOpen = useDolphinStore((store) => store.setDolphinOpen);
   const handleDolphinExitCode = (exitCode: number | null) => {
-    // ignore some situations
-    const ignore = [
-      exitCode === 3 && !isLinux && !isMac, // when selecting Update in game on windows, dolphin returns 3
-    ];
-
     if (exitCode === 0xc0000135) {
       return `Necessary DLLs for launching Dolphin are missing. Head to the FAQ in the settings to find out how to install them. 
       Required DLLs for launching Dolphin are missing. Check the Help section in the settings page to fix this issue.`;
-    } else if (exitCode !== null && !ignore.includes(true)) {
+    } else if (exitCode === 3 && isWindows) {
+      // when selecting Update in game on Windows, dolphin returns 3 which we don't want to send an error toast for
+      return null;
+    } else if (exitCode !== null) {
       return `Dolphin exited with error code: 0x${exitCode.toString(16)}.
       Please screenshot this and post it in a support channel in the Slippi Discord for assistance.`;
     }


### PR DESCRIPTION
Handles non-zero exit codes when Dolphin closes unexpectedly by showing an error message. Prior to this nothing would happen and the user would have no idea what is happening.

![image](https://user-images.githubusercontent.com/1534726/147711890-fcc89705-f19e-4fac-9ddc-b0b05e5dd27f.png)

TODO:
1. Test this on other operating systems, make sure closing the application normally doesn't cause errors messages.
2. Improve copy?

Improvements:
1. Make it so that if the error code detected is related to missing DLLs, direct the user to a download link for VCR
2. Perhaps increase the prominence of the error