### PR TITLE
feat: handle auth, errors, and retry with links

### DIFF
--- a/src/dolphin/install/fetchLatestVersion.ts
+++ b/src/dolphin/install/fetchLatestVersion.ts
@@ -1,6 +1,9 @@
-import { ApolloClient, gql, HttpLink, InMemoryCache } from "@apollo/client";
+import { ApolloClient, ApolloLink, gql, HttpLink, InMemoryCache } from "@apollo/client";
+import { onError } from "@apollo/client/link/error";
+import { RetryLink } from "@apollo/client/link/retry";
 import { appVersion } from "@common/constants";
 import { fetch } from "cross-fetch";
+import electronLog from "electron-log";
 import type { GraphQLError } from "graphql";
 
 import type { DolphinLaunchType } from "../types";
@@ -14,11 +17,36 @@ export type DolphinVersionResponse = {
   };
 };
 
-const httpLink = new HttpLink({ uri: process.env.SLIPPI_GRAPHQL_ENDPOINT, fetch });
+const log = electronLog.scope("dolphin/checkVersion");
 const isDevelopment = process.env.NODE_ENV !== "production";
 
+const httpLink = new HttpLink({ uri: process.env.SLIPPI_GRAPHQL_ENDPOINT, fetch });
+const retryLink = new RetryLink({
+  delay: {
+    initial: 300,
+    max: Infinity,
+    jitter: true,
+  },
+  attempts: {
+    max: 5,
+    retryIf: (error, _operation) => !!error,
+  },
+});
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors) {
+    graphQLErrors.map(({ message, locations, path }) =>
+      log.error(`Apollo GQL Error: Message: ${message}, Location: ${locations}, Path: ${path}`),
+    );
+  }
+  if (networkError) {
+    log.error(`Apollo Network Error: ${networkError}`);
+  }
+});
+
+const apolloLink = ApolloLink.from([errorLink, retryLink, httpLink]);
+
 const client = new ApolloClient({
-  link: httpLink,
+  link: apolloLink,
   cache: new InMemoryCache(),
   name: "slippi-launcher",
   version: `${appVersion}${isDevelopment ? "-dev" : ""}`,

--- a/src/dolphin/install/fetchLatestVersion.ts
+++ b/src/dolphin/install/fetchLatestVersion.ts
@@ -28,8 +28,8 @@ const retryLink = new RetryLink({
     jitter: true,
   },
   attempts: {
-    max: 5,
-    retryIf: (error, _operation) => !!error,
+    max: 3,
+    retryIf: (error) => Boolean(error),
   },
 });
 const errorLink = onError(({ graphQLErrors, networkError }) => {

--- a/src/renderer/containers/SpectatePage/ShareGameplayBlock/StartBroadcastDialog.tsx
+++ b/src/renderer/containers/SpectatePage/ShareGameplayBlock/StartBroadcastDialog.tsx
@@ -54,9 +54,7 @@ export const StartBroadcastDialog: React.FC<StartBroadcastDialogProps> = ({ open
   );
 
   const fetchUser = debounce(async () => {
-    console.log("start debounced code");
     await userQuery.refetch();
-    console.log("end debounced code");
   }, 200);
 
   const handleChange = React.useCallback(

--- a/src/renderer/services/slippi/slippi.service.ts
+++ b/src/renderer/services/slippi/slippi.service.ts
@@ -36,7 +36,6 @@ class SlippiBackendClient implements SlippiBackendService {
     private readonly dolphinService: DolphinService,
     clientVersion?: string,
   ) {
-    this.authService = authService;
     const httpLink = new HttpLink({ uri: SLIPPI_BACKEND_URL });
     const authLink = setContext(async () => {
       // The firebase ID token expires after 1 hour so we will update the header on all actions
@@ -56,7 +55,7 @@ class SlippiBackendClient implements SlippiBackendService {
       },
       attempts: {
         max: 3,
-        retryIf: (error) => !!error,
+        retryIf: (error) => Boolean(error),
       },
     });
     const errorLink = onError(({ graphQLErrors, networkError }) => {

--- a/src/renderer/services/slippi/slippi.service.ts
+++ b/src/renderer/services/slippi/slippi.service.ts
@@ -1,9 +1,12 @@
 import type { NormalizedCacheObject } from "@apollo/client";
 import { ApolloClient, ApolloLink, HttpLink, InMemoryCache } from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+import { onError } from "@apollo/client/link/error";
+import { RetryLink } from "@apollo/client/link/retry";
 import type { DolphinService, PlayKey } from "@dolphin/types";
 import type { GraphQLError } from "graphql";
 
-import type { AuthService, AuthUser } from "../auth/types";
+import type { AuthService } from "../auth/types";
 import {
   MUTATION_INIT_NETPLAY,
   MUTATION_RENAME_USER,
@@ -12,6 +15,7 @@ import {
 } from "./graphqlEndpoints";
 import type { SlippiBackendService } from "./types";
 
+const log = window.electron.log;
 const SLIPPI_BACKEND_URL = process.env.SLIPPI_GRAPHQL_ENDPOINT;
 
 const handleErrors = (errors: readonly GraphQLError[] | undefined) => {
@@ -25,7 +29,6 @@ const handleErrors = (errors: readonly GraphQLError[] | undefined) => {
 };
 
 class SlippiBackendClient implements SlippiBackendService {
-  private httpLink: HttpLink;
   private client: ApolloClient<NormalizedCacheObject>;
 
   constructor(
@@ -33,37 +36,47 @@ class SlippiBackendClient implements SlippiBackendService {
     private readonly dolphinService: DolphinService,
     clientVersion?: string,
   ) {
-    this.httpLink = new HttpLink({ uri: SLIPPI_BACKEND_URL });
+    this.authService = authService;
+    const httpLink = new HttpLink({ uri: SLIPPI_BACKEND_URL });
+    const authLink = setContext(async () => {
+      // The firebase ID token expires after 1 hour so we will update the header on all actions
+      const token = await this.authService.getUserToken();
+
+      return {
+        headers: {
+          authorization: token ? `Bearer ${token}` : undefined,
+        },
+      };
+    });
+    const retryLink = new RetryLink({
+      delay: {
+        initial: 300,
+        max: Infinity,
+        jitter: true,
+      },
+      attempts: {
+        max: 3,
+        retryIf: (error) => !!error,
+      },
+    });
+    const errorLink = onError(({ graphQLErrors, networkError }) => {
+      if (graphQLErrors) {
+        graphQLErrors.map(({ message, locations, path }) =>
+          log.error(`Apollo GQL Error: Message: ${message}, Location: ${locations}, Path: ${path}`),
+        );
+      }
+      if (networkError) {
+        log.error(`Apollo Network Error: ${networkError}`);
+      }
+    });
+
+    const apolloLink = ApolloLink.from([authLink, errorLink, retryLink, httpLink]);
     this.client = new ApolloClient({
-      link: this.httpLink,
+      link: apolloLink,
       cache: new InMemoryCache(),
       name: "slippi-launcher",
       version: clientVersion,
     });
-  }
-
-  // The firebase ID token expires after 1 hour so we will refresh it for actions that require it.
-  private async _refreshAuthToken(): Promise<AuthUser> {
-    const user = this.authService.getCurrentUser();
-    if (!user) {
-      throw new Error("User is not logged in.");
-    }
-    const token = await this.authService.getUserToken();
-
-    const authLink = new ApolloLink((operation, forward) => {
-      // Use the setContext method to set the HTTP headers.
-      operation.setContext({
-        headers: {
-          authorization: token ? `Bearer ${token}` : "",
-        },
-      });
-
-      // Call the next link in the middleware chain.
-      return forward(operation);
-    });
-    this.client.setLink(authLink.concat(this.httpLink));
-
-    return user;
   }
 
   public async validateUserId(userId: string): Promise<{ displayName: string; connectCode: string }> {
@@ -89,7 +102,10 @@ class SlippiBackendClient implements SlippiBackendService {
   }
 
   public async fetchPlayKey(): Promise<PlayKey | null> {
-    const user = await this._refreshAuthToken();
+    const user = this.authService.getCurrentUser();
+    if (!user) {
+      throw new Error("User is not logged in");
+    }
 
     const res = await this.client.query({
       query: QUERY_GET_USER_KEY,
@@ -132,7 +148,10 @@ class SlippiBackendClient implements SlippiBackendService {
   }
 
   public async changeDisplayName(name: string) {
-    const user = await this._refreshAuthToken();
+    const user = this.authService.getCurrentUser();
+    if (!user) {
+      throw new Error("User is not logged in");
+    }
 
     const res = await this.client.mutate({
       mutation: MUTATION_RENAME_USER,
@@ -149,8 +168,6 @@ class SlippiBackendClient implements SlippiBackendService {
   }
 
   public async initializeNetplay(codeStart: string): Promise<void> {
-    await this._refreshAuthToken();
-
     const res = await this.client.mutate({ mutation: MUTATION_INIT_NETPLAY, variables: { codeStart } });
     handleErrors(res.errors);
   }

--- a/src/renderer/services/slippi/slippi.service.ts
+++ b/src/renderer/services/slippi/slippi.service.ts
@@ -36,6 +36,10 @@ class SlippiBackendClient implements SlippiBackendService {
     private readonly dolphinService: DolphinService,
     clientVersion?: string,
   ) {
+    this.client = this._createApolloClient(clientVersion);
+  }
+
+  private _createApolloClient(clientVersion?: string) {
     const httpLink = new HttpLink({ uri: SLIPPI_BACKEND_URL });
     const authLink = setContext(async () => {
       // The firebase ID token expires after 1 hour so we will update the header on all actions
@@ -70,7 +74,7 @@ class SlippiBackendClient implements SlippiBackendService {
     });
 
     const apolloLink = ApolloLink.from([authLink, errorLink, retryLink, httpLink]);
-    this.client = new ApolloClient({
+    return new ApolloClient({
       link: apolloLink,
       cache: new InMemoryCache(),
       name: "slippi-launcher",


### PR DESCRIPTION
retryLink is fairly straightforward so I won't explain it.

errorLink gives us some more context about failures, but throwing in that function causes really weird experiences. I can look into it further, but I'm not sure if we will gain much by throwing in there.

`setContext` is the interesting link, it essentially replaces the old `_refreshAuthToken` by handling the authn at the time of request rather than manually before a request.
Docs (it is short, I promise): https://www.apollographql.com/docs/react/api/link/apollo-link-context/

We can then combine all these links together and the apollo client will use them when necessary.