### PR TITLE
Delete app data on uninstall

### DIFF
--- a/.erb/scripts/installer.nsh
+++ b/.erb/scripts/installer.nsh
@@ -84,3 +84,9 @@ var InstallType
     ExecShellWait "" "$PLUGINSDIR\${GC_INSTALLER}" SW_HIDE
   ${EndIf}
 !macroend
+
+!macro customUnInstall
+  ; Clean up Slippi URI Handling
+  DeleteRegKey HKCR "slippi"
+  DeleteRegKey HKCU "SOFTWARE\Classes\slippi"
+!macroend

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -65,7 +65,8 @@
     "warningsAsErrors": false,
     "allowElevation": true,
     "oneClick": false,
-    "allowToChangeInstallationDirectory": true
+    "allowToChangeInstallationDirectory": true,
+    "deleteAppDataOnUninstall": true
   },
   "linux": {
     "target": ["AppImage"],


### PR DESCRIPTION
This PR addresses #344.

While we're at it we also clear the registry keys that we defined on uninstall too. This change does not affect app updates.