### PR TITLE
feat: add check for updates button

### DIFF
--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -3,7 +3,7 @@ import { IniFile } from "@dolphin/config/iniFile";
 import { findDolphinExecutable } from "@dolphin/util";
 import { spawnSync } from "child_process";
 import { app } from "electron";
-import log from "electron-log";
+import electronLog from "electron-log";
 import * as fs from "fs-extra";
 import os from "os";
 import path from "path";
@@ -13,6 +13,8 @@ import { DolphinLaunchType } from "../types";
 import { downloadLatestDolphin } from "./download";
 import type { DolphinVersionResponse } from "./fetchLatestVersion";
 import { fetchLatestVersion } from "./fetchLatestVersion";
+
+const log = electronLog.scope("dolphin/installation");
 
 const isLinux = process.platform === "linux";
 

--- a/src/dolphin/install/installation.ts
+++ b/src/dolphin/install/installation.ts
@@ -89,9 +89,11 @@ export class DolphinInstallation {
   }
 
   public async validate({
+    onStart,
     onProgress,
     onComplete,
   }: {
+    onStart: () => void;
     onProgress: (current: number, total: number) => void;
     onComplete: () => void;
   }): Promise<void> {
@@ -118,6 +120,8 @@ export class DolphinInstallation {
         onComplete();
         return;
       }
+
+      onStart();
 
       log.info(`${type} Dolphin installation is outdated. Downloading latest...`);
     } catch (err) {

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -29,6 +29,7 @@ export class DolphinManager {
   public async installDolphin(dolphinType: DolphinLaunchType): Promise<void> {
     const dolphinInstall = this.getInstallation(dolphinType);
     await dolphinInstall.validate({
+      onStart: () => this._onStart(dolphinType),
       onProgress: (current, total) => this._onProgress(dolphinType, current, total),
       onComplete: () =>
         dolphinInstall.getDolphinVersion().then((version) => {
@@ -174,6 +175,7 @@ export class DolphinManager {
     }
 
     const installation = this.getInstallation(launchType);
+    this._onStart(launchType);
     await installation.downloadAndInstall({
       cleanInstall,
       onProgress: (current, total) => this._onProgress(launchType, current, total),
@@ -204,6 +206,13 @@ export class DolphinManager {
     await installation.updateSettings({
       replayPath: this.settingsManager.getRootSlpPath(),
       useMonthlySubfolders: this.settingsManager.getUseMonthlySubfolders(),
+    });
+  }
+
+  private _onStart(dolphinType: DolphinLaunchType) {
+    this.eventSubject.next({
+      type: DolphinEventType.DOWNLOAD_START,
+      dolphinType,
     });
   }
 

--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -42,6 +42,7 @@ export interface PlayKey {
 
 export enum DolphinEventType {
   CLOSED = "CLOSED",
+  DOWNLOAD_START = "DOWNLOAD_START",
   DOWNLOAD_PROGRESS = "DOWNLOAD_PROGRESS",
   DOWNLOAD_COMPLETE = "DOWNLOAD_COMPLETE",
 }
@@ -57,6 +58,11 @@ export type DolphinPlaybackClosedEvent = {
   dolphinType: DolphinLaunchType.PLAYBACK;
   instanceId: string;
   exitCode: number | null;
+};
+
+export type DolphinDownloadStartEvent = {
+  type: DolphinEventType.DOWNLOAD_START;
+  dolphinType: DolphinLaunchType;
 };
 
 export type DolphinDownloadProgressEvent = {
@@ -76,6 +82,7 @@ export type DolphinDownloadCompleteEvent = {
 
 export type DolphinEventMap = {
   [DolphinEventType.CLOSED]: DolphinNetplayClosedEvent | DolphinPlaybackClosedEvent;
+  [DolphinEventType.DOWNLOAD_START]: DolphinDownloadStartEvent;
   [DolphinEventType.DOWNLOAD_PROGRESS]: DolphinDownloadProgressEvent;
   [DolphinEventType.DOWNLOAD_COMPLETE]: DolphinDownloadCompleteEvent;
 };

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -3,10 +3,14 @@ import { slippiDonateUrl, socials } from "@common/constants";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import TwitterIcon from "@mui/icons-material/Twitter";
+import { Button } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import React from "react";
 
 import { ExternalLink as A } from "@/components/ExternalLink";
+import { useDolphinActions } from "@/lib/dolphin/useDolphinActions";
+import { useAppUpdate } from "@/lib/hooks/useAppUpdate";
+import { useServices } from "@/services";
 import { ReactComponent as DiscordIcon } from "@/styles/images/discord.svg";
 
 export const BasicFooter = styled.div`
@@ -26,8 +30,29 @@ export const BasicFooter = styled.div`
 `;
 
 export const Footer: React.FC = () => {
+  const { dolphinService } = useServices();
+  const { checkForAppUpdates } = useAppUpdate();
+  const { updateDolphin } = useDolphinActions(dolphinService);
+  const checkForUpdatesHandler = React.useCallback(async () => {
+    void checkForAppUpdates();
+    void updateDolphin();
+  }, [checkForAppUpdates, updateDolphin]);
+
   return (
     <Outer>
+      <Button
+        css={css`
+          text-transform: uppercase;
+          font-weight: bold;
+          font-size: 12px;
+          margin-right: auto;
+          justify-content: flex-start;
+          color: ${colors.purpleLight};
+        `}
+        onClick={checkForUpdatesHandler}
+      >
+        Check for updates
+      </Button>
       <Social title="Follow Project Slippi on Twitter" url={`https://twitter.com/${socials.twitterId}`}>
         <TwitterIcon />
       </Social>

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -3,15 +3,10 @@ import { slippiDonateUrl, socials } from "@common/constants";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import TwitterIcon from "@mui/icons-material/Twitter";
-import { Button } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import React from "react";
 
 import { ExternalLink as A } from "@/components/ExternalLink";
-import { useDolphinActions } from "@/lib/dolphin/useDolphinActions";
-import { useAppUpdate } from "@/lib/hooks/useAppUpdate";
-import { useToasts } from "@/lib/hooks/useToasts";
-import { useServices } from "@/services";
 import { ReactComponent as DiscordIcon } from "@/styles/images/discord.svg";
 
 export const BasicFooter = styled.div`
@@ -31,40 +26,8 @@ export const BasicFooter = styled.div`
 `;
 
 export const Footer: React.FC = () => {
-  const { showInfo, showError } = useToasts();
-  const { dolphinService } = useServices();
-  const { checkForAppUpdates } = useAppUpdate();
-  const { updateDolphin } = useDolphinActions(dolphinService);
-  const [checkingForUpdates, setCheckingForUpdates] = React.useState(false);
-  const checkForUpdatesHandler = React.useCallback(async () => {
-    setCheckingForUpdates(true);
-    try {
-      showInfo("Checking for updates...");
-      await checkForAppUpdates();
-      await updateDolphin();
-    } catch (err) {
-      window.electron.log.error(err);
-      showError("Failed to get updates");
-    }
-    setTimeout(() => setCheckingForUpdates(false), 10000);
-  }, [checkForAppUpdates, updateDolphin, showInfo, showError]);
-
   return (
     <Outer>
-      <Button
-        css={css`
-          text-transform: uppercase;
-          font-weight: bold;
-          font-size: 12px;
-          margin-right: auto;
-          justify-content: flex-start;
-          color: ${colors.purpleLight};
-        `}
-        onClick={checkForUpdatesHandler}
-        disabled={checkingForUpdates}
-      >
-        Check for updates
-      </Button>
       <Social title="Follow Project Slippi on Twitter" url={`https://twitter.com/${socials.twitterId}`}>
         <TwitterIcon />
       </Social>

--- a/src/renderer/components/PersistentNotification.tsx
+++ b/src/renderer/components/PersistentNotification.tsx
@@ -5,13 +5,13 @@ import ButtonBase from "@mui/material/ButtonBase";
 import React from "react";
 
 import { useAppStore } from "@/lib/hooks/useApp";
-import { useInstallAppUpdate } from "@/lib/hooks/useInstallAppUpdate";
+import { useAppUpdate } from "@/lib/hooks/useAppUpdate";
 
 export const PersistentNotification: React.FC = () => {
   const updateVersion = useAppStore((store) => store.updateVersion);
   const updateReady = useAppStore((store) => store.updateReady);
 
-  const installAppUpdate = useInstallAppUpdate();
+  const { installAppUpdate } = useAppUpdate();
 
   if (!updateVersion || !updateReady) {
     return null;

--- a/src/renderer/components/PersistentNotification.tsx
+++ b/src/renderer/components/PersistentNotification.tsx
@@ -23,7 +23,7 @@ export const PersistentNotification: React.FC = () => {
             justify-content: center;
           `}
         >
-          Downloading Version {updateVersion}...
+          Downloading version {updateVersion}...
         </div>
       </Outer>
     );

--- a/src/renderer/components/PersistentNotification.tsx
+++ b/src/renderer/components/PersistentNotification.tsx
@@ -10,8 +10,24 @@ import { useAppUpdate } from "@/lib/hooks/useAppUpdate";
 export const PersistentNotification: React.FC = () => {
   const updateVersion = useAppStore((store) => store.updateVersion);
   const updateReady = useAppStore((store) => store.updateReady);
+  const updateDownloadProgress = useAppStore((store) => store.updateDownloadProgress);
 
   const { installAppUpdate } = useAppUpdate();
+
+  if (!updateReady && updateDownloadProgress) {
+    return (
+      <Outer>
+        <div
+          css={css`
+            display: flex;
+            justify-content: center;
+          `}
+        >
+          Downloading Version {updateVersion}...
+        </div>
+      </Outer>
+    );
+  }
 
   if (!updateVersion || !updateReady) {
     return null;

--- a/src/renderer/containers/Header/index.tsx
+++ b/src/renderer/containers/Header/index.tsx
@@ -6,6 +6,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
+import { debounce } from "lodash";
 import React, { useCallback, useMemo } from "react";
 
 import { PlayButton, UpdatingButton } from "@/components/play_button/PlayButton";
@@ -53,7 +54,7 @@ export const Header: React.FC<HeaderProps> = ({ menuItems }) => {
   const { checkForAppUpdates } = useAppUpdate();
   const [checkingForUpdates, setCheckingForUpdates] = React.useState(false);
 
-  const checkForUpdatesHandler = React.useCallback(async () => {
+  const checkForUpdates = React.useCallback(async () => {
     setCheckingForUpdates(true);
     try {
       showInfo("Checking for updates...");
@@ -62,9 +63,12 @@ export const Header: React.FC<HeaderProps> = ({ menuItems }) => {
     } catch (err) {
       window.electron.log.error(err);
       showError("Failed to get updates");
+    } finally {
+      setCheckingForUpdates(false);
     }
-    setTimeout(() => setCheckingForUpdates(false), 10000);
   }, [checkForAppUpdates, updateDolphin, showInfo, showError]);
+
+  const checkForUpdatesHandler = debounce(checkForUpdates, 500);
 
   const onPlay = useCallback(
     async (offlineOnly?: boolean) => {

--- a/src/renderer/lib/dolphin/useDolphinActions.ts
+++ b/src/renderer/lib/dolphin/useDolphinActions.ts
@@ -23,6 +23,21 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
     [netplayStatus, playbackStatus],
   );
 
+  const updateDolphin = useCallback(async () => {
+    [DolphinLaunchType.NETPLAY, DolphinLaunchType.PLAYBACK].map(async (dolphinType) => {
+      if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
+        return;
+      }
+      return dolphinService.downloadDolphin(dolphinType).catch((err) => {
+        showError(
+          `Failed to install ${dolphinType} Dolphin. Try closing all Dolphin instances and restarting the launcher. Error: ${
+            err instanceof Error ? err.message : JSON.stringify(err)
+          }`,
+        );
+      });
+    });
+  }, [getInstallStatus, dolphinService, showError]);
+
   const openConfigureDolphin = useCallback(
     (dolphinType: DolphinLaunchType) => {
       if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
@@ -110,5 +125,6 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
     launchNetplay,
     viewReplays,
     importDolphin,
+    updateDolphin,
   };
 };

--- a/src/renderer/lib/dolphin/useDolphinActions.ts
+++ b/src/renderer/lib/dolphin/useDolphinActions.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 
 import { useToasts } from "@/lib/hooks/useToasts";
 
-import { DolphinStatus, setDolphinOpened, useDolphinStore } from "./useDolphinStore";
+import { DolphinStatus, setDolphinOpened, setDolphinStatus, useDolphinStore } from "./useDolphinStore";
 
 export const useDolphinActions = (dolphinService: DolphinService) => {
   const { showError, showSuccess } = useToasts();
@@ -29,6 +29,7 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
         if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
           return;
         }
+        setDolphinStatus(dolphinType, DolphinStatus.DOWNLOADING);
         return dolphinService.downloadDolphin(dolphinType).catch((err) => {
           showError(
             `Failed to install ${dolphinType} Dolphin. Try closing all Dolphin instances and restarting the launcher. Error: ${

--- a/src/renderer/lib/dolphin/useDolphinActions.ts
+++ b/src/renderer/lib/dolphin/useDolphinActions.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 
 import { useToasts } from "@/lib/hooks/useToasts";
 
-import { DolphinStatus, setDolphinOpened, setDolphinStatus, useDolphinStore } from "./useDolphinStore";
+import { DolphinStatus, setDolphinOpened, useDolphinStore } from "./useDolphinStore";
 
 export const useDolphinActions = (dolphinService: DolphinService) => {
   const { showError, showSuccess } = useToasts();
@@ -29,7 +29,6 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
         if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
           return;
         }
-        setDolphinStatus(dolphinType, DolphinStatus.DOWNLOADING);
         return dolphinService.downloadDolphin(dolphinType).catch((err) => {
           showError(
             `Failed to install ${dolphinType} Dolphin. Try closing all Dolphin instances and restarting the launcher. Error: ${

--- a/src/renderer/lib/dolphin/useDolphinActions.ts
+++ b/src/renderer/lib/dolphin/useDolphinActions.ts
@@ -24,18 +24,20 @@ export const useDolphinActions = (dolphinService: DolphinService) => {
   );
 
   const updateDolphin = useCallback(async () => {
-    [DolphinLaunchType.NETPLAY, DolphinLaunchType.PLAYBACK].map(async (dolphinType) => {
-      if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
-        return;
-      }
-      return dolphinService.downloadDolphin(dolphinType).catch((err) => {
-        showError(
-          `Failed to install ${dolphinType} Dolphin. Try closing all Dolphin instances and restarting the launcher. Error: ${
-            err instanceof Error ? err.message : JSON.stringify(err)
-          }`,
-        );
-      });
-    });
+    return Promise.all(
+      [DolphinLaunchType.NETPLAY, DolphinLaunchType.PLAYBACK].map(async (dolphinType) => {
+        if (getInstallStatus(dolphinType) !== DolphinStatus.READY) {
+          return;
+        }
+        return dolphinService.downloadDolphin(dolphinType).catch((err) => {
+          showError(
+            `Failed to install ${dolphinType} Dolphin. Try closing all Dolphin instances and restarting the launcher. Error: ${
+              err instanceof Error ? err.message : JSON.stringify(err)
+            }`,
+          );
+        });
+      }),
+    );
   }, [getInstallStatus, dolphinService, showError]);
 
   const openConfigureDolphin = useCallback(

--- a/src/renderer/lib/dolphin/useDolphinListeners.ts
+++ b/src/renderer/lib/dolphin/useDolphinListeners.ts
@@ -13,8 +13,8 @@ import { useToasts } from "@/lib/hooks/useToasts";
 import { handleDolphinExitCode } from "./handleDolphinExitCode";
 import {
   DolphinStatus,
-  setDolphinComplete,
   setDolphinOpened,
+  setDolphinStatus,
   setDolphinVersion,
   updateNetplayDownloadProgress,
 } from "./useDolphinStore";
@@ -42,7 +42,7 @@ export const useDolphinListeners = (dolphinService: DolphinService) => {
   }, []);
 
   const dolphinCompleteHandler = useCallback((event: DolphinDownloadCompleteEvent) => {
-    setDolphinComplete(event.dolphinType, DolphinStatus.READY);
+    setDolphinStatus(event.dolphinType, DolphinStatus.READY);
     setDolphinVersion(event.dolphinVersion, event.dolphinType);
   }, []);
 

--- a/src/renderer/lib/dolphin/useDolphinListeners.ts
+++ b/src/renderer/lib/dolphin/useDolphinListeners.ts
@@ -1,6 +1,7 @@
 import type {
   DolphinDownloadCompleteEvent,
   DolphinDownloadProgressEvent,
+  DolphinDownloadStartEvent,
   DolphinNetplayClosedEvent,
   DolphinPlaybackClosedEvent,
   DolphinService,
@@ -46,14 +47,25 @@ export const useDolphinListeners = (dolphinService: DolphinService) => {
     setDolphinVersion(event.dolphinVersion, event.dolphinType);
   }, []);
 
+  const dolphinDownloadStartHandler = useCallback((event: DolphinDownloadStartEvent) => {
+    setDolphinStatus(event.dolphinType, DolphinStatus.DOWNLOADING);
+  }, []);
+
   useEffect(() => {
     const subs: Array<() => void> = [];
     subs.push(dolphinService.onEvent(DolphinEventType.CLOSED, dolphinClosedHandler));
+    subs.push(dolphinService.onEvent(DolphinEventType.DOWNLOAD_START, dolphinDownloadStartHandler));
     subs.push(dolphinService.onEvent(DolphinEventType.DOWNLOAD_PROGRESS, dolphinProgressHandler));
     subs.push(dolphinService.onEvent(DolphinEventType.DOWNLOAD_COMPLETE, dolphinCompleteHandler));
 
     return () => {
       subs.forEach((unsub) => unsub());
     };
-  }, [dolphinService, dolphinClosedHandler, dolphinProgressHandler, dolphinCompleteHandler]);
+  }, [
+    dolphinService,
+    dolphinClosedHandler,
+    dolphinProgressHandler,
+    dolphinCompleteHandler,
+    dolphinDownloadStartHandler,
+  ]);
 };

--- a/src/renderer/lib/dolphin/useDolphinStore.ts
+++ b/src/renderer/lib/dolphin/useDolphinStore.ts
@@ -29,7 +29,7 @@ export const setDolphinOpened = (dolphinType: DolphinLaunchType, isOpened = true
   }
 };
 
-export const setDolphinComplete = (dolphinType: DolphinLaunchType, status: DolphinStatus) => {
+export const setDolphinStatus = (dolphinType: DolphinLaunchType, status: DolphinStatus) => {
   switch (dolphinType) {
     case DolphinLaunchType.NETPLAY:
       useDolphinStore.setState({ netplayStatus: status });

--- a/src/renderer/lib/hooks/useAppUpdate.ts
+++ b/src/renderer/lib/hooks/useAppUpdate.ts
@@ -1,7 +1,15 @@
 import { useToasts } from "@/lib/hooks/useToasts";
 
-export const useInstallAppUpdate = () => {
+export const useAppUpdate = () => {
   const { showError } = useToasts();
+
+  const checkForAppUpdates = async () => {
+    try {
+      await window.electron.common.checkForAppUpdates();
+    } catch (err) {
+      showError(err);
+    }
+  };
 
   const installAppUpdate = async () => {
     try {
@@ -11,7 +19,8 @@ export const useInstallAppUpdate = () => {
     }
   };
 
-  return () => {
-    void installAppUpdate();
+  return {
+    checkForAppUpdates,
+    installAppUpdate,
   };
 };

--- a/src/renderer/lib/hooks/useAppUpdate.ts
+++ b/src/renderer/lib/hooks/useAppUpdate.ts
@@ -1,23 +1,25 @@
+import React from "react";
+
 import { useToasts } from "@/lib/hooks/useToasts";
 
 export const useAppUpdate = () => {
   const { showError } = useToasts();
 
-  const checkForAppUpdates = async () => {
+  const checkForAppUpdates = React.useCallback(async () => {
     try {
       await window.electron.common.checkForAppUpdates();
     } catch (err) {
       showError(err);
     }
-  };
+  }, [showError]);
 
-  const installAppUpdate = async () => {
+  const installAppUpdate = React.useCallback(async () => {
     try {
       await window.electron.common.installAppUpdate();
     } catch (err) {
       showError(err);
     }
-  };
+  }, [showError]);
 
   return {
     checkForAppUpdates,


### PR DESCRIPTION
The slippi logo in the top right is repurposed to be a check for updates button. failures during an update aren't handled atm.

![image](https://user-images.githubusercontent.com/6331403/210948114-6cdc1966-09af-4f81-aa14-c39094a5e82a.png)

