### PR TITLE
feat: overwrite play key file if they don't match

### DIFF
--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -25,7 +25,11 @@ export const ipc_clearDolphinCache = makeEndpoint.main(
 
 export const ipc_storePlayKeyFile = makeEndpoint.main("storePlayKeyFile", <{ key: PlayKey }>_, <SuccessPayload>_);
 
-export const ipc_checkPlayKeyExists = makeEndpoint.main("checkPlayKeyExists", <EmptyPayload>_, <{ exists: boolean }>_);
+export const ipc_checkPlayKeyExists = makeEndpoint.main(
+  "checkPlayKeyExists",
+  <{ key: PlayKey }>_,
+  <{ exists: boolean }>_,
+);
 
 export const ipc_removePlayKeyFile = makeEndpoint.main("removePlayKeyFile", <EmptyPayload>_, <SuccessPayload>_);
 

--- a/src/dolphin/main.ts
+++ b/src/dolphin/main.ts
@@ -1,6 +1,7 @@
 import { isLinux, isMac } from "common/constants";
 import { app } from "electron";
 import * as fs from "fs-extra";
+import { isEqual } from "lodash";
 import path from "path";
 
 import { fileExists } from "../main/fileExists";
@@ -52,9 +53,14 @@ ipc_storePlayKeyFile.main!.handle(async ({ key }) => {
   return { success: true };
 });
 
-ipc_checkPlayKeyExists.main!.handle(async () => {
+ipc_checkPlayKeyExists.main!.handle(async ({ key }) => {
   const keyPath = await findPlayKey();
   const exists = await fileExists(keyPath);
+  if (exists) {
+    const jsonKey = await fs.readFile(keyPath);
+    const storedKey = JSON.parse(jsonKey.toString());
+    return { exists: isEqual(storedKey, key) };
+  }
   return { exists };
 });
 

--- a/src/renderer/lib/slippiBackend.ts
+++ b/src/renderer/lib/slippiBackend.ts
@@ -119,7 +119,7 @@ export async function fetchPlayKey(): Promise<PlayKey | null> {
 }
 
 export async function assertPlayKey(playKey: PlayKey) {
-  const playKeyExistsResult = await ipc_checkPlayKeyExists.renderer!.trigger({});
+  const playKeyExistsResult = await ipc_checkPlayKeyExists.renderer!.trigger({ key: playKey });
   if (!playKeyExistsResult.result) {
     log.error("Error checking for play key.", playKeyExistsResult.errors);
     throw new Error("Error checking for play key");


### PR DESCRIPTION
in the future we want to be a bit more tolerant about slippi being in a partially down state. to handle matchmaking without the DB or firebase we need to use the details from the user.json so we should keep the file up to date.