### PR TITLE
Fix slippi protocol not registering when installing for current user

### DIFF
--- a/.erb/scripts/installer.nsh
+++ b/.erb/scripts/installer.nsh
@@ -54,13 +54,23 @@ var InstallType
 !macro customInstall
   ; Add slippi URI Handling
   DetailPrint "Register slippi URI Handler"
-  DeleteRegKey HKCR "slippi"
-  WriteRegStr HKCR "slippi" "" "URL:slippi"
-  WriteRegStr HKCR "slippi" "URL Protocol" ""
-  WriteRegStr HKCR "slippi\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
-  WriteRegStr HKCR "slippi\shell" "" ""
-  WriteRegStr HKCR "slippi\shell\Open" "" ""
-  WriteRegStr HKCR "slippi\shell\Open\command" "" "$\"$INSTDIR\${APP_EXECUTABLE_FILENAME}$\" $\"%1$\""
+  ${If} $installMode == "all"
+    DeleteRegKey HKCR "slippi"
+    WriteRegStr HKCR "slippi" "" "URL:slippi"
+    WriteRegStr HKCR "slippi" "URL Protocol" ""
+    WriteRegStr HKCR "slippi\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+    WriteRegStr HKCR "slippi\shell" "" ""
+    WriteRegStr HKCR "slippi\shell\Open" "" ""
+    WriteRegStr HKCR "slippi\shell\Open\command" "" "$\"$INSTDIR\${APP_EXECUTABLE_FILENAME}$\" $\"%1$\""
+  ${Else}
+    DeleteRegKey HKCU "SOFTWARE\Classes\slippi"
+    WriteRegStr HKCU "SOFTWARE\Classes\slippi" "" "URL:slippi"
+    WriteRegStr HKCU "SOFTWARE\Classes\slippi" "URL Protocol" ""
+    WriteRegStr HKCU "SOFTWARE\Classes\slippi\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+    WriteRegStr HKCU "SOFTWARE\Classes\slippi\shell" "" ""
+    WriteRegStr HKCU "SOFTWARE\Classes\slippi\shell\Open" "" ""
+    WriteRegStr HKCU "SOFTWARE\Classes\slippi\shell\Open\command" "" "$\"$INSTDIR\${APP_EXECUTABLE_FILENAME}$\" $\"%1$\""
+  ${EndIf}
 
   ; Check if we should also install the GC drivers
   ${If} $InstallType == INSTALL


### PR DESCRIPTION
This PR fixes #327.

After extensive googling, it turns out [we can actually register custom URL scheme protocols without Admin](https://stackoverflow.com/questions/29509624/can-i-register-a-custom-url-scheme-without-administrator-elevation) as long as we use `HKCU\Software\Classes` instead of using `HKCR`.

The only thing left was to figure out how to conditionally write the registry based on which install mode was currently in use -- current user or all users. After having no luck with `$MultiUser.InstallMode`, [this comment](https://github.com/electron-userland/electron-builder/issues/3319#issuecomment-804344631) revealed that we can simply use `$installMode` for the conditional.