### PR TITLE
[WIP] [PR] Handle netplay Dolphin update via URI

### DIFF
--- a/release/app/package.json
+++ b/release/app/package.json
@@ -2,7 +2,7 @@
   "name": "slippi-launcher",
   "productName": "Slippi Launcher",
   "description": "Launch Slippi Online, browse and watch saved replays",
-  "version": "2.5.6",
+  "version": "2.5.7-beta.1",
   "main": "./dist/main/main.js",
   "author": {
     "name": "Jas Laferriere",


### PR DESCRIPTION
The idea behind this is that when Dolphin is not up to date, it shows an update button. when someone presses that update button, we'd like to update their Dolphin instead of requiring them to restart the launcher.

Currently testing this from the command line and it does seem to update the Dolphin version but it doesn't show the "Updating" UI, would probably like to add that.