### PR TITLE
feat: add notice about OBS websocket update

### DIFF
--- a/src/renderer/containers/Console/OBSWebsocketNotice.tsx
+++ b/src/renderer/containers/Console/OBSWebsocketNotice.tsx
@@ -1,0 +1,44 @@
+import { css } from "@emotion/react";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import React from "react";
+
+import { ExternalLink as A } from "@/components/ExternalLink";
+
+const OBS_WEBSOCKET_NOTICE_KEY = "SEEN_OBS_WEBSOCKET_NOTICE";
+
+export const OBSWebsocketNotice = () => {
+  const [seenNotice, setSeenNotice] = React.useState<boolean>(
+    localStorage.getItem(OBS_WEBSOCKET_NOTICE_KEY) === "true",
+  );
+  const onClose = () => {
+    localStorage.setItem(OBS_WEBSOCKET_NOTICE_KEY, "true");
+    setSeenNotice(true);
+  };
+  return (
+    <Dialog open={!seenNotice} closeAfterTransition={true} onClose={onClose}>
+      <DialogTitle>OBS Websocket 5.0 Update</DialogTitle>
+      <DialogContent>
+        <div
+          css={css`
+            a {
+              text-decoration: underline;
+            }
+          `}
+        >
+          We've updated to support OBS Websocket 5.0+ which comes standard in OBS 28+, but no longer support version
+          4.9.1.
+          <br />
+          <br />
+          If you are still on OBS 27, install{" "}
+          <A href="https://github.com/obsproject/obs-websocket/releases/tag/5.0.1">OBS Websocket 5.0.1</A>.
+          <br />
+          <br />
+          You will also need to update your console connection settings if you use the Autoswitcher because the OBS IP
+          and port are now separate fields in the settings.
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/renderer/containers/Console/OBSWebsocketNotice.tsx
+++ b/src/renderer/containers/Console/OBSWebsocketNotice.tsx
@@ -32,12 +32,13 @@ export const OBSWebsocketNotice = () => {
             }
           `}
         >
-          We've updated to support OBS Websocket 5.0+ which comes standard in OBS 28+, but no longer support version
-          4.9.1.
+          Slippi Launcher now supports OBS Websocket 5.0+ which comes standard in OBS 28+, but no longer supports
+          version 4.9.1.
           <br />
           <br />
           If you are still on OBS 27, install{" "}
-          <A href="https://github.com/obsproject/obs-websocket/releases/tag/5.0.1">OBS Websocket 5.0.1</A>.
+          <A href="https://github.com/obsproject/obs-websocket/releases/tag/5.0.1">OBS Websocket 5.0.1</A>. You can
+          install the 5.0 and 4.9-compat versions at the same time if needed.
           <br />
           <br />
           You will also need to update your console connection settings if you use the Autoswitcher because the OBS IP

--- a/src/renderer/containers/Console/OBSWebsocketNotice.tsx
+++ b/src/renderer/containers/Console/OBSWebsocketNotice.tsx
@@ -16,6 +16,11 @@ export const OBSWebsocketNotice = () => {
     localStorage.setItem(OBS_WEBSOCKET_NOTICE_KEY, "true");
     setSeenNotice(true);
   };
+
+  if (seenNotice) {
+    return null;
+  }
+
   return (
     <Dialog open={!seenNotice} closeAfterTransition={true} onClose={onClose}>
       <DialogTitle>OBS Websocket 5.0 Update</DialogTitle>

--- a/src/renderer/containers/Console/index.tsx
+++ b/src/renderer/containers/Console/index.tsx
@@ -23,6 +23,7 @@ import { useServices } from "@/services";
 
 import { AddConnectionDialog } from "./AddConnectionDialog";
 import { NewConnectionList } from "./NewConnectionList";
+import { OBSWebsocketNotice } from "./OBSWebsocketNotice";
 import { SavedConnectionsList } from "./SavedConnectionsList";
 
 const Outer = styled.div`
@@ -158,6 +159,7 @@ export const Console: React.FC = () => {
         onCancel={onCancel}
         disabled={consoleIsConnected(currentFormValues?.ipAddress)}
       />
+      <OBSWebsocketNotice />
     </Outer>
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6331403/192929224-bebf2ec9-2b0a-40cd-852d-c584cc15bf5a.png)

uses localstorage to ensure it only shows once. this should help avoid users getting confused about the change.