### PR TITLE
macOS: Mirror updated paths in Ishiiruka/374

### DIFF
--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -7,7 +7,7 @@ import electronLog from "electron-log";
 import * as fs from "fs-extra";
 import os from "os";
 import path from "path";
-import { gt, lt, lte } from "semver";
+import { lt } from "semver";
 
 import { DolphinLaunchType } from "../types";
 import { downloadLatestDolphin } from "./download";
@@ -224,13 +224,16 @@ export class DolphinInstallation {
       case "darwin": {
         const { installDolphinOnMac } = await import("./macos");
         const currentVersion = await this.getDolphinVersion();
-        const shouldMigrateUserFolder = currentVersion !== null && lte(currentVersion, "3.0.3");
-        if (shouldMigrateUserFolder) {
+        const userFolderInBundle = currentVersion !== null && lt(currentVersion, "3.0.4");
+        if (userFolderInBundle) {
           const oldUserFolder = path.join(dolphinPath, "Slippi Dolphin.app", "Contents", "Resources", "User");
           await fs.copy(oldUserFolder, this.userFolder, { recursive: true, overwrite: true });
         }
-        const skipUserFolderBkp = currentVersion !== null && gt(currentVersion, "3.0.3");
-        await installDolphinOnMac({ assetPath, destinationFolder: dolphinPath, skipUserFolderBkp });
+        await installDolphinOnMac({
+          assetPath,
+          destinationFolder: dolphinPath,
+          shouldBackupUserFolder: userFolderInBundle,
+        });
         break;
       }
       case "linux": {

--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -7,7 +7,7 @@ import electronLog from "electron-log";
 import * as fs from "fs-extra";
 import os from "os";
 import path from "path";
-import { lt } from "semver";
+import { gt, lt, lte } from "semver";
 
 import { DolphinLaunchType } from "../types";
 import { downloadLatestDolphin } from "./download";
@@ -223,7 +223,14 @@ export class DolphinInstallation {
       }
       case "darwin": {
         const { installDolphinOnMac } = await import("./macos");
-        await installDolphinOnMac({ assetPath, destinationFolder: dolphinPath });
+        const currentVersion = await this.getDolphinVersion();
+        const shouldMigrateUserFolder = currentVersion !== null && lte(currentVersion, "3.0.3");
+        if (shouldMigrateUserFolder) {
+          const oldUserFolder = path.join(dolphinPath, "Slippi Dolphin.app", "Contents", "Resources", "User");
+          await fs.copy(oldUserFolder, this.userFolder, { recursive: true, overwrite: true });
+        }
+        const skipUserFolderBkp = currentVersion !== null && gt(currentVersion, "3.0.3");
+        await installDolphinOnMac({ assetPath, destinationFolder: dolphinPath, skipUserFolderBkp });
         break;
       }
       case "linux": {

--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -31,9 +31,19 @@ export class DolphinInstallation {
         return path.join(this.installationFolder, "User");
       }
       case "darwin": {
-        const configPath = path.join(os.homedir(), "Library", "Application Support", "com.project-slippi.dolphin");
+        const oldConfigPath = path.join(this.installationFolder, "Slippi Dolphin.app", "Contents", "Resources", "User");
         const userFolderName = this.dolphinLaunchType === DolphinLaunchType.NETPLAY ? "netplay/User" : "playback/User";
-        return path.join(configPath, userFolderName);
+        const newConfigPath = path.join(
+          os.homedir(),
+          "Library",
+          "Application Support",
+          "com.project-slippi.dolphin",
+          userFolderName,
+        );
+
+        // TODO: remove this once we've deployed the new dolphin
+        const configPath = fs.pathExistsSync(newConfigPath) ? newConfigPath : oldConfigPath;
+        return configPath;
       }
       case "linux": {
         const configPath = path.join(os.homedir(), ".config");
@@ -224,7 +234,7 @@ export class DolphinInstallation {
       case "darwin": {
         const { installDolphinOnMac } = await import("./macos");
         const currentVersion = await this.getDolphinVersion();
-        const userFolderInBundle = currentVersion !== null && lt(currentVersion, "3.0.4");
+        const userFolderInBundle = currentVersion !== null && lt(currentVersion, "3.0.5");
         if (userFolderInBundle) {
           const oldUserFolder = path.join(dolphinPath, "Slippi Dolphin.app", "Contents", "Resources", "User");
           await fs.copy(oldUserFolder, this.userFolder, { recursive: true, overwrite: true });

--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -31,7 +31,9 @@ export class DolphinInstallation {
         return path.join(this.installationFolder, "User");
       }
       case "darwin": {
-        return path.join(this.installationFolder, "Slippi Dolphin.app", "Contents", "Resources", "User");
+        const configPath = path.join(os.homedir(), "Library", "Application Support", "com.project-slippi.dolphin");
+        const userFolderName = this.dolphinLaunchType === DolphinLaunchType.NETPLAY ? "netplay/User" : "playback/User";
+        return path.join(configPath, userFolderName);
       }
       case "linux": {
         const configPath = path.join(os.homedir(), ".config");

--- a/src/dolphin/install/macos.ts
+++ b/src/dolphin/install/macos.ts
@@ -7,17 +7,19 @@ import { extractDmg } from "./extractDmg";
 export async function installDolphinOnMac({
   assetPath,
   destinationFolder,
+  skipUserFolderBkp,
   log = console.log,
 }: {
   assetPath: string;
   destinationFolder: string;
+  skipUserFolderBkp: boolean;
   log?: (message: string) => void;
 }) {
   const backupLocation = destinationFolder + "_old";
   const dolphinResourcesPath = path.join(destinationFolder, "Slippi Dolphin.app", "Contents", "Resources");
 
-  const alreadyInstalled = await fs.pathExists(dolphinResourcesPath);
-  if (alreadyInstalled) {
+  const bkpUserFolder = !skipUserFolderBkp && (await fs.pathExists(dolphinResourcesPath));
+  if (bkpUserFolder) {
     log(`${dolphinResourcesPath} already exists. Moving...`);
     await fs.move(destinationFolder, backupLocation, { overwrite: true });
   }
@@ -42,7 +44,7 @@ export async function installDolphinOnMac({
   await fs.chown(binaryLocation, userInfo.uid, userInfo.gid);
 
   // move backed up User folder and user.json
-  if (alreadyInstalled) {
+  if (bkpUserFolder) {
     const oldUserFolder = path.join(backupLocation, "Slippi Dolphin.app", "Contents", "Resources", "User");
     const newUserFolder = path.join(dolphinResourcesPath, "User");
     log("moving User folder...");

--- a/src/dolphin/install/macos.ts
+++ b/src/dolphin/install/macos.ts
@@ -7,18 +7,18 @@ import { extractDmg } from "./extractDmg";
 export async function installDolphinOnMac({
   assetPath,
   destinationFolder,
-  skipUserFolderBkp,
+  shouldBackupUserFolder,
   log = console.log,
 }: {
   assetPath: string;
   destinationFolder: string;
-  skipUserFolderBkp: boolean;
+  shouldBackupUserFolder: boolean;
   log?: (message: string) => void;
 }) {
   const backupLocation = destinationFolder + "_old";
   const dolphinResourcesPath = path.join(destinationFolder, "Slippi Dolphin.app", "Contents", "Resources");
 
-  const bkpUserFolder = !skipUserFolderBkp && (await fs.pathExists(dolphinResourcesPath));
+  const bkpUserFolder = shouldBackupUserFolder && (await fs.pathExists(dolphinResourcesPath));
   if (bkpUserFolder) {
     log(`${dolphinResourcesPath} already exists. Moving...`);
     await fs.move(destinationFolder, backupLocation, { overwrite: true });

--- a/src/dolphin/install/macos.ts
+++ b/src/dolphin/install/macos.ts
@@ -12,14 +12,14 @@ export async function installDolphinOnMac({
 }: {
   assetPath: string;
   destinationFolder: string;
-  shouldBackupUserFolder: boolean;
+  shouldBackupUserFolder?: boolean;
   log?: (message: string) => void;
 }) {
   const backupLocation = destinationFolder + "_old";
   const dolphinResourcesPath = path.join(destinationFolder, "Slippi Dolphin.app", "Contents", "Resources");
 
-  const bkpUserFolder = shouldBackupUserFolder && (await fs.pathExists(dolphinResourcesPath));
-  if (bkpUserFolder) {
+  const backupUserFolder = shouldBackupUserFolder && (await fs.pathExists(dolphinResourcesPath));
+  if (backupUserFolder) {
     log(`${dolphinResourcesPath} already exists. Moving...`);
     await fs.move(destinationFolder, backupLocation, { overwrite: true });
   }
@@ -44,7 +44,7 @@ export async function installDolphinOnMac({
   await fs.chown(binaryLocation, userInfo.uid, userInfo.gid);
 
   // move backed up User folder and user.json
-  if (bkpUserFolder) {
+  if (backupUserFolder) {
     const oldUserFolder = path.join(backupLocation, "Slippi Dolphin.app", "Contents", "Resources", "User");
     const newUserFolder = path.join(dolphinResourcesPath, "User");
     log("moving User folder...");


### PR DESCRIPTION
This updates the Launcher to use the macOS `User` folder path(s) specified in [Ishiiruka/#374](https://github.com/project-slippi/Ishiiruka/pull/374).

The gist of this is that it appears that Ventura actually enforces signed bundles not being altered, and coupled with GateKeeper checking on each open as opposed to the first open, means that users get a message saying the app is damaged due to `Dolphin.ini`.

As far as I can tell this is the only core part that needs to be altered, and I went ahead and just mostly copied the approach the Linux block uses - but I defer to y'all.