### PR TITLE
fix: dolphin never getting to ready state if offline

### DIFF
--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -102,8 +102,8 @@ export class DolphinInstallation {
         return;
       }
 
-      const latestVersion = dolphinDownloadInfo?.version ?? "9.9.9";
-      const isOutdated = await this._isOutOfDate(latestVersion);
+      const latestVersion = dolphinDownloadInfo?.version;
+      const isOutdated = !latestVersion || (await this._isOutOfDate(latestVersion));
       if (!isOutdated) {
         log.info("No update found...");
         onComplete();
@@ -141,7 +141,7 @@ export class DolphinInstallation {
         dolphinDownloadInfo = await fetchLatestVersion(type);
       } catch (err) {
         log.error(`Failed to fetch latest Dolphin version: ${err}`);
-        return;
+        throw new Error(`Failed to fetch latest Dolphin version`);
       }
     }
 

--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -137,12 +137,7 @@ export class DolphinInstallation {
     const type = this.dolphinLaunchType;
     let dolphinDownloadInfo = releaseInfo;
     if (!dolphinDownloadInfo) {
-      try {
-        dolphinDownloadInfo = await fetchLatestVersion(type);
-      } catch (err) {
-        log.error(`Failed to fetch latest Dolphin version: ${err}`);
-        throw new Error(`Failed to fetch latest Dolphin version`);
-      }
+      dolphinDownloadInfo = await fetchLatestVersion(type);
     }
 
     const downloadUrl = dolphinDownloadInfo.downloadUrls[process.platform];


### PR DESCRIPTION
Users should still be able to access Dolphin related features as long as the executable is available.