### PR TITLE
Only spawn workers when needed

### DIFF
--- a/src/broadcast/broadcast.worker.interface.ts
+++ b/src/broadcast/broadcast.worker.interface.ts
@@ -13,51 +13,58 @@ import {
 const log = electronLog.scope("broadcast/broadcast.worker.interface");
 const broadcastLog = electronLog.scope("broadcastManager");
 
-export const broadcastWorker: Promise<Thread & BroadcastWorkerMethods> = new Promise((resolve, reject) => {
+export type BroadcastWorker = {
+  worker: Thread & BroadcastWorkerMethods;
+  terminate: () => Promise<void>;
+};
+
+export const createBroadcastWorker = async (): Promise<BroadcastWorker> => {
   log.debug("broadcast: Spawning worker");
 
-  spawn<BroadcastWorkerSpec>(new Worker("./broadcast.worker"), { timeout: 30000 })
-    .then((worker) => {
-      worker.getDolphinStatusObservable().subscribe(({ status }) => {
-        ipc_dolphinStatusChangedEvent.main!.trigger({ status }).catch(broadcastLog.error);
-      });
-      worker.getSlippiStatusObservable().subscribe(({ status }) => {
-        ipc_slippiStatusChangedEvent.main!.trigger({ status }).catch(broadcastLog.error);
-      });
-      worker.getLogObservable().subscribe((logMessage) => {
-        broadcastLog.info(logMessage);
-      });
-      worker.getErrorObservable().subscribe((err) => {
-        broadcastLog.error(err);
-        const errorMessage = err instanceof Error ? err.message : err;
-        ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(broadcastLog.error);
-      });
-      worker.getReconnectObservable().subscribe(({ config }) => {
-        ipc_broadcastReconnectEvent.main!.trigger({ config }).catch(broadcastLog.error);
-      });
-
-      log.debug("broadcast: Spawning worker: Done");
-
-      async function terminateWorker() {
-        log.debug("broadcast: Terminating worker");
-        try {
-          await worker.destroyWorker();
-        } finally {
-          await Thread.terminate(worker);
-        }
-      }
-
-      app.on("quit", terminateWorker);
-
-      // Thread.events(worker).subscribe((evt) => {
-      //   log.debug("replayBrowser: Worker event:", evt);
-      //   // TODO: Respawn on worker exit?
-      // });
-
-      resolve(worker);
-    })
-    .catch((err) => {
-      log.error(err);
-      reject(err);
+  try {
+    const worker = await spawn<BroadcastWorkerSpec>(new Worker("./broadcast.worker"), { timeout: 30000 });
+    worker.getDolphinStatusObservable().subscribe(({ status }) => {
+      ipc_dolphinStatusChangedEvent.main!.trigger({ status }).catch(broadcastLog.error);
     });
-});
+    worker.getSlippiStatusObservable().subscribe(({ status }) => {
+      ipc_slippiStatusChangedEvent.main!.trigger({ status }).catch(broadcastLog.error);
+    });
+    worker.getLogObservable().subscribe((logMessage) => {
+      broadcastLog.info(logMessage);
+    });
+    worker.getErrorObservable().subscribe((err) => {
+      broadcastLog.error(err);
+      const errorMessage = err instanceof Error ? err.message : err;
+      ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(broadcastLog.error);
+    });
+    worker.getReconnectObservable().subscribe(({ config }) => {
+      ipc_broadcastReconnectEvent.main!.trigger({ config }).catch(broadcastLog.error);
+    });
+
+    log.debug("broadcast: Spawning worker: Done");
+
+    const terminateWorker = async () => {
+      log.debug("broadcast: Terminating worker");
+      try {
+        await worker.dispose();
+      } finally {
+        await Thread.terminate(worker);
+      }
+    };
+
+    app.on("quit", terminateWorker);
+
+    // Thread.events(worker).subscribe((evt) => {
+    //   log.debug("replayBrowser: Worker event:", evt);
+    //   // TODO: Respawn on worker exit?
+    // });
+
+    return {
+      worker,
+      terminate: terminateWorker,
+    };
+  } catch (err) {
+    log.error(err);
+    throw err;
+  }
+};

--- a/src/broadcast/broadcast.worker.interface.ts
+++ b/src/broadcast/broadcast.worker.interface.ts
@@ -18,10 +18,9 @@ export type BroadcastWorker = RegisteredWorker<BroadcastWorkerSpec>;
 export const createBroadcastWorker = async (): Promise<BroadcastWorker> => {
   log.debug("broadcast: Spawning worker");
 
-  const broadcastWorker = await registerWorker<BroadcastWorkerSpec>(new Worker("./broadcast.worker"));
+  const worker = await registerWorker<BroadcastWorkerSpec>(new Worker("./broadcast.worker"));
   log.debug("broadcast: Spawning worker: Done");
 
-  const { worker } = broadcastWorker;
   worker.getDolphinStatusObservable().subscribe(({ status }) => {
     ipc_dolphinStatusChangedEvent.main!.trigger({ status }).catch(log.error);
   });
@@ -39,5 +38,5 @@ export const createBroadcastWorker = async (): Promise<BroadcastWorker> => {
   worker.getReconnectObservable().subscribe(({ config }) => {
     ipc_broadcastReconnectEvent.main!.trigger({ config }).catch(log.error);
   });
-  return broadcastWorker;
+  return worker;
 };

--- a/src/broadcast/broadcast.worker.interface.ts
+++ b/src/broadcast/broadcast.worker.interface.ts
@@ -1,8 +1,9 @@
-import { app } from "electron";
 import electronLog from "electron-log";
-import { spawn, Thread, Worker } from "threads";
+import { Worker } from "threads";
+import type { RegisteredWorker } from "utils/registerWorker";
+import { registerWorker } from "utils/registerWorker";
 
-import type { Methods as BroadcastWorkerMethods, WorkerSpec as BroadcastWorkerSpec } from "./broadcast.worker";
+import type { WorkerSpec as BroadcastWorkerSpec } from "./broadcast.worker";
 import {
   ipc_broadcastErrorOccurredEvent,
   ipc_broadcastReconnectEvent,
@@ -10,61 +11,33 @@ import {
   ipc_slippiStatusChangedEvent,
 } from "./ipc";
 
-const log = electronLog.scope("broadcast/broadcast.worker.interface");
-const broadcastLog = electronLog.scope("broadcastManager");
+const log = electronLog.scope("broadcast.worker");
 
-export type BroadcastWorker = {
-  worker: Thread & BroadcastWorkerMethods;
-  terminate: () => Promise<void>;
-};
+export type BroadcastWorker = RegisteredWorker<BroadcastWorkerSpec>;
 
 export const createBroadcastWorker = async (): Promise<BroadcastWorker> => {
   log.debug("broadcast: Spawning worker");
 
-  try {
-    const worker = await spawn<BroadcastWorkerSpec>(new Worker("./broadcast.worker"), { timeout: 30000 });
-    worker.getDolphinStatusObservable().subscribe(({ status }) => {
-      ipc_dolphinStatusChangedEvent.main!.trigger({ status }).catch(broadcastLog.error);
-    });
-    worker.getSlippiStatusObservable().subscribe(({ status }) => {
-      ipc_slippiStatusChangedEvent.main!.trigger({ status }).catch(broadcastLog.error);
-    });
-    worker.getLogObservable().subscribe((logMessage) => {
-      broadcastLog.info(logMessage);
-    });
-    worker.getErrorObservable().subscribe((err) => {
-      broadcastLog.error(err);
-      const errorMessage = err instanceof Error ? err.message : err;
-      ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(broadcastLog.error);
-    });
-    worker.getReconnectObservable().subscribe(({ config }) => {
-      ipc_broadcastReconnectEvent.main!.trigger({ config }).catch(broadcastLog.error);
-    });
+  const broadcastWorker = await registerWorker<BroadcastWorkerSpec>(new Worker("./broadcast.worker"));
+  log.debug("broadcast: Spawning worker: Done");
 
-    log.debug("broadcast: Spawning worker: Done");
-
-    const terminateWorker = async () => {
-      log.debug("broadcast: Terminating worker");
-      try {
-        await worker.dispose();
-      } finally {
-        await Thread.terminate(worker);
-      }
-    };
-
-    app.on("quit", terminateWorker);
-
-    // Thread.events(worker).subscribe((evt) => {
-    //   log.debug("replayBrowser: Worker event:", evt);
-    //   // TODO: Respawn on worker exit?
-    // });
-
-    return {
-      worker,
-      terminate: terminateWorker,
-    };
-  } catch (err) {
+  const { worker } = broadcastWorker;
+  worker.getDolphinStatusObservable().subscribe(({ status }) => {
+    ipc_dolphinStatusChangedEvent.main!.trigger({ status }).catch(log.error);
+  });
+  worker.getSlippiStatusObservable().subscribe(({ status }) => {
+    ipc_slippiStatusChangedEvent.main!.trigger({ status }).catch(log.error);
+  });
+  worker.getLogObservable().subscribe((logMessage) => {
+    log.info(logMessage);
+  });
+  worker.getErrorObservable().subscribe((err) => {
     log.error(err);
-    throw err;
-  }
+    const errorMessage = err instanceof Error ? err.message : err;
+    ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(log.error);
+  });
+  worker.getReconnectObservable().subscribe(({ config }) => {
+    ipc_broadcastReconnectEvent.main!.trigger({ config }).catch(log.error);
+  });
+  return broadcastWorker;
 };

--- a/src/broadcast/broadcast.worker.interface.ts
+++ b/src/broadcast/broadcast.worker.interface.ts
@@ -15,7 +15,7 @@ const log = electronLog.scope("broadcast.worker");
 
 export type BroadcastWorker = RegisteredWorker<BroadcastWorkerSpec>;
 
-export const createBroadcastWorker = async (): Promise<BroadcastWorker> => {
+export async function createBroadcastWorker(): Promise<BroadcastWorker> {
   log.debug("broadcast: Spawning worker");
 
   const worker = await registerWorker<BroadcastWorkerSpec>(new Worker("./broadcast.worker"));
@@ -39,4 +39,4 @@ export const createBroadcastWorker = async (): Promise<BroadcastWorker> => {
     ipc_broadcastReconnectEvent.main!.trigger({ config }).catch(log.error);
   });
   return worker;
-};
+}

--- a/src/broadcast/broadcast.worker.ts
+++ b/src/broadcast/broadcast.worker.ts
@@ -12,7 +12,7 @@ import type { StartBroadcastConfig } from "./types";
 import { BroadcastEvent } from "./types";
 
 export interface Methods {
-  destroyWorker: () => Promise<void>;
+  dispose: () => Promise<void>;
   startBroadcast(config: StartBroadcastConfig): Promise<void>;
   stopBroadcast(): Promise<void>;
   getLogObservable(): Observable<string>;
@@ -49,8 +49,15 @@ broadcastManager.on(BroadcastEvent.RECONNECT, (config: StartBroadcastConfig) => 
 });
 
 const methods: WorkerSpec = {
-  async destroyWorker(): Promise<void> {
+  async dispose(): Promise<void> {
     // Clean up worker
+    logSubject.complete();
+    errorSubject.complete();
+    slippiStatusSubject.complete();
+    dolphinStatusSubject.complete();
+    reconnectSubject.complete();
+
+    broadcastManager.removeAllListeners();
   },
   async startBroadcast(config: StartBroadcastConfig): Promise<void> {
     await broadcastManager.start(config);

--- a/src/broadcast/broadcast.worker.ts
+++ b/src/broadcast/broadcast.worker.ts
@@ -11,7 +11,7 @@ import { BroadcastManager } from "./broadcastManager";
 import type { StartBroadcastConfig } from "./types";
 import { BroadcastEvent } from "./types";
 
-export interface Methods {
+interface Methods {
   dispose: () => Promise<void>;
   startBroadcast(config: StartBroadcastConfig): Promise<void>;
   stopBroadcast(): Promise<void>;

--- a/src/broadcast/install.ts
+++ b/src/broadcast/install.ts
@@ -8,8 +8,8 @@ import type { SpectateWorker } from "./spectate.worker.interface";
 import { createSpectateWorker } from "./spectate.worker.interface";
 
 export default function installBroadcastIpc() {
-  let spectateWorker: SpectateWorker | null = null;
-  let broadcastWorker: BroadcastWorker | null = null;
+  let spectateWorker: SpectateWorker | undefined;
+  let broadcastWorker: BroadcastWorker | undefined;
 
   ipc_refreshBroadcastList.main!.handle(async ({ authToken }) => {
     if (!spectateWorker) {

--- a/src/broadcast/install.ts
+++ b/src/broadcast/install.ts
@@ -15,7 +15,7 @@ export default function installBroadcastIpc() {
     if (!spectateWorker) {
       spectateWorker = await createSpectateWorker(dolphinManager);
     }
-    await spectateWorker.worker.refreshBroadcastList(authToken);
+    await spectateWorker.refreshBroadcastList(authToken);
     return { success: true };
   });
 
@@ -24,7 +24,7 @@ export default function installBroadcastIpc() {
       throw new Error("Could not watch broadcast. Try refreshing the broadcast list and try again.");
     }
     const folderPath = settingsManager.get().settings.spectateSlpPath;
-    await spectateWorker.worker.startSpectate(broadcasterId, folderPath);
+    await spectateWorker.startSpectate(broadcasterId, folderPath);
     return { success: true };
   });
 
@@ -33,7 +33,7 @@ export default function installBroadcastIpc() {
       broadcastWorker = await createBroadcastWorker();
     }
 
-    await broadcastWorker.worker.startBroadcast(config);
+    await broadcastWorker.startBroadcast(config);
     return { success: true };
   });
 
@@ -42,8 +42,7 @@ export default function installBroadcastIpc() {
       throw new Error("Error stopping broadcast. Was the broadcast started to begin with?");
     }
 
-    await broadcastWorker.worker.stopBroadcast();
-    await broadcastWorker.terminate();
+    await broadcastWorker.stopBroadcast();
 
     return { success: true };
   });

--- a/src/broadcast/spectate.worker.interface.ts
+++ b/src/broadcast/spectate.worker.interface.ts
@@ -1,76 +1,50 @@
 import type { DolphinManager } from "@dolphin/manager";
 import type { ReplayCommunication } from "@dolphin/types";
-import { app } from "electron";
 import electronLog from "electron-log";
-import { spawn, Thread, Worker } from "threads";
+import { Worker } from "threads";
+import type { RegisteredWorker } from "utils/registerWorker";
+import { registerWorker } from "utils/registerWorker";
 
 import { ipc_broadcastErrorOccurredEvent, ipc_broadcastListUpdatedEvent, ipc_spectateReconnectEvent } from "./ipc";
-import type { Methods as SpectateWorkerMethods, WorkerSpec as SpectateWorkerSpec } from "./spectate.worker";
+import type { WorkerSpec as SpectateWorkerSpec } from "./spectate.worker";
 import type { BroadcasterItem } from "./types";
 
-const log = electronLog.scope("broadcast/spectate.worker.interface");
-const spectateLog = electronLog.scope("spectateManager");
+const log = electronLog.scope("spectate.worker");
 
-export type SpectateWorker = {
-  worker: Thread & SpectateWorkerMethods;
-  terminate: () => Promise<void>;
-};
+export type SpectateWorker = RegisteredWorker<SpectateWorkerSpec>;
 
 export const createSpectateWorker = async (dolphinManager: DolphinManager): Promise<SpectateWorker> => {
   log.debug("spectate: Spawning worker");
 
-  try {
-    const worker = await spawn<SpectateWorkerSpec>(new Worker("./spectate.worker"), { timeout: 30000 });
-    worker.getBroadcastListObservable().subscribe((data: BroadcasterItem[]) => {
-      ipc_broadcastListUpdatedEvent.main!.trigger({ items: data }).catch(spectateLog.error);
-    });
-    worker.getLogObservable().subscribe((logMessage) => {
-      spectateLog.info(logMessage);
-    });
-    worker.getErrorObservable().subscribe((err) => {
-      spectateLog.error(err);
-      const errorMessage = err instanceof Error ? err.message : err;
-      ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(spectateLog.error);
-    });
-    worker.getSpectateDetailsObservable().subscribe(({ playbackId, filePath }) => {
-      const replayComm: ReplayCommunication = {
-        mode: "mirror",
-        replay: filePath,
-      };
-      dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(spectateLog.error);
-    });
-    worker.getReconnectObservable().subscribe(() => {
-      ipc_spectateReconnectEvent.main!.trigger({}).catch(spectateLog.error);
-    });
+  const spectateWorker = await registerWorker<SpectateWorkerSpec>(new Worker("./spectate.worker"));
+  log.debug("spectate: Spawning worker: Done");
 
-    dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
-      worker.dolphinClosed(playbackId).catch(spectateLog.error);
-    });
-
-    log.debug("spectate: Spawning worker: Done");
-
-    const terminateWorker = async () => {
-      log.debug("spectate: Terminating worker");
-      try {
-        await worker.dispose();
-      } finally {
-        await Thread.terminate(worker);
-      }
-    };
-
-    app.on("quit", terminateWorker);
-
-    // Thread.events(worker).subscribe((evt) => {
-    //   log.debug("replayBrowser: Worker event:", evt);
-    //   // TODO: Respawn on worker exit?
-    // });
-
-    return {
-      worker,
-      terminate: terminateWorker,
-    };
-  } catch (err) {
+  const { worker } = spectateWorker;
+  worker.getBroadcastListObservable().subscribe((data: BroadcasterItem[]) => {
+    ipc_broadcastListUpdatedEvent.main!.trigger({ items: data }).catch(log.error);
+  });
+  worker.getLogObservable().subscribe((logMessage) => {
+    log.info(logMessage);
+  });
+  worker.getErrorObservable().subscribe((err) => {
     log.error(err);
-    throw err;
-  }
+    const errorMessage = err instanceof Error ? err.message : err;
+    ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(log.error);
+  });
+  worker.getSpectateDetailsObservable().subscribe(({ playbackId, filePath }) => {
+    const replayComm: ReplayCommunication = {
+      mode: "mirror",
+      replay: filePath,
+    };
+    dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(log.error);
+  });
+  worker.getReconnectObservable().subscribe(() => {
+    ipc_spectateReconnectEvent.main!.trigger({}).catch(log.error);
+  });
+
+  dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
+    worker.dolphinClosed(playbackId).catch(log.error);
+  });
+
+  return spectateWorker;
 };

--- a/src/broadcast/spectate.worker.interface.ts
+++ b/src/broadcast/spectate.worker.interface.ts
@@ -16,10 +16,9 @@ export type SpectateWorker = RegisteredWorker<SpectateWorkerSpec>;
 export const createSpectateWorker = async (dolphinManager: DolphinManager): Promise<SpectateWorker> => {
   log.debug("spectate: Spawning worker");
 
-  const spectateWorker = await registerWorker<SpectateWorkerSpec>(new Worker("./spectate.worker"));
+  const worker = await registerWorker<SpectateWorkerSpec>(new Worker("./spectate.worker"));
   log.debug("spectate: Spawning worker: Done");
 
-  const { worker } = spectateWorker;
   worker.getBroadcastListObservable().subscribe((data: BroadcasterItem[]) => {
     ipc_broadcastListUpdatedEvent.main!.trigger({ items: data }).catch(log.error);
   });
@@ -46,5 +45,5 @@ export const createSpectateWorker = async (dolphinManager: DolphinManager): Prom
     worker.dolphinClosed(playbackId).catch(log.error);
   });
 
-  return spectateWorker;
+  return worker;
 };

--- a/src/broadcast/spectate.worker.interface.ts
+++ b/src/broadcast/spectate.worker.interface.ts
@@ -1,4 +1,4 @@
-import { dolphinManager } from "@dolphin/manager";
+import type { DolphinManager } from "@dolphin/manager";
 import type { ReplayCommunication } from "@dolphin/types";
 import { app } from "electron";
 import electronLog from "electron-log";
@@ -11,59 +11,66 @@ import type { BroadcasterItem } from "./types";
 const log = electronLog.scope("broadcast/spectate.worker.interface");
 const spectateLog = electronLog.scope("spectateManager");
 
-export const spectateWorker: Promise<Thread & SpectateWorkerMethods> = new Promise((resolve, reject) => {
+export type SpectateWorker = {
+  worker: Thread & SpectateWorkerMethods;
+  terminate: () => Promise<void>;
+};
+
+export const createSpectateWorker = async (dolphinManager: DolphinManager): Promise<SpectateWorker> => {
   log.debug("spectate: Spawning worker");
 
-  spawn<SpectateWorkerSpec>(new Worker("./spectate.worker"), { timeout: 30000 })
-    .then((worker) => {
-      worker.getBroadcastListObservable().subscribe((data: BroadcasterItem[]) => {
-        ipc_broadcastListUpdatedEvent.main!.trigger({ items: data }).catch(spectateLog.error);
-      });
-      worker.getLogObservable().subscribe((logMessage) => {
-        spectateLog.info(logMessage);
-      });
-      worker.getErrorObservable().subscribe((err) => {
-        spectateLog.error(err);
-        const errorMessage = err instanceof Error ? err.message : err;
-        ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(spectateLog.error);
-      });
-      worker.getSpectateDetailsObservable().subscribe(({ playbackId, filePath }) => {
-        const replayComm: ReplayCommunication = {
-          mode: "mirror",
-          replay: filePath,
-        };
-        dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(spectateLog.error);
-      });
-      worker.getReconnectObservable().subscribe(() => {
-        ipc_spectateReconnectEvent.main!.trigger({}).catch(spectateLog.error);
-      });
-
-      dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
-        worker.dolphinClosed(playbackId).catch(spectateLog.error);
-      });
-
-      log.debug("spectate: Spawning worker: Done");
-
-      async function terminateWorker() {
-        log.debug("spectate: Terminating worker");
-        try {
-          await worker.destroyWorker();
-        } finally {
-          await Thread.terminate(worker);
-        }
-      }
-
-      app.on("quit", terminateWorker);
-
-      // Thread.events(worker).subscribe((evt) => {
-      //   log.debug("replayBrowser: Worker event:", evt);
-      //   // TODO: Respawn on worker exit?
-      // });
-
-      resolve(worker);
-    })
-    .catch((err) => {
-      log.error(err);
-      reject(err);
+  try {
+    const worker = await spawn<SpectateWorkerSpec>(new Worker("./spectate.worker"), { timeout: 30000 });
+    worker.getBroadcastListObservable().subscribe((data: BroadcasterItem[]) => {
+      ipc_broadcastListUpdatedEvent.main!.trigger({ items: data }).catch(spectateLog.error);
     });
-});
+    worker.getLogObservable().subscribe((logMessage) => {
+      spectateLog.info(logMessage);
+    });
+    worker.getErrorObservable().subscribe((err) => {
+      spectateLog.error(err);
+      const errorMessage = err instanceof Error ? err.message : err;
+      ipc_broadcastErrorOccurredEvent.main!.trigger({ errorMessage }).catch(spectateLog.error);
+    });
+    worker.getSpectateDetailsObservable().subscribe(({ playbackId, filePath }) => {
+      const replayComm: ReplayCommunication = {
+        mode: "mirror",
+        replay: filePath,
+      };
+      dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(spectateLog.error);
+    });
+    worker.getReconnectObservable().subscribe(() => {
+      ipc_spectateReconnectEvent.main!.trigger({}).catch(spectateLog.error);
+    });
+
+    dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
+      worker.dolphinClosed(playbackId).catch(spectateLog.error);
+    });
+
+    log.debug("spectate: Spawning worker: Done");
+
+    const terminateWorker = async () => {
+      log.debug("spectate: Terminating worker");
+      try {
+        await worker.dispose();
+      } finally {
+        await Thread.terminate(worker);
+      }
+    };
+
+    app.on("quit", terminateWorker);
+
+    // Thread.events(worker).subscribe((evt) => {
+    //   log.debug("replayBrowser: Worker event:", evt);
+    //   // TODO: Respawn on worker exit?
+    // });
+
+    return {
+      worker,
+      terminate: terminateWorker,
+    };
+  } catch (err) {
+    log.error(err);
+    throw err;
+  }
+};

--- a/src/broadcast/spectate.worker.interface.ts
+++ b/src/broadcast/spectate.worker.interface.ts
@@ -13,7 +13,7 @@ const log = electronLog.scope("spectate.worker");
 
 export type SpectateWorker = RegisteredWorker<SpectateWorkerSpec>;
 
-export const createSpectateWorker = async (dolphinManager: DolphinManager): Promise<SpectateWorker> => {
+export async function createSpectateWorker(dolphinManager: DolphinManager): Promise<SpectateWorker> {
   log.debug("spectate: Spawning worker");
 
   const worker = await registerWorker<SpectateWorkerSpec>(new Worker("./spectate.worker"));
@@ -46,4 +46,4 @@ export const createSpectateWorker = async (dolphinManager: DolphinManager): Prom
   });
 
   return worker;
-};
+}

--- a/src/broadcast/spectate.worker.ts
+++ b/src/broadcast/spectate.worker.ts
@@ -10,7 +10,7 @@ import { SpectateManager } from "./spectateManager";
 import type { BroadcasterItem } from "./types";
 import { SpectateEvent } from "./types";
 
-export interface Methods {
+interface Methods {
   dispose: () => Promise<void>;
   startSpectate(broadcastId: string, targetPath: string): Promise<void>;
   stopSpectate(broadcastId: string): Promise<void>;

--- a/src/broadcast/spectate.worker.ts
+++ b/src/broadcast/spectate.worker.ts
@@ -11,7 +11,7 @@ import type { BroadcasterItem } from "./types";
 import { SpectateEvent } from "./types";
 
 export interface Methods {
-  destroyWorker: () => Promise<void>;
+  dispose: () => Promise<void>;
   startSpectate(broadcastId: string, targetPath: string): Promise<void>;
   stopSpectate(broadcastId: string): Promise<void>;
   dolphinClosed(playbackId: string): Promise<void>;
@@ -55,8 +55,15 @@ spectateManager.on(SpectateEvent.RECONNECT, async () => {
 });
 
 const methods: WorkerSpec = {
-  async destroyWorker(): Promise<void> {
+  async dispose(): Promise<void> {
     // Clean up worker
+    logSubject.complete();
+    errorSubject.complete();
+    broadcastListSubject.complete();
+    spectateDetailsSubject.complete();
+    reconnectSubject.complete();
+
+    spectateManager.removeAllListeners();
   },
   async startSpectate(broadcastId: string, targetPath: string): Promise<void> {
     await spectateManager.watchBroadcast(broadcastId, targetPath);

--- a/src/console/install.ts
+++ b/src/console/install.ts
@@ -12,7 +12,7 @@ import type { MirrorWorker } from "./mirror.worker.interface";
 import { createMirrorWorker } from "./mirror.worker.interface";
 
 export default function installConsoleIpc() {
-  let mirrorWorker: MirrorWorker | null;
+  let mirrorWorker: MirrorWorker | undefined;
 
   ipc_connectToConsoleMirror.main!.handle(async ({ config }) => {
     if (!mirrorWorker) {

--- a/src/console/install.ts
+++ b/src/console/install.ts
@@ -20,7 +20,7 @@ export default function installConsoleIpc() {
       mirrorWorker = await createMirrorWorker(dolphinManager);
     }
 
-    await mirrorWorker.worker.connectToConsole(config);
+    await mirrorWorker.connectToConsole(config);
     return { success: true };
   });
 
@@ -29,11 +29,7 @@ export default function installConsoleIpc() {
       throw new Error("Failed to disconnect from console. Was the console connected to begin with?");
     }
 
-    await mirrorWorker.worker.disconnectFromConsole(ip);
-
-    // Clean up the worker
-    await mirrorWorker.terminate();
-    mirrorWorker = null;
+    await mirrorWorker.disconnectFromConsole(ip);
 
     return { success: true };
   });
@@ -43,7 +39,7 @@ export default function installConsoleIpc() {
       throw new Error("Failed to start mirroring. Is the console connected?");
     }
 
-    await mirrorWorker.worker.startMirroring(ip);
+    await mirrorWorker.startMirroring(ip);
     return { success: true };
   });
 

--- a/src/console/install.ts
+++ b/src/console/install.ts
@@ -1,3 +1,5 @@
+import { dolphinManager } from "@dolphin/manager";
+
 import { connectionScanner } from "./connectionScanner";
 import {
   ipc_connectToConsoleMirror,
@@ -6,24 +8,42 @@ import {
   ipc_startMirroring,
   ipc_stopDiscovery,
 } from "./ipc";
-import { mirrorWorker } from "./mirror.worker.interface";
+import type { MirrorWorker } from "./mirror.worker.interface";
+import { createMirrorWorker } from "./mirror.worker.interface";
 
 export default function installConsoleIpc() {
+  let mirrorWorker: MirrorWorker | null;
+
   ipc_connectToConsoleMirror.main!.handle(async ({ config }) => {
-    const mWorker = await mirrorWorker;
-    await mWorker.connectToConsole(config);
+    if (!mirrorWorker) {
+      // Only initialize the worker when we actually start connecting
+      mirrorWorker = await createMirrorWorker(dolphinManager);
+    }
+
+    await mirrorWorker.worker.connectToConsole(config);
     return { success: true };
   });
 
   ipc_disconnectFromConsoleMirror.main!.handle(async ({ ip }) => {
-    const mWorker = await mirrorWorker;
-    await mWorker.disconnectFromConsole(ip);
+    if (!mirrorWorker) {
+      throw new Error("Failed to disconnect from console. Was the console connected to begin with?");
+    }
+
+    await mirrorWorker.worker.disconnectFromConsole(ip);
+
+    // Clean up the worker
+    await mirrorWorker.terminate();
+    mirrorWorker = null;
+
     return { success: true };
   });
 
   ipc_startMirroring.main!.handle(async ({ ip }) => {
-    const mWorker = await mirrorWorker;
-    await mWorker.startMirroring(ip);
+    if (!mirrorWorker) {
+      throw new Error("Failed to start mirroring. Is the console connected?");
+    }
+
+    await mirrorWorker.worker.startMirroring(ip);
     return { success: true };
   });
 

--- a/src/console/mirror.worker.interface.ts
+++ b/src/console/mirror.worker.interface.ts
@@ -12,7 +12,7 @@ const log = electronLog.scope("mirror.worker");
 
 export type MirrorWorker = RegisteredWorker<MirrorWorkerSpec>;
 
-export const createMirrorWorker = async (dolphinManager: DolphinManager): Promise<MirrorWorker> => {
+export async function createMirrorWorker(dolphinManager: DolphinManager): Promise<MirrorWorker> {
   log.debug("mirror: Spawning worker");
 
   const worker = await registerWorker<MirrorWorkerSpec>(new Worker("./mirror.worker"));
@@ -51,4 +51,4 @@ export const createMirrorWorker = async (dolphinManager: DolphinManager): Promis
   });
 
   return worker;
-};
+}

--- a/src/console/mirror.worker.interface.ts
+++ b/src/console/mirror.worker.interface.ts
@@ -1,75 +1,55 @@
 import type { DolphinManager } from "@dolphin/manager";
 import type { ReplayCommunication } from "@dolphin/types";
-import { app } from "electron";
 import electronLog from "electron-log";
-import { spawn, Thread, Worker } from "threads";
+import { Worker } from "threads";
+import type { RegisteredWorker } from "utils/registerWorker";
+import { registerWorker } from "utils/registerWorker";
 
 import { ipc_consoleMirrorErrorMessageEvent, ipc_consoleMirrorStatusUpdatedEvent } from "./ipc";
-import type { Methods as MirrorWorkerMethods, WorkerSpec as MirrorWorkerSpec } from "./mirror.worker";
+import type { WorkerSpec as MirrorWorkerSpec } from "./mirror.worker";
 
-const log = electronLog.scope("console/workerInterface");
-const mirrorLog = electronLog.scope("mirrorManager");
+const log = electronLog.scope("mirror.worker");
 
-export type MirrorWorker = {
-  worker: Thread & MirrorWorkerMethods;
-  terminate: () => Promise<void>;
-};
+export type MirrorWorker = RegisteredWorker<MirrorWorkerSpec>;
 
 export const createMirrorWorker = async (dolphinManager: DolphinManager): Promise<MirrorWorker> => {
   log.debug("mirror: Spawning worker");
 
-  try {
-    const worker = await spawn<MirrorWorkerSpec>(new Worker("./mirror.worker"), { timeout: 30000 });
-    worker.getLogObservable().subscribe((logMessage) => {
-      mirrorLog.info(logMessage);
-    });
+  const customWorker = await registerWorker<MirrorWorkerSpec>(new Worker("./mirror.worker"));
+  log.debug("mirror: Spawning worker: Done");
 
-    worker.getErrorObservable().subscribe((errorMessage) => {
-      mirrorLog.error(errorMessage);
-      const message =
-        errorMessage instanceof Error
-          ? errorMessage.message
-          : typeof errorMessage === "string"
-          ? errorMessage
-          : JSON.stringify(errorMessage);
-      ipc_consoleMirrorErrorMessageEvent.main!.trigger({ message }).catch(mirrorLog.error);
-    });
+  const { worker } = customWorker;
+  worker.getLogObservable().subscribe((logMessage) => {
+    log.info(logMessage);
+  });
 
-    worker.getMirrorDetailsObservable().subscribe(({ playbackId, filePath, isRealtime }) => {
-      const replayComm: ReplayCommunication = {
-        mode: "mirror",
-        isRealTimeMode: isRealtime,
-        replay: filePath,
-      };
-      dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(mirrorLog.error);
-    });
+  worker.getErrorObservable().subscribe((errorMessage) => {
+    log.error(errorMessage);
+    const message =
+      errorMessage instanceof Error
+        ? errorMessage.message
+        : typeof errorMessage === "string"
+        ? errorMessage
+        : JSON.stringify(errorMessage);
+    ipc_consoleMirrorErrorMessageEvent.main!.trigger({ message }).catch(log.error);
+  });
 
-    worker.getMirrorStatusObservable().subscribe((statusUpdate) => {
-      ipc_consoleMirrorStatusUpdatedEvent.main!.trigger(statusUpdate).catch(mirrorLog.error);
-    });
-
-    dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
-      worker.dolphinClosed(playbackId).catch(mirrorLog.error);
-    });
-
-    log.debug("mirror: Spawning worker: Done");
-
-    const terminateWorker = async () => {
-      log.debug("mirror: Terminating worker");
-      try {
-        await worker.dispose();
-      } finally {
-        await Thread.terminate(worker);
-      }
+  worker.getMirrorDetailsObservable().subscribe(({ playbackId, filePath, isRealtime }) => {
+    const replayComm: ReplayCommunication = {
+      mode: "mirror",
+      isRealTimeMode: isRealtime,
+      replay: filePath,
     };
+    dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(log.error);
+  });
 
-    app.on("quit", terminateWorker);
-    return {
-      worker,
-      terminate: terminateWorker,
-    };
-  } catch (err) {
-    log.error(err);
-    throw err;
-  }
+  worker.getMirrorStatusObservable().subscribe((statusUpdate) => {
+    ipc_consoleMirrorStatusUpdatedEvent.main!.trigger(statusUpdate).catch(log.error);
+  });
+
+  dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
+    worker.dolphinClosed(playbackId).catch(log.error);
+  });
+
+  return customWorker;
 };

--- a/src/console/mirror.worker.interface.ts
+++ b/src/console/mirror.worker.interface.ts
@@ -1,4 +1,4 @@
-import { dolphinManager } from "@dolphin/manager";
+import type { DolphinManager } from "@dolphin/manager";
 import type { ReplayCommunication } from "@dolphin/types";
 import { app } from "electron";
 import electronLog from "electron-log";
@@ -10,63 +10,66 @@ import type { Methods as MirrorWorkerMethods, WorkerSpec as MirrorWorkerSpec } f
 const log = electronLog.scope("console/workerInterface");
 const mirrorLog = electronLog.scope("mirrorManager");
 
-export const mirrorWorker: Promise<Thread & MirrorWorkerMethods> = new Promise((resolve, reject) => {
+export type MirrorWorker = {
+  worker: Thread & MirrorWorkerMethods;
+  terminate: () => Promise<void>;
+};
+
+export const createMirrorWorker = async (dolphinManager: DolphinManager): Promise<MirrorWorker> => {
   log.debug("mirror: Spawning worker");
 
-  spawn<MirrorWorkerSpec>(new Worker("./mirror.worker"), { timeout: 30000 })
-    .then((worker) => {
-      worker.getLogObservable().subscribe((logMessage) => {
-        mirrorLog.info(logMessage);
-      });
-      worker.getErrorObservable().subscribe((errorMessage) => {
-        mirrorLog.error(errorMessage);
-        const message =
-          errorMessage instanceof Error
-            ? errorMessage.message
-            : typeof errorMessage === "string"
-            ? errorMessage
-            : JSON.stringify(errorMessage);
-        ipc_consoleMirrorErrorMessageEvent.main!.trigger({ message }).catch(mirrorLog.error);
-      });
-      worker.getMirrorDetailsObservable().subscribe(({ playbackId, filePath, isRealtime }) => {
-        const replayComm: ReplayCommunication = {
-          mode: "mirror",
-          isRealTimeMode: isRealtime,
-          replay: filePath,
-        };
-        dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(mirrorLog.error);
-      });
-
-      worker.getMirrorStatusObservable().subscribe((statusUpdate) => {
-        ipc_consoleMirrorStatusUpdatedEvent.main!.trigger(statusUpdate).catch(mirrorLog.error);
-      });
-
-      dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
-        worker.dolphinClosed(playbackId).catch(mirrorLog.error);
-      });
-
-      log.debug("mirror: Spawning worker: Done");
-
-      async function terminateWorker() {
-        log.debug("mirror: Terminating worker");
-        try {
-          await worker.destroyWorker();
-        } finally {
-          await Thread.terminate(worker);
-        }
-      }
-
-      app.on("quit", terminateWorker);
-
-      // Thread.events(worker).subscribe((evt) => {
-      //   log.debug("replayBrowser: Worker event:", evt);
-      //   // TODO: Respawn on worker exit?
-      // });
-
-      resolve(worker);
-    })
-    .catch((err) => {
-      log.error(err);
-      reject(err);
+  try {
+    const worker = await spawn<MirrorWorkerSpec>(new Worker("./mirror.worker"), { timeout: 30000 });
+    worker.getLogObservable().subscribe((logMessage) => {
+      mirrorLog.info(logMessage);
     });
-});
+
+    worker.getErrorObservable().subscribe((errorMessage) => {
+      mirrorLog.error(errorMessage);
+      const message =
+        errorMessage instanceof Error
+          ? errorMessage.message
+          : typeof errorMessage === "string"
+          ? errorMessage
+          : JSON.stringify(errorMessage);
+      ipc_consoleMirrorErrorMessageEvent.main!.trigger({ message }).catch(mirrorLog.error);
+    });
+
+    worker.getMirrorDetailsObservable().subscribe(({ playbackId, filePath, isRealtime }) => {
+      const replayComm: ReplayCommunication = {
+        mode: "mirror",
+        isRealTimeMode: isRealtime,
+        replay: filePath,
+      };
+      dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(mirrorLog.error);
+    });
+
+    worker.getMirrorStatusObservable().subscribe((statusUpdate) => {
+      ipc_consoleMirrorStatusUpdatedEvent.main!.trigger(statusUpdate).catch(mirrorLog.error);
+    });
+
+    dolphinManager.on("playback-dolphin-closed", (playbackId: string) => {
+      worker.dolphinClosed(playbackId).catch(mirrorLog.error);
+    });
+
+    log.debug("mirror: Spawning worker: Done");
+
+    const terminateWorker = async () => {
+      log.debug("mirror: Terminating worker");
+      try {
+        await worker.dispose();
+      } finally {
+        await Thread.terminate(worker);
+      }
+    };
+
+    app.on("quit", terminateWorker);
+    return {
+      worker,
+      terminate: terminateWorker,
+    };
+  } catch (err) {
+    log.error(err);
+    throw err;
+  }
+};

--- a/src/console/mirror.worker.interface.ts
+++ b/src/console/mirror.worker.interface.ts
@@ -15,10 +15,9 @@ export type MirrorWorker = RegisteredWorker<MirrorWorkerSpec>;
 export const createMirrorWorker = async (dolphinManager: DolphinManager): Promise<MirrorWorker> => {
   log.debug("mirror: Spawning worker");
 
-  const customWorker = await registerWorker<MirrorWorkerSpec>(new Worker("./mirror.worker"));
+  const worker = await registerWorker<MirrorWorkerSpec>(new Worker("./mirror.worker"));
   log.debug("mirror: Spawning worker: Done");
 
-  const { worker } = customWorker;
   worker.getLogObservable().subscribe((logMessage) => {
     log.info(logMessage);
   });
@@ -51,5 +50,5 @@ export const createMirrorWorker = async (dolphinManager: DolphinManager): Promis
     worker.dolphinClosed(playbackId).catch(log.error);
   });
 
-  return customWorker;
+  return worker;
 };

--- a/src/console/mirror.worker.ts
+++ b/src/console/mirror.worker.ts
@@ -11,7 +11,7 @@ import type { ConsoleMirrorStatusUpdate, MirrorConfig } from "./types";
 import { MirrorEvent } from "./types";
 
 export interface Methods {
-  destroyWorker: () => Promise<void>;
+  dispose: () => Promise<void>;
   connectToConsole(config: MirrorConfig): Promise<void>;
   disconnectFromConsole(ip: string): Promise<void>;
   startMirroring(id: string): Promise<void>;
@@ -52,8 +52,14 @@ mirrorManager.on(
 );
 
 const methods: WorkerSpec = {
-  async destroyWorker(): Promise<void> {
+  async dispose(): Promise<void> {
     // Clean up worker
+    logSubject.complete();
+    errorSubject.complete();
+    mirrorDetailsSubject.complete();
+    mirrorStatusSubject.complete();
+
+    mirrorManager.removeAllListeners();
   },
   async connectToConsole(config: MirrorConfig): Promise<void> {
     await mirrorManager.connect(config);

--- a/src/console/mirror.worker.ts
+++ b/src/console/mirror.worker.ts
@@ -10,7 +10,7 @@ import { MirrorManager } from "./mirrorManager";
 import type { ConsoleMirrorStatusUpdate, MirrorConfig } from "./types";
 import { MirrorEvent } from "./types";
 
-export interface Methods {
+interface Methods {
   dispose: () => Promise<void>;
   connectToConsole(config: MirrorConfig): Promise<void>;
   disconnectFromConsole(ip: string): Promise<void>;

--- a/src/replays/install.ts
+++ b/src/replays/install.ts
@@ -21,7 +21,7 @@ export default function installReplaysIpc() {
   });
 
   ipc_loadReplayFolder.main!.handle(async ({ folderPath }) => {
-    const { worker } = await replayBrowserWorker;
+    const worker = await replayBrowserWorker;
     worker.getProgressObservable().subscribe((progress) => {
       ipc_loadProgressUpdatedEvent.main!.trigger(progress).catch(console.warn);
     });
@@ -30,7 +30,7 @@ export default function installReplaysIpc() {
   });
 
   ipc_calculateGameStats.main!.handle(async ({ filePath }) => {
-    const { worker } = await replayBrowserWorker;
+    const worker = await replayBrowserWorker;
     const result = await worker.calculateGameStats(filePath);
     const fileResult = await worker.loadSingleFile(filePath);
     return { file: fileResult, stats: result };

--- a/src/replays/replays.worker.interface.ts
+++ b/src/replays/replays.worker.interface.ts
@@ -6,33 +6,40 @@ import type { Methods as WorkerMethods, WorkerSpec } from "./replays.worker";
 
 const log = electronLog.scope("replays/workerInterface");
 
-export const worker: Promise<Thread & WorkerMethods> = new Promise((resolve, reject) => {
+export type ReplayWorker = {
+  worker: Thread & WorkerMethods;
+  terminate: () => Promise<void>;
+};
+
+export const createReplayWorker = async (): Promise<ReplayWorker> => {
   log.debug("replayBrowser: Spawning worker");
 
-  spawn<WorkerSpec>(new Worker("./replays.worker"), { timeout: 30000 })
-    .then((worker) => {
-      log.debug("replayBrowser: Spawning worker: Done");
+  try {
+    const worker = await spawn<WorkerSpec>(new Worker("./replays.worker"), { timeout: 30000 });
+    log.debug("replayBrowser: Spawning worker: Done");
 
-      async function terminateWorker() {
-        log.debug("replayBrowser: Terminating worker");
-        try {
-          await worker.destroyWorker();
-        } finally {
-          await Thread.terminate(worker);
-        }
+    const terminateWorker = async () => {
+      log.debug("replayBrowser: Terminating worker");
+      try {
+        await worker.dispose();
+      } finally {
+        await Thread.terminate(worker);
       }
+    };
 
-      app.on("quit", terminateWorker);
+    app.on("quit", terminateWorker);
 
-      // Thread.events(worker).subscribe((evt) => {
-      //   log.debug("replayBrowser: Worker event:", evt);
-      //   // TODO: Respawn on worker exit?
-      // });
+    // Thread.events(worker).subscribe((evt) => {
+    //   log.debug("replayBrowser: Worker event:", evt);
+    //   // TODO: Respawn on worker exit?
+    // });
 
-      resolve(worker);
-    })
-    .catch((err) => {
-      log.error(err);
-      reject(err);
-    });
-});
+    return {
+      worker,
+      terminate: terminateWorker,
+    };
+  } catch (err) {
+    log.error(err);
+    throw err;
+  }
+};

--- a/src/replays/replays.worker.interface.ts
+++ b/src/replays/replays.worker.interface.ts
@@ -9,11 +9,11 @@ export type ReplayWorker = RegisteredWorker<WorkerSpec>;
 
 const log = electronLog.scope("replays.worker");
 
-export const createReplayWorker = async () => {
+export async function createReplayWorker(): Promise<ReplayWorker> {
   log.debug("replays: Spawning worker");
 
   const replayWorker = await registerWorker<WorkerSpec>(new Worker("./replays.worker"));
   log.debug("replays: Spawning worker: Done");
 
   return replayWorker;
-};
+}

--- a/src/replays/replays.worker.ts
+++ b/src/replays/replays.worker.ts
@@ -15,7 +15,7 @@ import { loadFolder } from "./loadFolder";
 import type { FileLoadResult, FileResult, Progress } from "./types";
 
 export interface Methods {
-  destroyWorker: () => Promise<void>;
+  dispose: () => Promise<void>;
   loadSingleFile(filePath: string): Promise<FileResult>;
   loadReplayFolder(folder: string): Promise<FileLoadResult>;
   calculateGameStats(fullPath: string): Promise<StatsType | null>;
@@ -27,8 +27,9 @@ export type WorkerSpec = ModuleMethods & Methods;
 let progressSubject: Subject<Progress> = new Subject();
 
 const methods: WorkerSpec = {
-  async destroyWorker(): Promise<void> {
+  async dispose(): Promise<void> {
     // Clean up worker
+    progressSubject.complete();
   },
   getProgressObservable(): Observable<Progress> {
     return Observable.from(progressSubject);

--- a/src/replays/replays.worker.ts
+++ b/src/replays/replays.worker.ts
@@ -14,7 +14,7 @@ import { loadFile } from "./loadFile";
 import { loadFolder } from "./loadFolder";
 import type { FileLoadResult, FileResult, Progress } from "./types";
 
-export interface Methods {
+interface Methods {
   dispose: () => Promise<void>;
   loadSingleFile(filePath: string): Promise<FileResult>;
   loadReplayFolder(folder: string): Promise<FileLoadResult>;

--- a/src/utils/registerWorker.ts
+++ b/src/utils/registerWorker.ts
@@ -1,0 +1,38 @@
+import { app } from "electron";
+import log from "electron-log";
+import type { Worker } from "threads";
+import { spawn, Thread } from "threads";
+import type { ModuleMethods } from "threads/dist/types/master";
+
+type WorkerMethods = { dispose: () => Promise<void> } & ModuleMethods;
+
+export type RegisteredWorker<T> = {
+  worker: Thread & T;
+  terminate: () => Promise<void>;
+};
+
+/**
+ * Spawns and registers a worker to automatically terminate once the app is quit.
+ */
+export async function registerWorker<T extends WorkerMethods>(worker: Worker): Promise<RegisteredWorker<T>> {
+  try {
+    const registeredWorker = (await spawn(worker, { timeout: 30000 })) as Thread & T;
+    const terminateWorker = async () => {
+      try {
+        await registeredWorker.dispose();
+      } finally {
+        await Thread.terminate(registeredWorker);
+      }
+    };
+
+    app.on("quit", terminateWorker);
+
+    return {
+      worker: registeredWorker,
+      terminate: terminateWorker,
+    };
+  } catch (err) {
+    log.error(err);
+    throw err;
+  }
+}

--- a/src/utils/registerWorker.ts
+++ b/src/utils/registerWorker.ts
@@ -6,10 +6,7 @@ import type { ModuleMethods } from "threads/dist/types/master";
 
 type WorkerMethods = { dispose: () => Promise<void> } & ModuleMethods;
 
-export type RegisteredWorker<T> = {
-  worker: Thread & T;
-  terminate: () => Promise<void>;
-};
+export type RegisteredWorker<T> = Thread & T;
 
 /**
  * Spawns and registers a worker to automatically terminate once the app is quit.
@@ -27,10 +24,7 @@ export async function registerWorker<T extends WorkerMethods>(worker: Worker): P
 
     app.on("quit", terminateWorker);
 
-    return {
-      worker: registeredWorker,
-      terminate: terminateWorker,
-    };
+    return registeredWorker;
   } catch (err) {
     log.error(err);
     throw err;


### PR DESCRIPTION
This PR refactors the workers to only be spawned when necessary.

Most players will rarely need console mirroring, or broadcast/spectate features so always spawning those workers on app launch is 1. wasting resources, 2. increasing app startup time.

We now only spawn the workers when we actually need to. We also move the common worker registration logic to `src/utils/registerWorker.ts` to automatically terminate the workers on app quit.

The purpose of the `src/utils` folder is to hold functions that are imported across the different main modules since ideally modules should not import from `src/main`.