### PR TITLE
Replace react-toast-notifications with notistack

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "react-query": "^3.12.0",
     "react-router-dom": "^6.2.1",
     "react-timeago": "^5.2.0",
-    "react-toast-notifications": "^2.4.4",
     "react-twitter-embed": "^4.0.4",
     "react-virtualized-auto-sizer": "^1.0.3",
     "react-window": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "lodash": "^4.17.21",
     "medium-json-feed": "^0.0.3",
     "mousetrap": "^1.6.5",
+    "notistack": "^3.0.0-alpha.2",
     "observable-fns": "^0.6.1",
     "os-name": "^4.0.0",
     "react": "^17.0.2",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,10 +2,10 @@ import "./styles/styles.scss";
 
 import { ThemeProvider } from "@emotion/react";
 import { StyledEngineProvider, ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
+import { SnackbarProvider } from "notistack";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
-import { ToastProvider } from "react-toast-notifications";
 
 import { useAppStore } from "@/lib/hooks/useApp";
 
@@ -59,11 +59,19 @@ const AppWithProviders: React.FC = () => {
       <MuiThemeProvider theme={slippiTheme}>
         <ThemeProvider theme={slippiTheme as any}>
           <QueryClientProvider client={queryClient}>
-            <ToastProvider components={{ Toast: CustomToast }} placement="bottom-right">
+            <SnackbarProvider
+              maxSnack={3}
+              preventDuplicate={true}
+              anchorOrigin={{
+                vertical: "bottom",
+                horizontal: "right",
+              }}
+              Components={{ default: CustomToast, success: CustomToast, error: CustomToast, warning: CustomToast }}
+            >
               <Router>
                 <App />
               </Router>
-            </ToastProvider>
+            </SnackbarProvider>
           </QueryClientProvider>
         </ThemeProvider>
       </MuiThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,14 +2,13 @@ import "./styles/styles.scss";
 
 import { ThemeProvider } from "@emotion/react";
 import { StyledEngineProvider, ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
-import { SnackbarProvider } from "notistack";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 
 import { useAppStore } from "@/lib/hooks/useApp";
 
-import { CustomToast } from "./components/CustomToast";
+import { ToastProvider } from "./components/ToastProvider";
 import { useAppListeners } from "./lib/hooks/useAppListeners";
 import { slippiTheme } from "./styles/theme";
 import { LandingView } from "./views/LandingView";
@@ -59,19 +58,11 @@ const AppWithProviders: React.FC = () => {
       <MuiThemeProvider theme={slippiTheme}>
         <ThemeProvider theme={slippiTheme as any}>
           <QueryClientProvider client={queryClient}>
-            <SnackbarProvider
-              maxSnack={3}
-              preventDuplicate={true}
-              anchorOrigin={{
-                vertical: "bottom",
-                horizontal: "right",
-              }}
-              Components={{ default: CustomToast, success: CustomToast, error: CustomToast, warning: CustomToast }}
-            >
+            <ToastProvider>
               <Router>
                 <App />
               </Router>
-            </SnackbarProvider>
+            </ToastProvider>
           </QueryClientProvider>
         </ThemeProvider>
       </MuiThemeProvider>

--- a/src/renderer/components/CustomToast.tsx
+++ b/src/renderer/components/CustomToast.tsx
@@ -1,24 +1,28 @@
-import { css } from "@emotion/react";
 import Alert from "@mui/material/Alert";
-import Collapse from "@mui/material/Collapse";
-import React from "react";
-import type { ToastProps } from "react-toast-notifications";
+import type { CustomContentProps } from "notistack";
+import { SnackbarContent, useSnackbar } from "notistack";
+import { forwardRef, memo } from "react";
 
-// The appearance prop matches one the severity types: 'error' | 'info' | 'success' | 'warning'
-export const CustomToast: React.ComponentType<ToastProps> = ({ appearance, children, onDismiss, transitionState }) => {
+const CustomSnackbarContent = forwardRef<HTMLDivElement, CustomContentProps>((props, forwardedRef) => {
+  const { closeSnackbar } = useSnackbar();
+
+  const { id, message, variant } = props;
+
   return (
-    <Collapse in={transitionState === "entered"} mountOnEnter unmountOnExit>
+    <SnackbarContent ref={forwardedRef}>
       <Alert
         variant="standard"
-        severity={appearance}
-        onClose={() => onDismiss()}
-        css={css`
-          margin-bottom: 5px;
-          max-width: 500px;
-        `}
+        severity={variant === "default" ? "info" : variant}
+        onClose={() => closeSnackbar(id)}
+        sx={{
+          maxWidth: 500,
+          width: "100%",
+        }}
       >
-        {children}
+        {message}
       </Alert>
-    </Collapse>
+    </SnackbarContent>
   );
-};
+});
+
+export const CustomToast = memo(CustomSnackbarContent);

--- a/src/renderer/components/MultiPathInput.tsx
+++ b/src/renderer/components/MultiPathInput.tsx
@@ -4,9 +4,9 @@ import MatCheckbox from "@mui/material/Checkbox";
 import InputBase from "@mui/material/InputBase";
 import type { OpenDialogOptions } from "electron";
 import React, { useState } from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { useSettings } from "@/lib/hooks/useSettings";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 export interface MultiPathInputProps {
   updatePaths: (paths: string[]) => void;
@@ -15,16 +15,12 @@ export interface MultiPathInputProps {
 }
 
 export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePaths, options }) => {
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const rootFolder = useSettings((store) => store.settings.rootSlpPath);
 
   const assertValidPath = (newPath: string): boolean => {
     const addErrorToast = (description: string) => {
-      addToast(description, {
-        appearance: "error",
-        autoDismiss: true,
-        autoDismissTimeout: 5000,
-      });
+      showError(description);
     };
     if (paths.includes(newPath)) {
       addErrorToast("That directory is already included.");

--- a/src/renderer/components/ToastProvider.tsx
+++ b/src/renderer/components/ToastProvider.tsx
@@ -42,6 +42,11 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
         error: CustomToast,
         warning: CustomToast,
       }}
+      TransitionProps={{
+        direction: "up",
+        mountOnEnter: true,
+        unmountOnExit: true,
+      }}
     >
       {children}
     </SnackbarProvider>

--- a/src/renderer/components/ToastProvider.tsx
+++ b/src/renderer/components/ToastProvider.tsx
@@ -1,7 +1,7 @@
 import Alert from "@mui/material/Alert";
 import type { CustomContentProps } from "notistack";
-import { SnackbarContent, useSnackbar } from "notistack";
-import { forwardRef, memo } from "react";
+import { SnackbarContent, SnackbarProvider, useSnackbar } from "notistack";
+import React, { forwardRef, memo } from "react";
 
 const CustomSnackbarContent = forwardRef<HTMLDivElement, CustomContentProps>((props, forwardedRef) => {
   const { closeSnackbar } = useSnackbar();
@@ -25,4 +25,25 @@ const CustomSnackbarContent = forwardRef<HTMLDivElement, CustomContentProps>((pr
   );
 });
 
-export const CustomToast = memo(CustomSnackbarContent);
+const CustomToast = memo(CustomSnackbarContent);
+
+export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <SnackbarProvider
+      maxSnack={3}
+      preventDuplicate={true}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "right",
+      }}
+      Components={{
+        default: CustomToast,
+        success: CustomToast,
+        error: CustomToast,
+        warning: CustomToast,
+      }}
+    >
+      {children}
+    </SnackbarProvider>
+  );
+};

--- a/src/renderer/containers/ActivateOnlineForm.tsx
+++ b/src/renderer/containers/ActivateOnlineForm.tsx
@@ -7,9 +7,9 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
-import { useToasts } from "react-toast-notifications";
 
 import { useAccount, usePlayKey } from "@/lib/hooks/useAccount";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { validateConnectCodeStart } from "@/lib/validate";
 import { useServices } from "@/services";
 
@@ -33,7 +33,7 @@ interface ConnectCodeSetterProps {
 
 const ConnectCodeSetter: React.FC<ConnectCodeSetterProps> = ({ displayName, onSuccess }) => {
   const { slippiBackendService } = useServices();
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const getStartTag = () => {
     const safeName = displayName ?? "";
     const matches = safeName.match(/[a-zA-Z]+/g) || [];
@@ -58,9 +58,7 @@ const ConnectCodeSetter: React.FC<ConnectCodeSetterProps> = ({ displayName, onSu
         },
         (err: Error) => {
           log.error(err);
-          addToast(err.message ?? JSON.stringify(err), {
-            appearance: "error",
-          });
+          showError(err.message ?? JSON.stringify(err));
           setIsLoading(false);
         },
       )

--- a/src/renderer/containers/Console/SavedConnectionItem.tsx
+++ b/src/renderer/containers/Console/SavedConnectionItem.tsx
@@ -12,11 +12,11 @@ import IconButton from "@mui/material/IconButton";
 import type { StoredConnection } from "@settings/types";
 import { ConnectionStatus, Ports } from "@slippi/slippi-js";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 import { lt } from "semver";
 
 import { ExternalLink as A } from "@/components/ExternalLink";
 import { LabelledText } from "@/components/LabelledText";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useServices } from "@/services";
 import { ReactComponent as WiiIcon } from "@/styles/images/wii-icon.svg";
 
@@ -47,7 +47,7 @@ export const SavedConnectionItem: React.FC<SavedConnectionItemProps> = ({
   nintendontVersion,
   latestVersion,
 }) => {
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const { consoleService } = useServices();
   const onConnect = React.useCallback(async () => {
     const conn = connection;
@@ -74,11 +74,9 @@ export const SavedConnectionItem: React.FC<SavedConnectionItemProps> = ({
   }, [consoleService, connection]);
   const onMirror = React.useCallback(() => {
     consoleService.startMirroring(connection.ipAddress).catch((err: any) => {
-      addToast(err.message ?? JSON.stringify(err), {
-        appearance: "error",
-      });
+      showError(err.message ?? JSON.stringify(err));
     });
-  }, [consoleService, connection, addToast]);
+  }, [consoleService, connection, showError]);
   const onDisconnect = () => consoleService.disconnectFromConsole(connection.ipAddress);
   const statusName = status === ConnectionStatus.DISCONNECTED && isAvailable ? "Available" : renderStatusName(status);
   const isConnected = status !== ConnectionStatus.DISCONNECTED;

--- a/src/renderer/containers/Console/index.tsx
+++ b/src/renderer/containers/Console/index.tsx
@@ -4,7 +4,6 @@ import AddIcon from "@mui/icons-material/Add";
 import type { StoredConnection } from "@settings/types";
 import { ConnectionStatus } from "@slippi/slippi-js";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { DualPane } from "@/components/DualPane";
 import { Footer } from "@/components/Footer";
@@ -13,6 +12,7 @@ import type { EditConnectionType } from "@/lib/consoleConnection";
 import { addConsoleConnection, deleteConsoleConnection, editConsoleConnection } from "@/lib/consoleConnection";
 import { useConsoleDiscoveryStore } from "@/lib/hooks/useConsoleDiscovery";
 import { useSettings } from "@/lib/hooks/useSettings";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useServices } from "@/services";
 
 import { AddConnectionDialog } from "./AddConnectionDialog";
@@ -48,7 +48,7 @@ export const Console: React.FC = () => {
     [connectedConsoles],
   );
 
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   React.useEffect(() => {
     // Start scanning for new consoles
@@ -57,14 +57,14 @@ export const Console: React.FC = () => {
       .startDiscovery()
       .then(() => setIsScanning(true))
       .catch((err) => {
-        addToast(err.message ?? JSON.stringify(err), { appearance: "error" });
+        showError(err.message ?? JSON.stringify(err));
       });
 
     // Stop scanning on component unmount
     return () => {
       void consoleService.stopDiscovery();
     };
-  }, [addToast, consoleService]);
+  }, [showError, consoleService]);
 
   const onCancel = () => {
     setModalOpen(false);

--- a/src/renderer/containers/Header/ActivateOnlineDialog.tsx
+++ b/src/renderer/containers/Header/ActivateOnlineDialog.tsx
@@ -5,9 +5,9 @@ import DialogTitle from "@mui/material/DialogTitle";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { usePlayKey } from "@/lib/hooks/useAccount";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 import { ActivateOnlineForm } from "../ActivateOnlineForm";
 
@@ -21,7 +21,7 @@ export const ActivateOnlineDialog: React.FC<ActivateOnlineDialogProps> = ({ open
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const refreshPlayKey = usePlayKey();
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const handleSubmit = () => {
     refreshPlayKey()
@@ -30,7 +30,7 @@ export const ActivateOnlineDialog: React.FC<ActivateOnlineDialogProps> = ({ open
         onSubmit();
       })
       .catch((err) => {
-        addToast(err.message, { apperance: "error" });
+        showError(err.message);
       });
   };
 

--- a/src/renderer/containers/Header/NameChangeDialog.tsx
+++ b/src/renderer/containers/Header/NameChangeDialog.tsx
@@ -3,11 +3,11 @@ import CircularProgress from "@mui/material/CircularProgress";
 import TextField from "@mui/material/TextField";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
-import { useToasts } from "react-toast-notifications";
 
 import { ConfirmationModal } from "@/components/ConfirmationModal";
 import { useAccount } from "@/lib/hooks/useAccount";
 import { useAsync } from "@/lib/hooks/useAsync";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { validateDisplayName } from "@/lib/validate";
 import { useServices } from "@/services";
 
@@ -22,7 +22,7 @@ export const NameChangeDialog: React.FC<{
   const name = watch("displayName");
 
   const setDisplayName = useAccount((store) => store.setDisplayName);
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const submitNameChange = useAsync(async () => {
     try {
@@ -30,7 +30,7 @@ export const NameChangeDialog: React.FC<{
       setDisplayName(name);
     } catch (err: any) {
       console.error(err);
-      addToast(err.message, { appearance: "error" });
+      showError(err.message);
     } finally {
       handleClose();
     }

--- a/src/renderer/containers/Header/index.tsx
+++ b/src/renderer/containers/Header/index.tsx
@@ -9,7 +9,6 @@ import ButtonBase from "@mui/material/ButtonBase";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { PlayIcon } from "@/components/PlayIcon";
 import { useAccount } from "@/lib/hooks/useAccount";
@@ -17,6 +16,7 @@ import { useDolphin } from "@/lib/hooks/useDolphin";
 import { useLoginModal } from "@/lib/hooks/useLoginModal";
 import { useSettings } from "@/lib/hooks/useSettings";
 import { useSettingsModal } from "@/lib/hooks/useSettingsModal";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useServices } from "@/services";
 import slippiLogo from "@/styles/images/slippi-logo.svg";
 import { platformTitleBarStyles } from "@/styles/platformTitleBarStyles";
@@ -48,10 +48,10 @@ export const Header: React.FC<HeaderProps> = ({ menuItems }) => {
   const playKey = useAccount((store) => store.playKey);
   const serverError = useAccount((store) => store.serverError);
   const meleeIsoPath = useSettings((store) => store.settings.isoPath) || undefined;
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const { launchNetplay } = useDolphin();
 
-  const handleError = (err: any) => addToast(err.message ?? JSON.stringify(err), { appearance: "error" });
+  const handleError = React.useCallback((err: any) => showError(err.message ?? JSON.stringify(err)), [showError]);
 
   const onPlay = async (offlineOnly?: boolean) => {
     if (!offlineOnly) {

--- a/src/renderer/containers/QuickStart/ImportDolphinSettingsStep.tsx
+++ b/src/renderer/containers/QuickStart/ImportDolphinSettingsStep.tsx
@@ -6,12 +6,12 @@ import Container from "@mui/material/Container";
 import FormHelperText from "@mui/material/FormHelperText";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
-import { useToasts } from "react-toast-notifications";
 
 import { Checkbox } from "@/components/FormInputs/Checkbox";
 import { PathInput } from "@/components/PathInput";
 import { useDolphin } from "@/lib/hooks/useDolphin";
 import { useDesktopApp } from "@/lib/hooks/useQuickStart";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 import { QuickStartHeader } from "./QuickStartHeader";
 
@@ -26,7 +26,7 @@ type FormValues = {
 export const ImportDolphinSettingsStep: React.FC = () => {
   const setExists = useDesktopApp((store) => store.setExists);
   const desktopAppDolphinPath = useDesktopApp((store) => store.dolphinPath);
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const { importDolphin } = useDolphin();
 
   const migrateDolphin = async (values: FormValues) => {
@@ -59,7 +59,7 @@ export const ImportDolphinSettingsStep: React.FC = () => {
   const migrateNetplay = watch("shouldImportNetplay");
   const migratePlayback = watch("shouldImportPlayback");
 
-  const handleError = (err: any) => addToast(err.message ?? JSON.stringify(err), { appearance: "error" });
+  const handleError = React.useCallback((err: any) => showError(err.message ?? JSON.stringify(err)), [showError]);
 
   const onFormSubmit = handleSubmit((values) => {
     migrateDolphin(values).catch(handleError);

--- a/src/renderer/containers/QuickStart/IsoSelectionStep.tsx
+++ b/src/renderer/containers/QuickStart/IsoSelectionStep.tsx
@@ -9,10 +9,10 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import React, { useCallback } from "react";
 import { useDropzone } from "react-dropzone";
 import { useQuery } from "react-query";
-import { useToasts } from "react-toast-notifications";
 
 import { ConfirmationModal } from "@/components/ConfirmationModal";
 import { useIsoPath } from "@/lib/hooks/useSettings";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { hasBorder } from "@/styles/hasBorder";
 
 import { QuickStartHeader } from "./QuickStartHeader";
@@ -51,7 +51,7 @@ const Container = styled.div`
 `;
 
 export const IsoSelectionStep: React.FC = () => {
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const [tempIsoPath, setTempIsoPath] = React.useState("");
   const validIsoPathQuery = useQuery(["validIsoPathQuery", tempIsoPath], async () => {
     if (!tempIsoPath) {
@@ -75,10 +75,7 @@ export const IsoSelectionStep: React.FC = () => {
 
     const filePath = acceptedFiles[0].path;
     if (filePath.endsWith(".7z")) {
-      addToast("7z files must be uncompressed to be used in Dolphin.", {
-        id: "7z",
-        appearance: "error",
-      });
+      showError("7z files must be uncompressed to be used in Dolphin.");
       return;
     }
 
@@ -98,17 +95,14 @@ export const IsoSelectionStep: React.FC = () => {
   const unknownIso = Boolean(tempIsoPath) && !loading && validIsoPath === IsoValidity.UNKNOWN;
   const handleClose = () => setTempIsoPath("");
   const onConfirm = useCallback(() => {
-    setIsoPath(tempIsoPath).catch((err) => addToast(err.message, { appearance: "error" }));
-  }, [addToast, setIsoPath, tempIsoPath]);
+    setIsoPath(tempIsoPath).catch((err) => showError(err.message));
+  }, [showError, setIsoPath, tempIsoPath]);
 
   React.useEffect(() => {
     if (invalidIso) {
-      addToast("Provided ISO will not work with Slippi Online. Please provide an NTSC 1.02 ISO.", {
-        id: "invalidISO",
-        appearance: "error",
-      });
+      showError("Provided ISO will not work with Slippi Online. Please provide an NTSC 1.02 ISO.");
     }
-  }, [addToast, invalidIso]);
+  }, [showError, invalidIso]);
 
   React.useEffect(() => {
     // Auto-confirm ISO if it's valid

--- a/src/renderer/containers/ReplayBrowser/FilterToolbar.tsx
+++ b/src/renderer/containers/ReplayBrowser/FilterToolbar.tsx
@@ -8,12 +8,12 @@ import InputAdornment from "@mui/material/InputAdornment";
 import InputBase from "@mui/material/InputBase";
 import debounce from "lodash/debounce";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { Button, Checkbox, Dropdown } from "@/components/FormInputs";
 import { useReplayFilter } from "@/lib/hooks/useReplayFilter";
 import { useReplays } from "@/lib/hooks/useReplays";
 import { useSettings } from "@/lib/hooks/useSettings";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { ReplaySortOption, SortDirection } from "@/lib/replayFileSort";
 
 const Outer = styled.div`
@@ -48,13 +48,11 @@ export const FilterToolbar = React.forwardRef<HTMLInputElement, FilterToolbarPro
   const sortDirection = useReplayFilter((store) => store.sortDirection);
   const setSortDirection = useReplayFilter((store) => store.setSortDirection);
   const [searchText, setSearchText] = React.useState(storeSearchText ?? "");
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const refresh = React.useCallback(() => {
-    init(rootSlpPath, extraSlpPaths, true, currentFolder).catch((err) =>
-      addToast(err.message, { appearance: "error" }),
-    );
-  }, [rootSlpPath, extraSlpPaths, init, currentFolder, addToast]);
+    init(rootSlpPath, extraSlpPaths, true, currentFolder).catch((err) => showError(err.message));
+  }, [rootSlpPath, extraSlpPaths, init, currentFolder, showError]);
 
   const debounceChange = debounce((text: string) => {
     setStoreSearchText(text);

--- a/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayBrowser.tsx
@@ -10,7 +10,6 @@ import List from "@mui/material/List";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { DualPane } from "@/components/DualPane";
 import { BasicFooter } from "@/components/Footer";
@@ -21,6 +20,7 @@ import { useDolphin } from "@/lib/hooks/useDolphin";
 import { useReplayBrowserList, useReplayBrowserNavigation } from "@/lib/hooks/useReplayBrowserList";
 import { useReplayFilter } from "@/lib/hooks/useReplayFilter";
 import { useReplays, useReplaySelection } from "@/lib/hooks/useReplays";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { humanReadableBytes } from "@/lib/utils";
 
 import { FileList } from "./FileList";
@@ -46,7 +46,7 @@ export const ReplayBrowser: React.FC = () => {
   const totalBytes = useReplays((store) => store.totalBytes);
   const fileSelection = useReplaySelection();
   const fileErrorCount = useReplays((store) => store.fileErrorCount);
-  const { addToast } = useToasts();
+  const { showError, showSuccess } = useToasts();
 
   const resetFilter = useReplayFilter((store) => store.resetFilter);
   const { files: filteredFiles, hiddenFileCount } = useReplayBrowserList();
@@ -64,7 +64,7 @@ export const ReplayBrowser: React.FC = () => {
 
   const onFolderTreeNodeClick = (fullPath: string) => {
     loadFolder(fullPath).catch((err) => {
-      addToast(`Error loading folder: ${err.message ?? JSON.stringify(err)}`, { appearance: "error" });
+      showError(`Error loading folder: ${err.message ?? JSON.stringify(err)}`);
     });
   };
 
@@ -85,12 +85,12 @@ export const ReplayBrowser: React.FC = () => {
       );
       const errCount = promises.reduce((curr, res) => (res.status === "rejected" ? curr + 1 : curr), 0);
       if (errCount > 0) {
-        addToast(`${errCount} file(s) failed to delete.`, { appearance: "error", autoDismiss: true });
+        showError(`${errCount} file(s) failed to delete.`);
       } else {
-        addToast(`${filePaths.length} file(s) successfully deleted.`, { appearance: "success", autoDismiss: true });
+        showSuccess(`${filePaths.length} file(s) successfully deleted.`);
       }
     },
-    [addToast, removeFiles],
+    [showError, showSuccess, removeFiles],
   );
 
   return (

--- a/src/renderer/containers/Settings/AdvancedAppSettings.tsx
+++ b/src/renderer/containers/Settings/AdvancedAppSettings.tsx
@@ -1,9 +1,9 @@
 import Button from "@mui/material/Button";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { Toggle } from "@/components/FormInputs/Toggle";
 import { useAutoUpdateLauncher } from "@/lib/hooks/useSettings";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 import { SettingItem } from "./SettingItem";
 
@@ -26,16 +26,16 @@ export const AdvancedAppSettings = React.memo(() => {
 });
 
 const ClearTempFilesForm = React.memo(() => {
-  const { addToast } = useToasts();
+  const { showSuccess, showError } = useToasts();
   const onClear = React.useCallback(() => {
     window.electron.common
       .clearTempFolder()
       .then(() => {
-        addToast("Successfully cleared temporary files.", { autoDismiss: true });
+        showSuccess("Successfully cleared temporary files.");
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : JSON.stringify(err);
-        addToast(message, { appearance: "error" });
+        showError(message);
       });
   }, []);
   return (

--- a/src/renderer/containers/Settings/BuildInfo.tsx
+++ b/src/renderer/containers/Settings/BuildInfo.tsx
@@ -1,9 +1,9 @@
 import { css } from "@emotion/react";
 import moment from "moment";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { ExternalLink as A } from "@/components/ExternalLink";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useAdvancedUser } from "@/lib/useAdvancedUser";
 
 const osInfo = window.electron.common.getOsInfoSync();
@@ -23,7 +23,7 @@ export const BuildInfo: React.FC<BuildInfoProps> = ({ className, enableAdvancedU
   const [clickCount, setClickCount] = React.useState(0);
   const isAdvancedUser = useAdvancedUser((store) => store.isAdvancedUser);
   const setIsAdvancedUser = useAdvancedUser((store) => store.setIsAdvancedUser);
-  const { addToast } = useToasts();
+  const { showWarning } = useToasts();
   const handleBuildNumberClick = () => {
     if (!enableAdvancedUserClick) {
       return;
@@ -36,7 +36,7 @@ export const BuildInfo: React.FC<BuildInfoProps> = ({ className, enableAdvancedU
     }
 
     if (!isAdvancedUser) {
-      addToast("I hope you know what you're doing...", { appearance: "warning", autoDismiss: true });
+      showWarning("I hope you know what you're doing...");
     }
 
     setIsAdvancedUser(!isAdvancedUser);

--- a/src/renderer/containers/Settings/SupportBox.tsx
+++ b/src/renderer/containers/Settings/SupportBox.tsx
@@ -6,10 +6,10 @@ import FileCopyIcon from "@mui/icons-material/FileCopy";
 import LiveHelpIcon from "@mui/icons-material/LiveHelp";
 import CircularProgress from "@mui/material/CircularProgress";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { ExternalLink as A } from "@/components/ExternalLink";
 import { Button } from "@/components/FormInputs";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { ReactComponent as DiscordIcon } from "@/styles/images/discord.svg";
 
 const log = window.electron.log;
@@ -17,11 +17,11 @@ const log = window.electron.log;
 export const SupportBox: React.FC<{ className?: string }> = ({ className }) => {
   const [isCopying, setCopying] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const handleError = (err: any) => {
     log.error("Error copying logs", err);
-    addToast(err.message || JSON.stringify(err), { appearance: "error" });
+    showError(err.message || JSON.stringify(err));
   };
 
   const onCopy = async () => {

--- a/src/renderer/containers/SpectatePage/ShareGameplayBlock/index.tsx
+++ b/src/renderer/containers/SpectatePage/ShareGameplayBlock/index.tsx
@@ -1,11 +1,11 @@
 import { Ports } from "@slippi/slippi-js";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { InfoBlock } from "@/components/InfoBlock";
 import { useAccount } from "@/lib/hooks/useAccount";
 import { useBroadcast } from "@/lib/hooks/useBroadcast";
 import { useConsole } from "@/lib/hooks/useConsole";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 import { BroadcastPanel } from "./BroadcastPanel";
 
@@ -22,7 +22,7 @@ export const ShareGameplayBlock: React.FC<{ className?: string }> = ({ className
   const slippiStatus = useConsole((store) => store.slippiConnectionStatus);
   const dolphinStatus = useConsole((store) => store.dolphinConnectionStatus);
   const [start, stop] = useBroadcast();
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   return (
     <InfoBlock title="Share your gameplay" className={className}>
@@ -42,7 +42,7 @@ export const ShareGameplayBlock: React.FC<{ className?: string }> = ({ className
             });
           } catch (err) {
             log.error(err);
-            addToast("Error connecting to Dolphin. Ensure Dolphin is running and try again.", { appearance: "error" });
+            showError("Error connecting to Dolphin. Ensure Dolphin is running and try again.");
           }
         }}
       />

--- a/src/renderer/lib/hooks/useApp.ts
+++ b/src/renderer/lib/hooks/useApp.ts
@@ -1,8 +1,8 @@
-import { useToasts } from "react-toast-notifications";
 import create from "zustand";
 import { combine } from "zustand/middleware";
 
 import { useAccount } from "@/lib/hooks/useAccount";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useServices } from "@/services";
 import type { AuthUser } from "@/services/auth/types";
 
@@ -33,7 +33,7 @@ export const useAppStore = create(
 
 export const useAppInitialization = () => {
   const { authService, slippiBackendService } = useServices();
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const initializing = useAppStore((store) => store.initializing);
   const initialized = useAppStore((store) => store.initialized);
   const setInitializing = useAppStore((store) => store.setInitializing);
@@ -79,11 +79,7 @@ export const useAppInitialization = () => {
 
             const message = `Failed to communicate with Slippi servers. You either have no internet
               connection or Slippi is experiencing some downtime. Playing online may or may not work.`;
-            addToast(message, {
-              id: "server-communication-error",
-              appearance: "error",
-              autoDismiss: false,
-            });
+            showError(message);
           }),
       );
     }

--- a/src/renderer/lib/hooks/useAppListeners.ts
+++ b/src/renderer/lib/hooks/useAppListeners.ts
@@ -2,11 +2,11 @@
 import { IsoValidity } from "@common/types";
 import throttle from "lodash/throttle";
 import React from "react";
-import { useToasts } from "react-toast-notifications";
 
 import { useAppInitialization, useAppStore } from "@/lib/hooks/useApp";
 import { useConsole } from "@/lib/hooks/useConsole";
 import { useReplays } from "@/lib/hooks/useReplays";
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useServices } from "@/services";
 
 import { handleDolphinExitCode } from "../utils";
@@ -194,16 +194,12 @@ export const useAppListeners = () => {
     init(rootSlpPath, extraSlpPaths, true).catch(console.error);
   }, [rootSlpPath, extraSlpPaths, init]);
 
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
   const consoleMirrorErrorHandler = React.useCallback(
     (message: string) => {
-      addToast(message, {
-        id: message,
-        appearance: "error",
-        autoDismiss: true,
-      });
+      showError(message);
     },
-    [addToast],
+    [showError],
   );
   React.useEffect(() => {
     return consoleService.onConsoleMirrorErrorMessage(consoleMirrorErrorHandler);
@@ -229,14 +225,10 @@ export const useAppListeners = () => {
       // Check if it exited cleanly
       const errMsg = handleDolphinExitCode(exitCode);
       if (errMsg) {
-        addToast(errMsg, {
-          id: errMsg,
-          appearance: "error",
-          autoDismiss: false,
-        });
+        showError(errMsg);
       }
     },
-    [addToast, setDolphinOpen],
+    [showError, setDolphinOpen],
   );
   React.useEffect(() => {
     return window.electron.dolphin.onDolphinClosed(dolphinClosedHandler);

--- a/src/renderer/lib/hooks/useBroadcastList.ts
+++ b/src/renderer/lib/hooks/useBroadcastList.ts
@@ -1,9 +1,9 @@
 import type { BroadcasterItem } from "@broadcast/types";
 import throttle from "lodash/throttle";
-import { useToasts } from "react-toast-notifications";
 import create from "zustand";
 import { combine } from "zustand/middleware";
 
+import { useToasts } from "@/lib/hooks/useToasts";
 import { useServices } from "@/services";
 
 export const useBroadcastListStore = create(
@@ -20,7 +20,7 @@ export const useBroadcastListStore = create(
 export const useBroadcastList = () => {
   const { authService, broadcastService } = useServices();
   const items = useBroadcastListStore((store) => store.items);
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const refresh = async () => {
     const authToken = await authService.getUserToken();
@@ -31,11 +31,7 @@ export const useBroadcastList = () => {
   const throttledRefresh = throttle(() => {
     refresh().catch((err) => {
       const errMessage = err.message ?? JSON.stringify(err);
-      addToast(errMessage, {
-        autoDismiss: true,
-        appearance: "error",
-        id: errMessage,
-      });
+      showError(errMessage);
     });
   }, 2000);
 

--- a/src/renderer/lib/hooks/useDolphin.ts
+++ b/src/renderer/lib/hooks/useDolphin.ts
@@ -1,8 +1,9 @@
 import type { ReplayQueueItem } from "@dolphin/types";
 import { DolphinLaunchType } from "@dolphin/types";
-import { useToasts } from "react-toast-notifications";
 import create from "zustand";
 import { combine } from "zustand/middleware";
+
+import { useToasts } from "@/lib/hooks/useToasts";
 
 export const useDolphinStore = create(
   combine(
@@ -23,8 +24,8 @@ export const useDolphinStore = create(
 );
 
 export const useDolphin = () => {
-  const { addToast } = useToasts();
-  const handleError = (err: any) => addToast(err.message ?? JSON.stringify(err), { appearance: "error" });
+  const { showError, showSuccess } = useToasts();
+  const handleError = (err: any) => showError(err.message ?? JSON.stringify(err));
 
   const setDolphinOpen = useDolphinStore((store) => store.setDolphinOpen);
 
@@ -74,7 +75,7 @@ export const useDolphin = () => {
   const importDolphin = async (toImportDolphinPath: string, dolphinType: DolphinLaunchType) => {
     try {
       await window.electron.dolphin.importDolphinSettings({ toImportDolphinPath, dolphinType });
-      addToast(`${dolphinType} Dolphin settings successfully imported`, { appearance: "success" });
+      showSuccess(`${dolphinType} Dolphin settings successfully imported`);
     } catch (err) {
       handleError(err);
     }

--- a/src/renderer/lib/hooks/useFileDrag.ts
+++ b/src/renderer/lib/hooks/useFileDrag.ts
@@ -1,7 +1,7 @@
-import { useToasts } from "react-toast-notifications";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 export const useFileDrag = () => {
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const fileDrag = async (event: React.DragEvent<HTMLDivElement>, filePaths: string[]) => {
     try {
@@ -10,9 +10,7 @@ export const useFileDrag = () => {
         window.electron.common.onDragState(filePaths);
       }
     } catch (err: any) {
-      addToast(err.message ?? JSON.stringify(err), {
-        appearance: "error",
-      });
+      showError(err.message ?? JSON.stringify(err));
     }
   };
 

--- a/src/renderer/lib/hooks/useInstallAppUpdate.ts
+++ b/src/renderer/lib/hooks/useInstallAppUpdate.ts
@@ -1,7 +1,7 @@
-import { useToasts } from "react-toast-notifications";
+import { useToasts } from "@/lib/hooks/useToasts";
 
 export const useInstallAppUpdate = () => {
-  const { addToast } = useToasts();
+  const { showError } = useToasts();
 
   const installAppUpdate = async () => {
     try {
@@ -13,7 +13,7 @@ export const useInstallAppUpdate = () => {
       } else {
         message = JSON.stringify(err);
       }
-      addToast(message, { appearance: "error" });
+      showError(message);
     }
   };
 

--- a/src/renderer/lib/hooks/useToasts.ts
+++ b/src/renderer/lib/hooks/useToasts.ts
@@ -1,0 +1,10 @@
+import { useSnackbar } from "notistack";
+
+export const useToasts = () => {
+  const { enqueueSnackbar } = useSnackbar();
+  return {
+    showError: (message: string) => enqueueSnackbar(message, { variant: "error" }),
+    showSuccess: (message: string) => enqueueSnackbar(message, { variant: "success" }),
+    showWarning: (message: string) => enqueueSnackbar(message, { variant: "warning" }),
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4709,7 +4709,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.1.1:
+clsx@^1.1.0, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -7062,6 +7062,11 @@ globby@^11.0.1, globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+goober@^2.0.33:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.8.tgz#e592c04d093cb38f77b38cfcb012b7811c85765e"
+  integrity sha512-S0C85gCzcfFCMSdjD/CxyQMt1rbf2qEg6hmDzxk2FfD7+7Ogk55m8ZFUMtqNaZM4VVX/qaU9AzSORG+Gf4ZpAQ==
+
 got@^11.7.0:
   version "11.8.2"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
@@ -7217,7 +7222,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9477,6 +9482,15 @@ normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
+notistack@^3.0.0-alpha.2:
+  version "3.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.0-alpha.2.tgz#47fb09fdd21e425a5403fbdc159723bfda27f323"
+  integrity sha512-MojdM5PtM/2SXjB1bU6IGZQMAHtRAB932TzyfBuTKyztO+I47yGBD/2niiAYd2a9IzmC2Qqq0cXIryOuSE8j8w==
+  dependencies:
+    clsx "^1.1.0"
+    goober "^2.0.33"
+    hoist-non-react-statics "^3.3.0"
 
 npm-conf@^1.1.3:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,7 +260,7 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.7":
+"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
   integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
@@ -1364,16 +1364,6 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^10.0.27":
-  version "10.0.29"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
-  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
-  dependencies:
-    "@emotion/sheet" "0.9.4"
-    "@emotion/stylis" "0.8.5"
-    "@emotion/utils" "0.11.3"
-    "@emotion/weak-memoize" "0.2.5"
-
 "@emotion/cache@^11.7.1":
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
@@ -1385,28 +1375,7 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
-"@emotion/core@^10.0.14":
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.3.1.tgz#4021b6d8b33b3304d48b0bb478485e7d7421c69d"
-  integrity sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/css" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
-"@emotion/css@^10.0.27":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
-  integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
-  dependencies:
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/utils" "0.11.3"
-    babel-plugin-emotion "^10.0.27"
-
-"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
+"@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
@@ -1424,11 +1393,6 @@
   integrity sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==
   dependencies:
     "@emotion/memoize" "^0.7.4"
-
-"@emotion/memoize@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
-  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
   version "0.7.5"
@@ -1448,17 +1412,6 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
-  version "0.11.16"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
-  integrity sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==
-  dependencies:
-    "@emotion/hash" "0.8.0"
-    "@emotion/memoize" "0.7.4"
-    "@emotion/unitless" "0.7.5"
-    "@emotion/utils" "0.11.3"
-    csstype "^2.5.7"
-
 "@emotion/serialize@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
@@ -1469,11 +1422,6 @@
     "@emotion/unitless" "^0.7.5"
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
-
-"@emotion/sheet@0.9.4":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
-  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
 
 "@emotion/sheet@^1.1.0":
   version "1.1.0"
@@ -1491,27 +1439,17 @@
     "@emotion/serialize" "^1.0.2"
     "@emotion/utils" "^1.0.0"
 
-"@emotion/stylis@0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
-  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
-
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
+"@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
-
-"@emotion/utils@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
-  integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
 
 "@emotion/utils@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
   integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
-"@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
+"@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
@@ -3955,22 +3893,6 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.27:
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz#a1fe3503cff80abfd0bdda14abd2e8e57a79d17d"
-  integrity sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/hash" "0.8.0"
-    "@emotion/memoize" "0.7.4"
-    "@emotion/serialize" "^0.11.16"
-    babel-plugin-macros "^2.0.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    convert-source-map "^1.5.0"
-    escape-string-regexp "^1.0.5"
-    find-root "^1.1.0"
-    source-map "^0.5.7"
-
 babel-plugin-istanbul@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
@@ -3992,7 +3914,7 @@ babel-plugin-jest-hoist@^27.4.0:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1:
+babel-plugin-macros@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -4024,11 +3946,6 @@ babel-plugin-polyfill-regenerator@^0.3.0:
   integrity sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.0"
-
-babel-plugin-syntax-jsx@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
-  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
@@ -5240,11 +5157,6 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
-
-csstype@^2.5.7:
-  version "2.6.19"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
-  integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
 
 csstype@^3.0.11:
   version "3.0.11"
@@ -10662,15 +10574,7 @@ react-timeago@^5.2.0:
   dependencies:
     eslint "^7.26.0"
 
-react-toast-notifications@^2.4.4:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/react-toast-notifications/-/react-toast-notifications-2.5.1.tgz#30216eedb5608ec69719a818b9a2e09283e90074"
-  integrity sha512-eYuuiSPGLyuMHojRH2U7CbENvFHsvNia39pLM/s10KipIoNs14T7RIJk4aU2N+l++OsSgtJqnFObx9bpwLMU5A==
-  dependencies:
-    "@emotion/core" "^10.0.14"
-    react-transition-group "^4.4.1"
-
-react-transition-group@^4.4.1, react-transition-group@^4.4.2:
+react-transition-group@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
   integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==


### PR DESCRIPTION
This PR replaces the usage of the no-longer-maintained [`react-toast-notifications`](https://www.npmjs.com/package/react-toast-notifications) with the MUI endorsed `notistack`. We need to use the v3.alpha version of [`notistack`](https://github.com/iamhosseindhv/notistack/tree/alpha) since v2 doesn't have an easy way of overwriting the toast style. Honestly not too sure if using an alpha library is better or worse than an unmaintained library. ¯\\\_(ツ)\_/¯

We also introduce our own `useToasts` hook to make future toast library changes simpler. Future toast changes should only need to update the `useToasts.ts` and `ToastProvider.tsx` files instead of all files that emit toasts.