### PR TITLE
ci: sign windows exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,15 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install
+      - name: Load Windows signing certificate and secret
+        if: matrix.os == 'windows-latest' && env.CERTIFICATE_WINDOWS_PASSWORD != null
+        shell: bash
+        run: |
+          echo "CSC_LINK=${{ secrets.CERTIFICATE_WINDOWS_APPLICATION }}" >> $GITHUB_ENV
+          echo "CSC_KEY_PASSWORD=${{ secrets.CERTIFICATE_WINDOWS_PASSWORD }}" >> $GITHUB_ENV
+        env:
+          CERTIFICATE_WINDOWS_APPLICATION: ${{ secrets.CERTIFICATE_WINDOWS_APPLICATION }}
+          CERTIFICATE_WINDOWS_PASSWORD: ${{ secrets.CERTIFICATE_WINDOWS_PASSWORD }}
       - name: Load macOS signing certificates and secrets
         if: matrix.os == 'macOS-latest' && env.CERTIFICATE_MACOS_PASSWORD != null
         run: |


### PR DESCRIPTION
uses electron-builder's built in signing functionality like we do for macOS
![image](https://user-images.githubusercontent.com/6331403/192460296-4c0f6ec3-17e5-4336-bd83-da09198ce896.png)
