### PR TITLE
refactor: prepare react router routes for v6 upgrade

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -47,7 +47,7 @@ const App: React.FC = () => {
       <Route path="/main" component={MainView} />
       <Route path="/landing" component={LandingView} />
       <Route path="/settings" component={SettingsView} />
-      <Redirect exact from="/" to="/landing" />
+      <Route exact path="/" component={() => <Redirect to="/landing" />} />
       <Route component={NotFoundView} />
     </Switch>
   );

--- a/src/renderer/components/AuthGuard.tsx
+++ b/src/renderer/components/AuthGuard.tsx
@@ -4,7 +4,7 @@ import { useAccount } from "@/lib/hooks/useAccount";
 
 import { LoginNotice } from "./LoginNotice";
 
-export const PrivateRoute = ({ children }: { children: React.ReactNode }) => {
+export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const user = useAccount((store) => store.user);
   const isLoggedIn = user !== null;
   if (!isLoggedIn) {

--- a/src/renderer/components/PrivateRoute.tsx
+++ b/src/renderer/components/PrivateRoute.tsx
@@ -1,32 +1,14 @@
 import React from "react";
-import { Route, RouteProps } from "react-router-dom";
 
 import { useAccount } from "@/lib/hooks/useAccount";
 
 import { LoginNotice } from "./LoginNotice";
 
-export const PrivateRoute: React.FC<RouteProps> = ({ children, component: Component, ...rest }) => {
+export const PrivateRoute = ({ children }: { children: React.ReactNode }) => {
   const user = useAccount((store) => store.user);
   const isLoggedIn = user !== null;
-
-  return (
-    <Route
-      {...rest}
-      render={(props) => {
-        if (!isLoggedIn) {
-          return <LoginNotice />;
-        }
-
-        if (!Component && children) {
-          return children;
-        }
-
-        if (Component) {
-          return <Component {...props} />;
-        }
-
-        return null;
-      }}
-    />
-  );
+  if (!isLoggedIn) {
+    return <LoginNotice />;
+  }
+  return <>{children}</>;
 };

--- a/src/renderer/containers/ReplayBrowser/ReplayBrowserPage.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayBrowserPage.tsx
@@ -21,9 +21,7 @@ export const ReplayBrowserPage: React.FC = () => {
       <Route path={`${path}/:filePath`}>
         <ChildPage goBack={() => history.push(path)} parent={path} />
       </Route>
-      <Route exact path={path}>
-        <Redirect to={lastPath} />
-      </Route>
+      <Route exact path={path} component={() => <Redirect to={lastPath} />} />
     </Switch>
   );
 };

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -80,7 +80,9 @@ export const MainView: React.FC = () => {
               </RouteToUse>
             );
           })}
-          {defaultRoute && <Redirect exact from={path} to={`${path}/${defaultRoute.subpath}`} />}
+          {defaultRoute && (
+            <Route exact path={path} component={() => <Redirect to={`${path}/${defaultRoute.subpath}`} />} />
+          )}
         </Switch>
       </div>
       <LoginDialog />

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -73,11 +73,11 @@ export const MainView: React.FC = () => {
       <div style={{ flex: 1, overflow: "auto", display: "flex" }}>
         <Switch>
           {menuItems.map((item) => {
-            const RouteToUse = item.private ? PrivateRoute : Route;
+            const element = item.private ? <PrivateRoute>{item.component}</PrivateRoute> : item.component;
             return (
-              <RouteToUse key={item.subpath} path={`${path}/${item.subpath}`}>
-                {item.component}
-              </RouteToUse>
+              <Route key={item.subpath} path={`${path}/${item.subpath}`}>
+                {element}
+              </Route>
             );
           })}
           {defaultRoute && (

--- a/src/renderer/views/MainView.tsx
+++ b/src/renderer/views/MainView.tsx
@@ -5,8 +5,8 @@ import SlowMotionVideoIcon from "@material-ui/icons/SlowMotionVideo";
 import React from "react";
 import { Redirect, Route, Switch, useRouteMatch } from "react-router-dom";
 
+import { AuthGuard } from "@/components/AuthGuard";
 import { PersistentNotification } from "@/components/PersistentNotification";
-import { PrivateRoute } from "@/components/PrivateRoute";
 import { Console } from "@/containers/Console";
 import { Header } from "@/containers/Header";
 import { LoginDialog } from "@/containers/Header/LoginDialog";
@@ -73,7 +73,7 @@ export const MainView: React.FC = () => {
       <div style={{ flex: 1, overflow: "auto", display: "flex" }}>
         <Switch>
           {menuItems.map((item) => {
-            const element = item.private ? <PrivateRoute>{item.component}</PrivateRoute> : item.component;
+            const element = item.private ? <AuthGuard>{item.component}</AuthGuard> : item.component;
             return (
               <Route key={item.subpath} path={`${path}/${item.subpath}`}>
                 {element}

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -158,9 +158,7 @@ export const SettingsView: React.FC = () => {
                 );
               })}
               {settingItems.length > 0 && (
-                <Route exact path={path}>
-                  <Redirect to={`${path}/${settingItems[0].path}`} />
-                </Route>
+                <Route exact path={path} component={() => <Redirect to={`${path}/${settingItems[0].path}`} />} />
               )}
             </Switch>
           </ContentColumn>


### PR DESCRIPTION
This PR migrates some of the route related components to be closer to the React Router v6 API. This will make it easier for the react-router upgrade in the future.

For more info on these changes, see: https://reactrouter.com/docs/en/v6/upgrading/v5#upgrade-to-react-router-v51