### PR TITLE
feat: add better handling when play key fails to fetch

### DIFF
--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -36,7 +36,7 @@ export interface PlayKey {
   playKey: string;
   connectCode: string;
   displayName: string;
-  latestVersion: string;
+  latestVersion?: string;
 }
 
 export interface DolphinVersionResponse {

--- a/src/renderer/containers/Header/UserInfo.tsx
+++ b/src/renderer/containers/Header/UserInfo.tsx
@@ -11,8 +11,19 @@ export const UserInfo: React.FC<{
   uid: string;
   displayName: string | null;
   playKey: PlayKey | null;
+  isServerError: boolean | null;
   loading: boolean;
-}> = ({ uid, displayName, playKey, loading }) => {
+}> = ({ uid, displayName, playKey, isServerError, loading }) => {
+  const isErrorText = isServerError || !playKey;
+  let subtext = "";
+  if (isServerError) {
+    subtext = "Slippi server error";
+  } else if (!playKey) {
+    subtext = "Online activation required";
+  } else {
+    subtext = playKey.connectCode;
+  }
+
   return (
     <div
       css={css`
@@ -50,10 +61,10 @@ export const UserInfo: React.FC<{
             css={css`
               font-weight: bold;
               font-size: 14px;
-              color: ${playKey ? colors.purpleLight : "red"};
+              color: ${isErrorText ? "red" : colors.purpleLight};
             `}
           >
-            {playKey ? playKey.connectCode : "Online activation required"}
+            {subtext}
           </div>
         )}
       </div>

--- a/src/renderer/containers/Header/UserInfo.tsx
+++ b/src/renderer/containers/Header/UserInfo.tsx
@@ -11,12 +11,12 @@ export const UserInfo: React.FC<{
   uid: string;
   displayName: string | null;
   playKey: PlayKey | null;
-  isServerError: boolean | null;
+  serverError: boolean | null;
   loading: boolean;
-}> = ({ uid, displayName, playKey, isServerError, loading }) => {
-  const isErrorText = isServerError || !playKey;
+}> = ({ uid, displayName, playKey, serverError, loading }) => {
+  const isErrorText = serverError || !playKey;
   let subtext = "";
-  if (isServerError) {
+  if (serverError) {
     subtext = "Slippi server error";
   } else if (!playKey) {
     subtext = "Online activation required";

--- a/src/renderer/containers/Header/UserInfo.tsx
+++ b/src/renderer/containers/Header/UserInfo.tsx
@@ -14,7 +14,7 @@ export const UserInfo: React.FC<{
   serverError: boolean | null;
   loading: boolean;
 }> = ({ uid, displayName, playKey, serverError, loading }) => {
-  const isErrorText = serverError || !playKey;
+  const showError = serverError || !playKey;
   let subtext = "";
   if (serverError) {
     subtext = "Slippi server error";
@@ -61,7 +61,7 @@ export const UserInfo: React.FC<{
             css={css`
               font-weight: bold;
               font-size: 14px;
-              color: ${isErrorText ? "red" : colors.purpleLight};
+              color: ${showError ? "red" : colors.purpleLight};
             `}
           >
             {subtext}

--- a/src/renderer/containers/Header/UserMenu.tsx
+++ b/src/renderer/containers/Header/UserMenu.tsx
@@ -22,7 +22,7 @@ export const UserMenu: React.FC<{
   const playKey = useAccount((store) => store.playKey);
   const displayName = useAccount((store) => store.displayName);
   const loading = useAccount((store) => store.loading);
-  const isServerError = useAccount((store) => store.isServerError);
+  const serverError = useAccount((store) => store.serverError);
   const [openLogoutPrompt, setOpenLogoutPrompt] = React.useState(false);
   const [openNameChangePrompt, setOpenNameChangePrompt] = React.useState(false);
   const [openActivationDialog, setOpenActivationDialog] = React.useState(false);
@@ -52,7 +52,7 @@ export const UserMenu: React.FC<{
   const generateMenuItems = (): IconMenuItem[] => {
     const items: IconMenuItem[] = [];
 
-    if (!playKey && !isServerError) {
+    if (!playKey && !serverError) {
       items.push({
         onClick: () => {
           closeMenu();
@@ -92,7 +92,7 @@ export const UserMenu: React.FC<{
           uid={user.uid}
           displayName={displayName}
           playKey={playKey}
-          isServerError={isServerError}
+          serverError={serverError}
           loading={loading}
         />
       </ButtonBase>

--- a/src/renderer/containers/Header/UserMenu.tsx
+++ b/src/renderer/containers/Header/UserMenu.tsx
@@ -22,6 +22,7 @@ export const UserMenu: React.FC<{
   const playKey = useAccount((store) => store.playKey);
   const displayName = useAccount((store) => store.displayName);
   const loading = useAccount((store) => store.loading);
+  const isServerError = useAccount((store) => store.isServerError);
   const [openLogoutPrompt, setOpenLogoutPrompt] = React.useState(false);
   const [openNameChangePrompt, setOpenNameChangePrompt] = React.useState(false);
   const [openActivationDialog, setOpenActivationDialog] = React.useState(false);
@@ -51,7 +52,7 @@ export const UserMenu: React.FC<{
   const generateMenuItems = (): IconMenuItem[] => {
     const items: IconMenuItem[] = [];
 
-    if (!playKey) {
+    if (!playKey && !isServerError) {
       items.push({
         onClick: () => {
           closeMenu();
@@ -87,7 +88,13 @@ export const UserMenu: React.FC<{
   return (
     <div>
       <ButtonBase onClick={handleClick}>
-        <UserInfo uid={user.uid} displayName={displayName} playKey={playKey} loading={loading} />
+        <UserInfo
+          uid={user.uid}
+          displayName={displayName}
+          playKey={playKey}
+          isServerError={isServerError}
+          loading={loading}
+        />
       </ButtonBase>
       <IconMenu
         anchorEl={anchorEl}

--- a/src/renderer/containers/Header/index.tsx
+++ b/src/renderer/containers/Header/index.tsx
@@ -45,7 +45,7 @@ export const Header: React.FC<HeaderProps> = ({ path, menuItems }) => {
   const { open } = useSettingsModal();
   const currentUser = useAccount((store) => store.user);
   const playKey = useAccount((store) => store.playKey);
-  const isServerError = useAccount((store) => store.isServerError);
+  const serverError = useAccount((store) => store.serverError);
   const meleeIsoPath = useSettings((store) => store.settings.isoPath) || undefined;
   const { addToast } = useToasts();
   const { launchNetplay } = useDolphin();
@@ -61,7 +61,7 @@ export const Header: React.FC<HeaderProps> = ({ path, menuItems }) => {
       }
 
       // Ensure user has a valid play key
-      if (!playKey && !isServerError) {
+      if (!playKey && !serverError) {
         setActivateOnlineModal(true);
         return;
       }

--- a/src/renderer/containers/Header/index.tsx
+++ b/src/renderer/containers/Header/index.tsx
@@ -45,6 +45,7 @@ export const Header: React.FC<HeaderProps> = ({ path, menuItems }) => {
   const { open } = useSettingsModal();
   const currentUser = useAccount((store) => store.user);
   const playKey = useAccount((store) => store.playKey);
+  const isServerError = useAccount((store) => store.isServerError);
   const meleeIsoPath = useSettings((store) => store.settings.isoPath) || undefined;
   const { addToast } = useToasts();
   const { launchNetplay } = useDolphin();
@@ -60,17 +61,19 @@ export const Header: React.FC<HeaderProps> = ({ path, menuItems }) => {
       }
 
       // Ensure user has a valid play key
-      if (!playKey) {
+      if (!playKey && !isServerError) {
         setActivateOnlineModal(true);
         return;
       }
 
-      // Ensure the play key is saved to disk
-      try {
-        await assertPlayKey(playKey);
-      } catch (err) {
-        handleError(err.message);
-        return;
+      if (playKey) {
+        // Ensure the play key is saved to disk
+        try {
+          await assertPlayKey(playKey);
+        } catch (err) {
+          handleError(err.message);
+          return;
+        }
       }
     }
 

--- a/src/renderer/lib/hooks/useAccount.ts
+++ b/src/renderer/lib/hooks/useAccount.ts
@@ -11,6 +11,7 @@ export const useAccount = create(
       user: null as firebase.User | null,
       loading: false,
       playKey: null as PlayKey | null,
+      isServerError: false as boolean | null,
       displayName: "",
     },
     (set, get) => ({
@@ -25,6 +26,7 @@ export const useAccount = create(
         }),
       setLoading: (loading: boolean) => set({ loading }),
       setPlayKey: (playKey: PlayKey | null) => set({ playKey }),
+      setIsServerError: (isServerError: boolean | null) => set({ isServerError }),
       setDisplayName: (displayName: string) => set({ displayName }),
       refreshPlayKey: async (): Promise<void> => {
         // We're already refreshing the key
@@ -34,10 +36,10 @@ export const useAccount = create(
 
         set({ loading: true });
         await fetchPlayKey()
-          .then((playKey) => set({ playKey }))
+          .then((playKey) => set({ playKey, isServerError: false }))
           .catch((err) => {
             console.warn("Error fetching play key: ", err);
-            set({ playKey: null });
+            set({ playKey: null, isServerError: true });
           })
           .finally(() => set({ loading: false }));
       },

--- a/src/renderer/lib/hooks/useAccount.ts
+++ b/src/renderer/lib/hooks/useAccount.ts
@@ -11,7 +11,7 @@ export const useAccount = create(
       user: null as firebase.User | null,
       loading: false,
       playKey: null as PlayKey | null,
-      isServerError: false as boolean | null,
+      serverError: false as boolean | null,
       displayName: "",
     },
     (set, get) => ({
@@ -26,7 +26,7 @@ export const useAccount = create(
         }),
       setLoading: (loading: boolean) => set({ loading }),
       setPlayKey: (playKey: PlayKey | null) => set({ playKey }),
-      setIsServerError: (isServerError: boolean | null) => set({ isServerError }),
+      setServerError: (serverError: boolean | null) => set({ serverError }),
       setDisplayName: (displayName: string) => set({ displayName }),
       refreshPlayKey: async (): Promise<void> => {
         // We're already refreshing the key
@@ -36,10 +36,10 @@ export const useAccount = create(
 
         set({ loading: true });
         await fetchPlayKey()
-          .then((playKey) => set({ playKey, isServerError: false }))
+          .then((playKey) => set({ playKey, serverError: false }))
           .catch((err) => {
             console.warn("Error fetching play key: ", err);
-            set({ playKey: null, isServerError: true });
+            set({ playKey: null, serverError: true });
           })
           .finally(() => set({ loading: false }));
       },

--- a/src/renderer/lib/hooks/useAccount.ts
+++ b/src/renderer/lib/hooks/useAccount.ts
@@ -11,7 +11,7 @@ export const useAccount = create(
       user: null as firebase.User | null,
       loading: false,
       playKey: null as PlayKey | null,
-      serverError: false as boolean | null,
+      serverError: false,
       displayName: "",
     },
     (set, get) => ({
@@ -26,7 +26,7 @@ export const useAccount = create(
         }),
       setLoading: (loading: boolean) => set({ loading }),
       setPlayKey: (playKey: PlayKey | null) => set({ playKey }),
-      setServerError: (serverError: boolean | null) => set({ serverError }),
+      setServerError: (serverError: boolean) => set({ serverError }),
       setDisplayName: (displayName: string) => set({ displayName }),
       refreshPlayKey: async (): Promise<void> => {
         // We're already refreshing the key

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -45,7 +45,7 @@ export const useAppInitialization = () => {
   const setLogMessage = useAppStore((store) => store.setLogMessage);
   const setUser = useAccount((store) => store.setUser);
   const setPlayKey = useAccount((store) => store.setPlayKey);
-  const setIsServerError = useAccount((store) => store.setIsServerError);
+  const setServerError = useAccount((store) => store.setServerError);
   const setDesktopAppExists = useDesktopApp((store) => store.setExists);
   const setDesktopAppDolphinPath = useDesktopApp((store) => store.setDolphinPath);
 
@@ -74,11 +74,11 @@ export const useAppInitialization = () => {
       promises.push(
         fetchPlayKey()
           .then((key) => {
-            setIsServerError(false);
+            setServerError(false);
             setPlayKey(key);
           })
           .catch((err) => {
-            setIsServerError(true);
+            setServerError(true);
             console.warn(err);
 
             const message = `Failed to communicate with Slippi servers. You either have no internet

--- a/src/renderer/lib/hooks/useQuickStart.ts
+++ b/src/renderer/lib/hooks/useQuickStart.ts
@@ -19,7 +19,7 @@ function generateSteps(
   options: Partial<{
     hasUser: boolean;
     hasPlayKey: boolean;
-    isServerError: boolean;
+    serverError: boolean;
     hasIso: boolean;
     hasOldDesktopApp: boolean;
   }>,
@@ -35,7 +35,7 @@ function generateSteps(
     steps.unshift(QuickStartStep.MIGRATE_DOLPHIN);
   }
 
-  if (!options.hasPlayKey && !options.isServerError) {
+  if (!options.hasPlayKey && !options.serverError) {
     steps.unshift(QuickStartStep.ACTIVATE_ONLINE);
   }
 
@@ -51,13 +51,13 @@ export const useQuickStart = () => {
   const savedIsoPath = useSettings((store) => store.settings.isoPath);
   const user = useAccount((store) => store.user);
   const playKey = useAccount((store) => store.playKey);
-  const isServerError = useAccount((store) => store.isServerError);
+  const serverError = useAccount((store) => store.serverError);
   const desktopAppPathExists = useDesktopApp((store) => store.exists);
   const options = {
     hasUser: Boolean(user),
     hasIso: Boolean(savedIsoPath),
     hasPlayKey: Boolean(playKey),
-    isServerError: Boolean(isServerError),
+    serverError: Boolean(serverError),
     hasOldDesktopApp: desktopAppPathExists,
   };
   const [steps] = React.useState(generateSteps(options));
@@ -79,7 +79,7 @@ export const useQuickStart = () => {
       stepToShow = QuickStartStep.MIGRATE_DOLPHIN;
     }
 
-    if (!options.hasPlayKey && !options.isServerError) {
+    if (!options.hasPlayKey && !options.serverError) {
       stepToShow = QuickStartStep.ACTIVATE_ONLINE;
     }
 
@@ -95,7 +95,7 @@ export const useQuickStart = () => {
     options.hasOldDesktopApp,
     options.hasPlayKey,
     options.hasUser,
-    options.isServerError,
+    options.serverError,
   ]);
 
   const nextStep = () => {

--- a/src/renderer/lib/hooks/useQuickStart.ts
+++ b/src/renderer/lib/hooks/useQuickStart.ts
@@ -19,6 +19,7 @@ function generateSteps(
   options: Partial<{
     hasUser: boolean;
     hasPlayKey: boolean;
+    isServerError: boolean;
     hasIso: boolean;
     hasOldDesktopApp: boolean;
   }>,
@@ -34,7 +35,7 @@ function generateSteps(
     steps.unshift(QuickStartStep.MIGRATE_DOLPHIN);
   }
 
-  if (!options.hasPlayKey) {
+  if (!options.hasPlayKey && !options.isServerError) {
     steps.unshift(QuickStartStep.ACTIVATE_ONLINE);
   }
 
@@ -50,11 +51,13 @@ export const useQuickStart = () => {
   const savedIsoPath = useSettings((store) => store.settings.isoPath);
   const user = useAccount((store) => store.user);
   const playKey = useAccount((store) => store.playKey);
+  const isServerError = useAccount((store) => store.isServerError);
   const desktopAppPathExists = useDesktopApp((store) => store.exists);
   const options = {
     hasUser: Boolean(user),
     hasIso: Boolean(savedIsoPath),
     hasPlayKey: Boolean(playKey),
+    isServerError: Boolean(isServerError),
     hasOldDesktopApp: desktopAppPathExists,
   };
   const [steps] = React.useState(generateSteps(options));
@@ -76,15 +79,24 @@ export const useQuickStart = () => {
       stepToShow = QuickStartStep.MIGRATE_DOLPHIN;
     }
 
-    if (!options.hasPlayKey) {
+    if (!options.hasPlayKey && !options.isServerError) {
       stepToShow = QuickStartStep.ACTIVATE_ONLINE;
     }
 
     if (!options.hasUser) {
       stepToShow = QuickStartStep.LOGIN;
     }
+
     setCurrentStep(stepToShow);
-  }, [history, steps, options.hasIso, options.hasOldDesktopApp, options.hasPlayKey, options.hasUser]);
+  }, [
+    history,
+    steps,
+    options.hasIso,
+    options.hasOldDesktopApp,
+    options.hasPlayKey,
+    options.hasUser,
+    options.isServerError,
+  ]);
 
   const nextStep = () => {
     const currentIndex = steps.findIndex((s) => s === currentStep);

--- a/src/renderer/lib/slippiBackend.ts
+++ b/src/renderer/lib/slippiBackend.ts
@@ -102,6 +102,7 @@ export async function fetchPlayKey(): Promise<PlayKey | null> {
 
   const connectCode = res.data.getUser?.connectCode?.code;
   const playKey = res.data.getUser?.private?.playKey;
+  const displayName = res.data.getUser?.displayName || "";
   if (!connectCode || !playKey) {
     // If we don't have a connect code or play key, return this as null such that logic that
     // handles it will cause the user to set them up.
@@ -110,9 +111,9 @@ export async function fetchPlayKey(): Promise<PlayKey | null> {
 
   return {
     uid: user.uid,
-    connectCode: connectCode,
-    playKey: playKey,
-    displayName: res.data.getUser?.displayName,
+    connectCode,
+    playKey,
+    displayName,
     latestVersion: res.data.getLatestDolphin?.version,
   };
 }

--- a/src/renderer/lib/slippiBackend.ts
+++ b/src/renderer/lib/slippiBackend.ts
@@ -100,8 +100,8 @@ export async function fetchPlayKey(): Promise<PlayKey | null> {
 
   handleErrors(res.errors);
 
-  const connectCode = res.data?.getUser?.connectCode?.code;
-  const playKey = res.data?.getUser?.private?.playKey;
+  const connectCode = res.data.getUser?.connectCode?.code;
+  const playKey = res.data.getUser?.private?.playKey;
   if (!connectCode || !playKey) {
     // If we don't have a connect code or play key, return this as null such that logic that
     // handles it will cause the user to set them up.
@@ -112,8 +112,8 @@ export async function fetchPlayKey(): Promise<PlayKey | null> {
     uid: user.uid,
     connectCode: connectCode,
     playKey: playKey,
-    displayName: res.data?.getUser?.displayName,
-    latestVersion: res.data?.getLatestDolphin?.version,
+    displayName: res.data.getUser?.displayName,
+    latestVersion: res.data.getLatestDolphin?.version,
   };
 }
 

--- a/src/renderer/lib/slippiBackend.ts
+++ b/src/renderer/lib/slippiBackend.ts
@@ -87,7 +87,7 @@ async function refreshFirebaseAuth(): Promise<firebase.User> {
   return user;
 }
 
-export async function fetchPlayKey(): Promise<PlayKey> {
+export async function fetchPlayKey(): Promise<PlayKey | null> {
   const user = await refreshFirebaseAuth();
 
   const res = await client.query({
@@ -100,12 +100,20 @@ export async function fetchPlayKey(): Promise<PlayKey> {
 
   handleErrors(res.errors);
 
+  const connectCode = res.data?.getUser?.connectCode?.code;
+  const playKey = res.data?.getUser?.private?.playKey;
+  if (!connectCode || !playKey) {
+    // If we don't have a connect code or play key, return this as null such that logic that
+    // handles it will cause the user to set them up.
+    return null;
+  }
+
   return {
     uid: user.uid,
-    connectCode: res.data.getUser.connectCode.code,
-    playKey: res.data.getUser.private.playKey,
-    displayName: res.data.getUser.displayName,
-    latestVersion: res.data.getLatestDolphin.version,
+    connectCode: connectCode,
+    playKey: playKey,
+    displayName: res.data?.getUser?.displayName,
+    latestVersion: res.data?.getLatestDolphin?.version,
   };
 }
 


### PR DESCRIPTION
Previously when the user had no internet access or Slippi servers were down we would show the online activation step which was pretty confusing to users.

New behavior:
https://user-images.githubusercontent.com/1534726/153937946-e748898c-87fd-4f17-a0fc-5bd83fbbaacb.mp4


