### PR TITLE
feat: add button to open dolphin settings folder 

### DIFF
--- a/src/dolphin/api.ts
+++ b/src/dolphin/api.ts
@@ -6,10 +6,10 @@ import {
   ipc_configureDolphin,
   ipc_dolphinEvent,
   ipc_downloadDolphin,
-  ipc_getUserFolderPath,
   ipc_hardResetDolphin,
   ipc_importDolphinSettings,
   ipc_launchNetplayDolphin,
+  ipc_openDolphinSettingsFolder,
   ipc_removePlayKeyFile,
   ipc_softResetDolphin,
   ipc_storePlayKeyFile,
@@ -37,9 +37,8 @@ const dolphinApi: DolphinService = {
   async hardResetDolphin(dolphinType: DolphinLaunchType) {
     await ipc_hardResetDolphin.renderer!.trigger({ dolphinType });
   },
-  async getUserFolderPath(dolphinType: DolphinLaunchType) {
-    const { result } = await ipc_getUserFolderPath.renderer!.trigger({ dolphinType });
-    return result.path;
+  async openDolphinSettingsFolder(dolphinType: DolphinLaunchType) {
+    await ipc_openDolphinSettingsFolder.renderer!.trigger({ dolphinType });
   },
   async storePlayKeyFile(key: PlayKey) {
     await ipc_storePlayKeyFile.renderer!.trigger({ key });

--- a/src/dolphin/api.ts
+++ b/src/dolphin/api.ts
@@ -6,6 +6,7 @@ import {
   ipc_configureDolphin,
   ipc_dolphinEvent,
   ipc_downloadDolphin,
+  ipc_getUserFolderPath,
   ipc_hardResetDolphin,
   ipc_importDolphinSettings,
   ipc_launchNetplayDolphin,
@@ -35,6 +36,10 @@ const dolphinApi: DolphinService = {
   },
   async hardResetDolphin(dolphinType: DolphinLaunchType) {
     await ipc_hardResetDolphin.renderer!.trigger({ dolphinType });
+  },
+  async getUserFolderPath(dolphinType: DolphinLaunchType) {
+    const { result } = await ipc_getUserFolderPath.renderer!.trigger({ dolphinType });
+    return result.path;
   },
   async storePlayKeyFile(key: PlayKey) {
     await ipc_storePlayKeyFile.renderer!.trigger({ key });

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -29,6 +29,12 @@ export const ipc_softResetDolphin = makeEndpoint.main(
   <SuccessPayload>_,
 );
 
+export const ipc_getUserFolderPath = makeEndpoint.main(
+  "getUserFolderPath",
+  <{ dolphinType: DolphinLaunchType }>_,
+  <{ path: string }>_,
+);
+
 export const ipc_storePlayKeyFile = makeEndpoint.main("storePlayKeyFile", <{ key: PlayKey }>_, <SuccessPayload>_);
 
 export const ipc_checkPlayKeyExists = makeEndpoint.main(

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -29,10 +29,10 @@ export const ipc_softResetDolphin = makeEndpoint.main(
   <SuccessPayload>_,
 );
 
-export const ipc_getUserFolderPath = makeEndpoint.main(
-  "getUserFolderPath",
+export const ipc_openDolphinSettingsFolder = makeEndpoint.main(
+  "openDolphinSettingsFolder",
   <{ dolphinType: DolphinLaunchType }>_,
-  <{ path: string }>_,
+  <SuccessPayload>_,
 );
 
 export const ipc_storePlayKeyFile = makeEndpoint.main("storePlayKeyFile", <{ key: PlayKey }>_, <SuccessPayload>_);

--- a/src/dolphin/setup.ts
+++ b/src/dolphin/setup.ts
@@ -1,4 +1,4 @@
-import { app } from "electron";
+import { app, shell } from "electron";
 import log from "electron-log";
 import * as fs from "fs-extra";
 import { isEqual } from "lodash";
@@ -11,10 +11,10 @@ import {
   ipc_configureDolphin,
   ipc_dolphinEvent,
   ipc_downloadDolphin,
-  ipc_getUserFolderPath,
   ipc_hardResetDolphin,
   ipc_importDolphinSettings,
   ipc_launchNetplayDolphin,
+  ipc_openDolphinSettingsFolder,
   ipc_removePlayKeyFile,
   ipc_softResetDolphin,
   ipc_storePlayKeyFile,
@@ -50,9 +50,10 @@ export default function setupDolphinIpc({ dolphinManager }: { dolphinManager: Do
     return { success: true };
   });
 
-  ipc_getUserFolderPath.main!.handle(async ({ dolphinType }) => {
+  ipc_openDolphinSettingsFolder.main!.handle(async ({ dolphinType }) => {
     const path = await dolphinManager.getInstallation(dolphinType).userFolder;
-    return { path };
+    await shell.openPath(path);
+    return { success: true };
   });
 
   ipc_hardResetDolphin.main!.handle(async ({ dolphinType }) => {

--- a/src/dolphin/setup.ts
+++ b/src/dolphin/setup.ts
@@ -11,6 +11,7 @@ import {
   ipc_configureDolphin,
   ipc_dolphinEvent,
   ipc_downloadDolphin,
+  ipc_getUserFolderPath,
   ipc_hardResetDolphin,
   ipc_importDolphinSettings,
   ipc_launchNetplayDolphin,
@@ -47,6 +48,11 @@ export default function setupDolphinIpc({ dolphinManager }: { dolphinManager: Do
     console.log("soft resetting dolphin...");
     await dolphinManager.reinstallDolphin(dolphinType, false);
     return { success: true };
+  });
+
+  ipc_getUserFolderPath.main!.handle(async ({ dolphinType }) => {
+    const path = await dolphinManager.getInstallation(dolphinType).userFolder;
+    return { path };
   });
 
   ipc_hardResetDolphin.main!.handle(async ({ dolphinType }) => {

--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -87,6 +87,7 @@ export interface DolphinService {
   configureDolphin(dolphinType: DolphinLaunchType): Promise<void>;
   softResetDolphin(dolphinType: DolphinLaunchType): Promise<void>;
   hardResetDolphin(dolphinType: DolphinLaunchType): Promise<void>;
+  getUserFolderPath(dolphinType: DolphinLaunchType): Promise<string>;
   storePlayKeyFile(key: PlayKey): Promise<void>;
   checkPlayKeyExists(key: PlayKey): Promise<boolean>;
   removePlayKeyFile(): Promise<void>;

--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -87,7 +87,7 @@ export interface DolphinService {
   configureDolphin(dolphinType: DolphinLaunchType): Promise<void>;
   softResetDolphin(dolphinType: DolphinLaunchType): Promise<void>;
   hardResetDolphin(dolphinType: DolphinLaunchType): Promise<void>;
-  getUserFolderPath(dolphinType: DolphinLaunchType): Promise<string>;
+  openDolphinSettingsFolder(dolphinType: DolphinLaunchType): Promise<void>;
   storePlayKeyFile(key: PlayKey): Promise<void>;
   checkPlayKeyExists(key: PlayKey): Promise<boolean>;
   removePlayKeyFile(): Promise<void>;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -125,6 +125,10 @@ const createWindow = async () => {
     },
     onOpenReplayFile: playReplayAndShowStats,
     createWindow,
+    onOpenAppSupportFolder: () => {
+      const path = app.getPath("userData");
+      void shell.openPath(path);
+    },
     enableDevTools: isDevelopment,
   });
   menu = menuBuilder.buildMenu();

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -76,7 +76,7 @@ export class MenuBuilder {
           },
         },
         {
-          label: "Open Application Support Folder",
+          label: "Open App Settings Folder",
           click: () => {
             this.onOpenAppSupportFolder();
           },

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -11,6 +11,7 @@ export class MenuBuilder {
   private mainWindow: BrowserWindow;
   private onOpenPreferences: () => void;
   private onOpenReplayFile: (filePath: string) => void;
+  private onOpenAppSupportFolder: () => void;
   private createWindow: () => Promise<void>;
   private enableDevTools?: boolean;
 
@@ -18,6 +19,7 @@ export class MenuBuilder {
     mainWindow: BrowserWindow;
     onOpenPreferences: () => void;
     onOpenReplayFile: (filePath: string) => void;
+    onOpenAppSupportFolder: () => void;
     createWindow: () => Promise<void>;
     enableDevTools?: boolean;
   }) {
@@ -25,6 +27,7 @@ export class MenuBuilder {
     this.enableDevTools = options.enableDevTools;
     this.onOpenPreferences = options.onOpenPreferences;
     this.onOpenReplayFile = options.onOpenReplayFile;
+    this.onOpenAppSupportFolder = options.onOpenAppSupportFolder;
     this.createWindow = options.createWindow;
   }
 
@@ -70,6 +73,12 @@ export class MenuBuilder {
           accelerator: "Cmd+,",
           click: () => {
             this.onOpenPreferences();
+          },
+        },
+        {
+          label: "Open Application Support Folder",
+          click: () => {
+            this.onOpenAppSupportFolder();
           },
         },
         {

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -38,20 +38,18 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
   const [resetModalOpen, setResetModalOpen] = React.useState(false);
   const [isResetType, setResetType] = React.useState<ResetType | null>(null);
   const { dolphinService } = useServices();
-  const { openConfigureDolphin, hardResetDolphin, softResetDolphin, importDolphin, getDolphinUserPath } =
-    useDolphinActions(dolphinService);
+  const { openConfigureDolphin, hardResetDolphin, softResetDolphin, importDolphin } = useDolphinActions(dolphinService);
 
   const dolphinIsReady = dolphinStatus === DolphinStatus.READY && !dolphinIsOpen && isResetType === null;
   const versionString: string =
     dolphinStatus === DolphinStatus.UNKNOWN ? "Not found" : !dolphinVersion ? "Unknown" : dolphinVersion;
 
-  const openDolphinDirectoryHandler = async () => {
-    if (isMac || isLinux) {
-      const userSettingsPath = await getDolphinUserPath(dolphinType);
-      await window.electron.shell.openPath(userSettingsPath);
+  const openDolphinDirectoryHandler = React.useCallback(async () => {
+    if (isMac || !isLinux) {
+      await dolphinService.openDolphinSettingsFolder(dolphinType);
     }
     await window.electron.shell.openPath(dolphinPath);
-  };
+  }, [dolphinPath, dolphinService, dolphinType]);
 
   const configureDolphinHandler = async () => {
     openConfigureDolphin(dolphinType);

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -47,8 +47,9 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
   const openDolphinDirectoryHandler = React.useCallback(async () => {
     if (isMac || !isLinux) {
       await dolphinService.openDolphinSettingsFolder(dolphinType);
+    } else {
+      await window.electron.shell.openPath(dolphinPath);
     }
-    await window.electron.shell.openPath(dolphinPath);
   }, [dolphinPath, dolphinService, dolphinType]);
 
   const configureDolphinHandler = async () => {
@@ -91,7 +92,7 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
             Configure Dolphin
           </Button>
           <Button variant="outlined" color="primary" onClick={openDolphinDirectoryHandler}>
-            Open folder
+            Open settings folder
           </Button>
         </div>
       </SettingItem>

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -93,12 +93,14 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
           <Button variant="contained" color="primary" onClick={configureDolphinHandler} disabled={!dolphinIsReady}>
             Configure Dolphin
           </Button>
-          <Button variant="outlined" color="primary" onClick={openDolphinDirectoryHandler}>
-            Open containing folder
-          </Button>
+          {!isLinux && (
+            <Button variant="outlined" color="primary" onClick={openDolphinDirectoryHandler}>
+              Open containing folder
+            </Button>
+          )}
           {!isWindows && (
             <Button variant="outlined" color="primary" onClick={openDolphinSettingsHandler}>
-              Open User Settings folder
+              Open user settings folder
             </Button>
           )}
         </div>

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -16,7 +16,7 @@ import { useServices } from "@/services";
 
 import { SettingItem } from "./SettingItem";
 
-const { isLinux, isMac } = window.electron.common;
+const { isLinux, isMac, isWindows } = window.electron.common;
 const log = window.electron.log;
 
 enum ResetType {
@@ -38,7 +38,8 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
   const [resetModalOpen, setResetModalOpen] = React.useState(false);
   const [isResetType, setResetType] = React.useState<ResetType | null>(null);
   const { dolphinService } = useServices();
-  const { openConfigureDolphin, hardResetDolphin, softResetDolphin, importDolphin } = useDolphinActions(dolphinService);
+  const { openConfigureDolphin, hardResetDolphin, softResetDolphin, importDolphin, getDolphinUserPath } =
+    useDolphinActions(dolphinService);
 
   const dolphinIsReady = dolphinStatus === DolphinStatus.READY && !dolphinIsOpen && isResetType === null;
   const versionString: string =
@@ -50,6 +51,11 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
 
   const configureDolphinHandler = async () => {
     openConfigureDolphin(dolphinType);
+  };
+
+  const openDolphinSettingsHandler = async () => {
+    const userSettingsPath = await getDolphinUserPath(dolphinType);
+    await window.electron.shell.openPath(userSettingsPath);
   };
 
   const softResetDolphinHandler = async () => {
@@ -90,6 +96,11 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
           <Button variant="outlined" color="primary" onClick={openDolphinDirectoryHandler}>
             Open containing folder
           </Button>
+          {!isWindows && (
+            <Button variant="outlined" color="primary" onClick={openDolphinSettingsHandler}>
+              Open User Settings folder
+            </Button>
+          )}
         </div>
       </SettingItem>
       <DevGuard show={isLinux}>

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -16,7 +16,7 @@ import { useServices } from "@/services";
 
 import { SettingItem } from "./SettingItem";
 
-const { isLinux, isMac, isWindows } = window.electron.common;
+const { isLinux, isMac } = window.electron.common;
 const log = window.electron.log;
 
 enum ResetType {
@@ -46,16 +46,15 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
     dolphinStatus === DolphinStatus.UNKNOWN ? "Not found" : !dolphinVersion ? "Unknown" : dolphinVersion;
 
   const openDolphinDirectoryHandler = async () => {
+    if (isMac || isLinux) {
+      const userSettingsPath = await getDolphinUserPath(dolphinType);
+      await window.electron.shell.openPath(userSettingsPath);
+    }
     await window.electron.shell.openPath(dolphinPath);
   };
 
   const configureDolphinHandler = async () => {
     openConfigureDolphin(dolphinType);
-  };
-
-  const openDolphinSettingsHandler = async () => {
-    const userSettingsPath = await getDolphinUserPath(dolphinType);
-    await window.electron.shell.openPath(userSettingsPath);
   };
 
   const softResetDolphinHandler = async () => {
@@ -93,16 +92,9 @@ export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ 
           <Button variant="contained" color="primary" onClick={configureDolphinHandler} disabled={!dolphinIsReady}>
             Configure Dolphin
           </Button>
-          {!isLinux && (
-            <Button variant="outlined" color="primary" onClick={openDolphinDirectoryHandler}>
-              Open containing folder
-            </Button>
-          )}
-          {!isWindows && (
-            <Button variant="outlined" color="primary" onClick={openDolphinSettingsHandler}>
-              Open user settings folder
-            </Button>
-          )}
+          <Button variant="outlined" color="primary" onClick={openDolphinDirectoryHandler}>
+            Open folder
+          </Button>
         </div>
       </SettingItem>
       <DevGuard show={isLinux}>

--- a/src/renderer/lib/dolphin/useDolphinActions.ts
+++ b/src/renderer/lib/dolphin/useDolphinActions.ts
@@ -23,6 +23,13 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
     [netplayStatus, playbackStatus],
   );
 
+  const getDolphinUserPath = useCallback(
+    async (dolphinType: DolphinLaunchType): Promise<string> => {
+      return await dolphinService.getUserFolderPath(dolphinType);
+    },
+    [dolphinService],
+  );
+
   const openConfigureDolphin = useCallback(
     (dolphinType: DolphinLaunchType) => {
       if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
@@ -110,5 +117,6 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
     launchNetplay,
     viewReplays,
     importDolphin,
+    getDolphinUserPath,
   };
 };

--- a/src/renderer/lib/dolphin/useDolphinActions.ts
+++ b/src/renderer/lib/dolphin/useDolphinActions.ts
@@ -23,13 +23,6 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
     [netplayStatus, playbackStatus],
   );
 
-  const getDolphinUserPath = useCallback(
-    async (dolphinType: DolphinLaunchType): Promise<string> => {
-      return await dolphinService.getUserFolderPath(dolphinType);
-    },
-    [dolphinService],
-  );
-
   const openConfigureDolphin = useCallback(
     (dolphinType: DolphinLaunchType) => {
       if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
@@ -117,6 +110,5 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
     launchNetplay,
     viewReplays,
     importDolphin,
-    getDolphinUserPath,
   };
 };


### PR DESCRIPTION
Swap the `Open containing folder` with `Open settings folder` which opens the correct location for where the User settings are stored on each OS. for windows this is just where dolphin is located, but on macOS/linux it is a separate config folder.
![image](https://user-images.githubusercontent.com/6331403/210708275-65001a37-a973-43c1-9bbf-5eb9438ece92.png)

