### PR TITLE
feat: leverage slippi backend's getLatestDolphin query

### DIFF
--- a/src/dolphin/checkVersion.ts
+++ b/src/dolphin/checkVersion.ts
@@ -1,4 +1,5 @@
 import { ApolloClient, gql, HttpLink, InMemoryCache } from "@apollo/client";
+import { isDevelopment } from "common/constants";
 import { fetch } from "cross-fetch";
 import { GraphQLError } from "graphql";
 
@@ -12,7 +13,7 @@ const client = new ApolloClient({
   link: httpLink,
   cache: new InMemoryCache(),
   name: "slippi-launcher",
-  version: appVersion,
+  version: `${appVersion}${isDevelopment ? "-dev" : ""}`,
 });
 
 const getLatestDolphinQuery = gql`

--- a/src/dolphin/checkVersion.ts
+++ b/src/dolphin/checkVersion.ts
@@ -1,0 +1,62 @@
+import { ApolloClient, gql, HttpLink, InMemoryCache } from "@apollo/client";
+import { fetch } from "cross-fetch";
+import { GraphQLError } from "graphql";
+
+import { DolphinLaunchType, DolphinVersionResponse } from "./types";
+
+const httpLink = new HttpLink({ uri: process.env.SLIPPI_GRAPHQL_ENDPOINT, fetch });
+
+const appVersion = __VERSION__;
+
+const client = new ApolloClient({
+  link: httpLink,
+  cache: new InMemoryCache(),
+  name: "slippi-launcher",
+  version: appVersion,
+});
+
+const getLatestDolphinQuery = gql`
+  query GetLatestDolphin($purpose: DolphinPurpose, $includeBeta: Boolean) {
+    getLatestDolphin(purpose: $purpose, includeBeta: $includeBeta) {
+      linuxDownloadUrl
+      windowsDownloadUrl
+      macDownloadUrl
+      version
+    }
+  }
+`;
+
+const handleErrors = (errors: readonly GraphQLError[] | undefined) => {
+  if (errors) {
+    let errMsgs = "";
+    errors.forEach((err) => {
+      errMsgs += `${err.message}\n`;
+    });
+    throw new Error(errMsgs);
+  }
+};
+
+export async function fetchLatestDolphin(
+  dolphinType: DolphinLaunchType,
+  beta = false,
+): Promise<DolphinVersionResponse> {
+  const res = await client.query({
+    query: getLatestDolphinQuery,
+    fetchPolicy: "network-only",
+    variables: {
+      purpose: dolphinType.toUpperCase(),
+      includeBeta: beta,
+    },
+  });
+
+  handleErrors(res.errors);
+
+  return {
+    version: res.data.getLatestDolphin.version,
+    downloadUrls: {
+      darwin: res.data.getLatestDolphin.macDownloadUrl,
+      linux: res.data.getLatestDolphin.linuxDownloadUrl,
+      win32: res.data.getLatestDolphin.windowsDownloadUrl,
+    },
+  };
+}

--- a/src/dolphin/downloadDolphin.ts
+++ b/src/dolphin/downloadDolphin.ts
@@ -1,5 +1,5 @@
 import AdmZip from "adm-zip";
-import { ChildProcessWithoutNullStreams, spawn, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import { isLinux } from "common/constants";
 import { app, BrowserWindow } from "electron";
 import { download } from "electron-dl";
@@ -10,48 +10,13 @@ import path from "path";
 import { lt } from "semver";
 
 import { fileExists } from "../main/fileExists";
-import { getLatestRelease } from "../main/github";
+import { fetchLatestDolphin } from "./checkVersion";
 import { ipc_dolphinDownloadFinishedEvent, ipc_dolphinDownloadLogReceivedEvent } from "./ipc";
-import { DolphinLaunchType } from "./types";
+import { DolphinLaunchType, DolphinVersionResponse } from "./types";
 import { findDolphinExecutable } from "./util";
 
 function logDownloadInfo(message: string): void {
   void ipc_dolphinDownloadLogReceivedEvent.main!.trigger({ message });
-}
-
-export async function assertDolphinInstallation(
-  type: DolphinLaunchType,
-  log: (message: string) => void,
-): Promise<void> {
-  try {
-    await findDolphinExecutable(type);
-    log(`Found existing ${type} Dolphin executable.`);
-    log(`Checking if we need to update ${type} Dolphin`);
-    const data = await getLatestReleaseData(type);
-    const latestVersion = data.tag_name;
-    const isOutdated = await compareDolphinVersion(type, latestVersion);
-    if (isOutdated) {
-      log(`${type} Dolphin installation is outdated. Downloading latest...`);
-      await downloadAndInstallDolphin(type, log);
-      return;
-    }
-    log("No update found...");
-    return;
-  } catch (err) {
-    log(`Could not find ${type} Dolphin installation. Downloading...`);
-    await downloadAndInstallDolphin(type, log);
-  }
-}
-
-export async function downloadAndInstallDolphin(
-  type: DolphinLaunchType,
-  log: (message: string) => void,
-  cleanInstall = false,
-): Promise<void> {
-  const downloadedAsset = await downloadLatestDolphin(type, log);
-  log(`Installing ${type} Dolphin...`);
-  await installDolphin(type, downloadedAsset, log, cleanInstall);
-  log(`Finished ${type} installing`);
 }
 
 export async function assertDolphinInstallations(): Promise<void> {
@@ -66,67 +31,71 @@ export async function assertDolphinInstallations(): Promise<void> {
   return;
 }
 
+export async function assertDolphinInstallation(
+  type: DolphinLaunchType,
+  log: (message: string) => void,
+): Promise<void> {
+  try {
+    await findDolphinExecutable(type);
+    log(`Found existing ${type} Dolphin executable.`);
+    log(`Checking if we need to update ${type} Dolphin`);
+    const data = await fetchLatestDolphin(type);
+    const latestVersion = data.version;
+    const isOutdated = await compareDolphinVersion(type, latestVersion);
+    if (isOutdated) {
+      log(`${type} Dolphin installation is outdated. Downloading latest...`);
+      await downloadAndInstallDolphin(type, data, log);
+      return;
+    }
+    log("No update found...");
+    return;
+  } catch (err) {
+    log(`Could not find ${type} Dolphin installation. Downloading...`);
+    const data = await fetchLatestDolphin(type);
+    await downloadAndInstallDolphin(type, data, log);
+  }
+}
+
 async function compareDolphinVersion(type: DolphinLaunchType, latestVersion: string): Promise<boolean> {
   const dolphinPath = await findDolphinExecutable(type);
   const dolphinVersion = spawnSync(dolphinPath, ["--version"]).stdout.toString();
   return lt(dolphinVersion, latestVersion);
 }
 
-export async function openDolphin(type: DolphinLaunchType, params?: string[]): Promise<ChildProcessWithoutNullStreams> {
-  const dolphinPath = await findDolphinExecutable(type);
-  return spawn(dolphinPath, params);
-}
-
-async function getLatestDolphinAsset(type: DolphinLaunchType): Promise<any> {
-  const release = await getLatestReleaseData(type);
-  const asset = release.assets.find((a: any) => matchesPlatform(a.name));
-  if (!asset) {
-    throw new Error(`No release asset matched the current platform: ${process.platform}`);
-  }
-  return asset;
-}
-
-async function getLatestReleaseData(type: DolphinLaunchType): Promise<any> {
-  const owner = "project-slippi";
-  let repo = "Ishiiruka";
-  if (type === DolphinLaunchType.PLAYBACK) {
-    repo += "-Playback";
-  }
-  return getLatestRelease(owner, repo);
-}
-
-function matchesPlatform(releaseName: string): boolean {
-  switch (process.platform) {
-    case "win32":
-      return releaseName.endsWith("Win.zip");
-    case "darwin":
-      return releaseName.endsWith("Mac.dmg");
-    case "linux":
-      return releaseName.endsWith("Linux.zip");
-    default:
-      return false;
-  }
+export async function downloadAndInstallDolphin(
+  type: DolphinLaunchType,
+  releaseInfo: DolphinVersionResponse,
+  log: (message: string) => void,
+  cleanInstall = false,
+): Promise<void> {
+  const downloadedAsset = await downloadLatestDolphin(releaseInfo, log);
+  log(`Installing v${releaseInfo.version} ${type} Dolphin...`);
+  await installDolphin(type, downloadedAsset, log, cleanInstall);
+  log(`Finished v${releaseInfo.version} ${type} Dolphin install`);
 }
 
 async function downloadLatestDolphin(
-  type: DolphinLaunchType,
+  releaseInfo: DolphinVersionResponse,
   log: (status: string) => void = console.log,
 ): Promise<string> {
-  const asset = await getLatestDolphinAsset(type);
+  const downloadUrl = releaseInfo.downloadUrls[process.platform];
+  const parsedUrl = new URL(downloadUrl);
+  const filename = path.basename(parsedUrl.pathname);
+
   const downloadDir = path.join(app.getPath("userData"), "temp");
   await fs.ensureDir(downloadDir);
-  const downloadLocation = path.join(downloadDir, asset.name);
+  const downloadLocation = path.join(downloadDir, filename);
   const exists = await fileExists(downloadLocation);
   if (!exists) {
-    log(`Downloading ${asset.browser_download_url} to ${downloadLocation}`);
+    log(`Downloading ${downloadUrl} to ${downloadLocation}`);
     const win = BrowserWindow.getFocusedWindow();
     if (win) {
-      await download(win, asset.browser_download_url, {
-        filename: asset.name,
+      await download(win, downloadUrl, {
+        filename: filename,
         directory: downloadDir,
         onProgress: (progress) => log(`Downloading... ${(progress.percent * 100).toFixed(0)}%`),
       });
-      log(`Successfully downloaded ${asset.browser_download_url} to ${downloadLocation}`);
+      log(`Successfully downloaded ${downloadUrl} to ${downloadLocation}`);
     } else {
       log("I dunno how we got here, but apparently there isn't a browser window /shrug");
     }

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -6,6 +6,7 @@ import * as fs from "fs-extra";
 import { fileExists } from "main/fileExists";
 import path from "path";
 
+import { fetchLatestDolphin } from "./checkVersion";
 import { downloadAndInstallDolphin } from "./downloadDolphin";
 import { DolphinInstance, PlaybackDolphinInstance } from "./instance";
 import { DolphinLaunchType, ReplayCommunication } from "./types";
@@ -126,7 +127,8 @@ export class DolphinManager extends EventEmitter {
     }
 
     // No dolphins of launchType are open so lets reinstall
-    await downloadAndInstallDolphin(launchType, log.info, true);
+    const releaseInfo = await fetchLatestDolphin(launchType);
+    await downloadAndInstallDolphin(launchType, releaseInfo, log.info, true);
     const isoPath = settingsManager.get().settings.isoPath;
     if (isoPath) {
       const gameDir = path.dirname(isoPath);

--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -38,3 +38,12 @@ export interface PlayKey {
   displayName: string;
   latestVersion: string;
 }
+
+export interface DolphinVersionResponse {
+  version: string;
+  downloadUrls: {
+    darwin: string;
+    linux: string;
+    win32: string;
+  };
+}

--- a/src/renderer/lib/slippiBackend.ts
+++ b/src/renderer/lib/slippiBackend.ts
@@ -1,6 +1,7 @@
 import { ApolloClient, ApolloLink, gql, HttpLink, InMemoryCache } from "@apollo/client";
 import { ipc_checkPlayKeyExists, ipc_removePlayKeyFile, ipc_storePlayKeyFile } from "@dolphin/ipc";
 import { PlayKey } from "@dolphin/types";
+import { isDevelopment } from "common/constants";
 import electronLog from "electron-log";
 import firebase from "firebase";
 import { GraphQLError } from "graphql";
@@ -15,7 +16,7 @@ const client = new ApolloClient({
   link: httpLink,
   cache: new InMemoryCache(),
   name: "slippi-launcher",
-  version: appVersion,
+  version: `${appVersion}${isDevelopment ? "-dev" : ""}`,
 });
 
 const getUserKeyQuery = gql`

--- a/webpack.main.additions.js
+++ b/webpack.main.additions.js
@@ -1,6 +1,8 @@
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const ThreadsPlugin = require("threads-plugin");
 const Dotenv = require("dotenv-webpack");
+const { DefinePlugin } = require("webpack");
+const pkg = require("./package.json");
 
 module.exports = function (context) {
   // Enforce chunkhash when building output files.
@@ -27,6 +29,12 @@ module.exports = function (context) {
     new ThreadsPlugin({ target: "electron-node-worker" }),
     // Expose dotenv variables
     new Dotenv(),
+  );
+
+  context.plugins.push(
+    new DefinePlugin({
+      __VERSION__: JSON.stringify(pkg.version),
+    }),
   );
 
   return context;


### PR DESCRIPTION
Swaps our current implementation of querying github in favor of the getLatestDolphin query on our backend.

The refactor of `downloadDolphin.ts` does reorder a bit of the code so the diff is a bit greater there.