### PR TITLE
Use full screen background image in stats page

### DIFF
--- a/src/renderer/containers/ReplayFileStats/GameProfileHeader.tsx
+++ b/src/renderer/containers/ReplayFileStats/GameProfileHeader.tsx
@@ -115,6 +115,7 @@ export const GameProfileHeader: React.FC<GameProfileHeaderProps> = ({
         display: flex;
         justify-content: space-between;
         align-items: center;
+        border-bottom: solid 3px rgba(255, 255, 255, 0.5);
       `}
     >
       <div

--- a/src/renderer/containers/ReplayFileStats/GameProfileHeader.tsx
+++ b/src/renderer/containers/ReplayFileStats/GameProfileHeader.tsx
@@ -1,4 +1,3 @@
-import { colors } from "@common/colors";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
@@ -21,7 +20,6 @@ import React from "react";
 
 import { extractPlayerNames } from "@/lib/matchNames";
 import { convertFrameCountToDurationString, monthDayHourFormat } from "@/lib/time";
-import { getStageImage } from "@/lib/utils";
 
 import { PlayerInfo } from "./PlayerInfo";
 
@@ -111,9 +109,8 @@ export const GameProfileHeader: React.FC<GameProfileHeaderProps> = ({
   onClose,
 }) => {
   const { metadata, settings } = file;
-  const stageImage = settings.stageId !== null ? getStageImage(settings.stageId) : undefined;
   return (
-    <Header backgroundImage={stageImage}>
+    <Header>
       <div
         css={css`
           display: flex;
@@ -159,21 +156,11 @@ export const GameProfileHeader: React.FC<GameProfileHeaderProps> = ({
   );
 };
 
-const Header = styled.div<{
-  backgroundImage?: any;
-}>`
+const Header = styled.div`
   z-index: 1;
   top: 0;
   width: 100%;
-  border-bottom: solid 2px ${colors.purpleDark};
-  background-size: cover;
-  background-position: center center;
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5) 0 30%, rgba(0, 0, 0, 0.8) 90%)
-    ${(p) =>
-      p.backgroundImage
-        ? `,
-    url("${p.backgroundImage}")`
-        : ""};
+  background-color: rgba(0, 0, 0, 0.5);
 `;
 
 const GameDetails: React.FC<{

--- a/src/renderer/containers/ReplayFileStats/GameProfileHeader.tsx
+++ b/src/renderer/containers/ReplayFileStats/GameProfileHeader.tsx
@@ -110,58 +110,49 @@ export const GameProfileHeader: React.FC<GameProfileHeaderProps> = ({
 }) => {
   const { metadata, settings } = file;
   return (
-    <Header>
+    <div
+      css={css`
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      `}
+    >
       <div
         css={css`
           display: flex;
-          justify-content: space-between;
-          align-items: center;
+          flex-direction: column;
         `}
       >
         <div
           css={css`
             display: flex;
-            flex-direction: column;
+            align-items: center;
           `}
         >
-          <div
-            css={css`
-              display: flex;
-              align-items: center;
-            `}
-          >
-            <div>
-              <Tooltip title="Back to replays">
-                <span>
-                  <IconButton
-                    onClick={onClose}
-                    disabled={disabled}
-                    css={css`
-                      padding: 8px;
-                    `}
-                    size="large"
-                  >
-                    <ArrowBackIcon />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            </div>
-            <PlayerInfoDisplay metadata={metadata} settings={settings} />
+          <div>
+            <Tooltip title="Back to replays">
+              <span>
+                <IconButton
+                  onClick={onClose}
+                  disabled={disabled}
+                  css={css`
+                    padding: 8px;
+                  `}
+                  size="large"
+                >
+                  <ArrowBackIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
           </div>
-          <GameDetails file={file} stats={stats} />
+          <PlayerInfoDisplay metadata={metadata} settings={settings} />
         </div>
-        <Controls disabled={disabled} index={index} total={total} onNext={onNext} onPrev={onPrev} onPlay={onPlay} />
+        <GameDetails file={file} stats={stats} />
       </div>
-    </Header>
+      <Controls disabled={disabled} index={index} total={total} onNext={onNext} onPrev={onPrev} onPlay={onPlay} />
+    </div>
   );
 };
-
-const Header = styled.div`
-  z-index: 1;
-  top: 0;
-  width: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-`;
 
 const GameDetails: React.FC<{
   file: FileResult;

--- a/src/renderer/containers/ReplayFileStats/TableStyles.tsx
+++ b/src/renderer/containers/ReplayFileStats/TableStyles.tsx
@@ -1,19 +1,29 @@
+import { colors } from "@common/colors";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Paper from "@mui/material/Paper";
+import { alpha } from "@mui/material/styles";
 import React from "react";
 
 export const Table: React.FC = (props) => {
   return (
-    <Paper component="table" style={{ borderCollapse: "collapse", height: "fit-content" }}>
+    <Paper
+      component="table"
+      style={{
+        borderCollapse: "collapse",
+        height: "fit-content",
+        borderRadius: 4,
+        border: "none",
+        backgroundColor: alpha(colors.purpleDark, 0.9),
+      }}
+    >
       {props.children}
     </Paper>
   );
 };
 
 export const TableHeaderCell = styled.td`
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  border-style: none solid;
+  border: none;
   background-color: rgba(255, 255, 255, 0.2);
   height: 40px;
   text-align: left;
@@ -22,21 +32,22 @@ export const TableHeaderCell = styled.td`
 `;
 
 export const TableSubHeaderCell = styled.td`
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  border-style: none solid;
+  border: none;
   background-color: rgba(255, 255, 255, 0.1);
   color: rgba(255, 255, 255, 0.8);
   height: 25px;
   font-size: 14px;
   font-weight: 500;
   padding: 5px 10px;
+  &:not(:first-of-type) {
+    border-left: solid 2px rgba(255, 255, 255, 0.1);
+  }
 `;
 
 export const TableCell = styled.td<{
   highlight?: boolean;
 }>`
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  border-style: none solid;
+  border: none;
   color: rgba(255, 255, 255, 0.6);
   padding: 10px;
   font-size: 16px;
@@ -46,9 +57,13 @@ export const TableCell = styled.td<{
       font-weight: 500;
       color: #ffe21f;
     `};
+  &:not(:first-of-type) {
+    border-left: solid 2px rgba(255, 255, 255, 0.1);
+  }
 `;
 
 export const TableRow = styled.tr`
+  border: none;
   &:nth-of-type(even) {
     background-color: rgba(255, 255, 255, 0.05);
   }

--- a/src/renderer/containers/ReplayFileStats/index.tsx
+++ b/src/renderer/containers/ReplayFileStats/index.tsx
@@ -16,17 +16,24 @@ import { BasicFooter } from "@/components/Footer";
 import { LoadingScreen } from "@/components/LoadingScreen";
 import { IconMessage } from "@/components/Message";
 import { useMousetrap } from "@/lib/hooks/useMousetrap";
+import { getStageImage } from "@/lib/utils";
 import { withFont } from "@/styles/withFont";
 
 import { GameProfile } from "./GameProfile";
 import { GameProfileHeader } from "./GameProfileHeader";
 
-const Outer = styled.div`
+const Outer = styled.div<{
+  backgroundImage?: any;
+}>`
   position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  background-size: cover;
+  background-position: center center;
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8) 0 100%),
+    ${(p) => (p.backgroundImage ? `url("${p.backgroundImage}")` : "")};
 `;
 
 const Content = styled.div`
@@ -104,8 +111,11 @@ export const ReplayFileStats: React.FC<ReplayFileStatsProps> = (props) => {
     return <LoadingScreen message="Loading..." />;
   }
 
+  const { settings } = file;
+  const stageImage = settings.stageId !== null ? getStageImage(settings.stageId) : undefined;
+
   return (
-    <Outer>
+    <Outer backgroundImage={stageImage}>
       <GameProfileHeader
         {...props}
         file={file}

--- a/src/renderer/containers/ReplayFileStats/index.tsx
+++ b/src/renderer/containers/ReplayFileStats/index.tsx
@@ -30,10 +30,19 @@ const Outer = styled.div<{
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background-size: cover;
-  background-position: center center;
-  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.8) 0 100%),
-    ${(p) => (p.backgroundImage ? `url("${p.backgroundImage}")` : "")};
+  &::before {
+    z-index: -1;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    content: "";
+    background-size: cover;
+    background-position: center center;
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.6) 0 100%),
+      ${(p) => (p.backgroundImage ? `url("${p.backgroundImage}")` : "")};
+    box-shadow: inset 0 0 2000px rgba(255, 255, 255, 0.2);
+    filter: blur(10px);
+  }
 `;
 
 const Content = styled.div`


### PR DESCRIPTION
### Description

This PR makes the background stage image occupy the entire stats page. AKA it makes the stats page purty.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/8384734/159276383-4624a940-e47f-44f3-8532-89d168d78c70.png)


#### After
![image](https://user-images.githubusercontent.com/8384734/159422712-eff0c913-1a03-4e40-8261-b7afdf599640.png)
