### PR TITLE
fix: showing invalid toast immediately on drop

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,4 +12,5 @@ export enum IsoValidity {
   VALID = "VALID",
   UNKNOWN = "UNKNOWN",
   INVALID = "INVALID",
+  UNVALIDATED = "UNVALIDATED",
 }

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -74,7 +74,7 @@ export function setupListeners() {
   ipc_checkValidIso.main!.handle(async ({ path }) => {
     // Make sure we have a valid path
     if (!path) {
-      return { path, valid: IsoValidity.INVALID };
+      return { path, valid: IsoValidity.UNVALIDATED };
     }
 
     try {

--- a/src/renderer/containers/QuickStart/IsoSelectionStep.tsx
+++ b/src/renderer/containers/QuickStart/IsoSelectionStep.tsx
@@ -56,7 +56,7 @@ export const IsoSelectionStep: React.FC = () => {
   const [tempIsoPath, setTempIsoPath] = React.useState("");
   const verification = ipc_checkValidIso.renderer!.useValue(
     { path: tempIsoPath },
-    { path: tempIsoPath, valid: IsoValidity.INVALID },
+    { path: tempIsoPath, valid: IsoValidity.UNVALIDATED },
   );
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("xs"));

--- a/src/renderer/containers/Settings/MeleeOptions.tsx
+++ b/src/renderer/containers/Settings/MeleeOptions.tsx
@@ -26,7 +26,8 @@ const renderValidityStatus = (isoValidity: IsoValidity) => {
     case IsoValidity.UNKNOWN: {
       return <Help />;
     }
-    case IsoValidity.INVALID: {
+    case IsoValidity.INVALID:
+    case IsoValidity.UNVALIDATED: {
       return <ErrorIcon />;
     }
   }

--- a/src/renderer/lib/hooks/useAppListeners.ts
+++ b/src/renderer/lib/hooks/useAppListeners.ts
@@ -137,7 +137,7 @@ export const useAppListeners = () => {
   const setIsValid = useIsoVerification((store) => store.setIsValid);
   React.useEffect(() => {
     if (!isoPath) {
-      setIsValid(IsoValidity.INVALID);
+      setIsValid(IsoValidity.UNVALIDATED);
       setIsValidating(false);
       return;
     }

--- a/src/renderer/lib/hooks/useIsoVerification.ts
+++ b/src/renderer/lib/hooks/useIsoVerification.ts
@@ -6,7 +6,7 @@ export const useIsoVerification = create(
   combine(
     {
       isValidating: false,
-      validity: IsoValidity.INVALID,
+      validity: IsoValidity.UNVALIDATED,
     },
     (set) => ({
       setIsValidating: (val: boolean) => set({ isValidating: val }),


### PR DESCRIPTION
adds an `Unvalidated` state for ISOs so that we don't immediately assume the ISO is invalid and show the error