### PR TITLE
Fix MacOS graphical bug after bumping to Electron version 19

### DIFF
--- a/src/renderer/containers/ReplayBrowser/ReplayFile.tsx
+++ b/src/renderer/containers/ReplayBrowser/ReplayFile.tsx
@@ -139,7 +139,6 @@ export const ReplayFile: React.FC<ReplayFileProps> = ({
                 filePaths={[fullPath]}
                 css={css`
                   opacity: 0.9;
-                  transition: opacity 0.2s ease-in-out;
                   &:hover {
                     opacity: 1;
                     text-decoration: underline;


### PR DESCRIPTION
### Description

This PR fixes the MacOS graphical issue when selecting a replay file which was discovered after bumping Electron version to v19.

This bug may be related to [this open issue](https://bugs.chromium.org/p/chromium/issues/detail?id=961581) or [this closed issue](https://bugs.chromium.org/p/chromium/issues/detail?id=503638) in Chromium's bug tracker. In any case it's likely got something to do with `mix-blend-mode: color-dodge;` and how it interacts with `transform` or `transition` changes. Not too sure why but disabling this opacity transition makes this bug not appear for now -- but perhaps there may be other triggers that cause this bug to reappear. It will be good to continue monitoring this issue especially on MacOS in the future after changes to `ReplayFile.tsx`.

### Recording of the issue

https://user-images.githubusercontent.com/8384734/184087007-10a7b642-a748-4a59-a0cd-9b99c71eb8f3.mov

### Alternatives considered

* This [StackOverflow](https://stackoverflow.com/a/38466053) answer suggested adding either `will-change: opacity` or `transform: translateZ(0)` neither of which "fixed" the problem but rather it did allow the graphical issue to be permanently triggered rather than requiring a mouseover as in the video recording.