### PR TITLE
fix: extend SLP directory path validation to be more robust

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -6,7 +6,7 @@ import settingsApi from "@settings/api";
 import { clipboard, contextBridge, shell } from "electron";
 import log from "electron-log";
 import path from "path";
-import isSubdirectory from "utils/isSubdirectory";
+import { isSubdirectory } from "utils/isSubdirectory";
 
 import commonApi from "./api";
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -6,6 +6,7 @@ import settingsApi from "@settings/api";
 import { clipboard, contextBridge, shell } from "electron";
 import log from "electron-log";
 import path from "path";
+import isSubdirectory from "utils/isSubdirectory";
 
 import commonApi from "./api";
 
@@ -16,10 +17,11 @@ const api = {
   broadcast: broadcastApi,
   dolphin: dolphinApi,
   replays: replaysApi,
+  utils: {
+    isSubdirectory,
+  },
   path: {
     join: path.join,
-    isAbsolute: path.isAbsolute,
-    relative: path.relative,
   },
   clipboard: {
     writeText: clipboard.writeText,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -18,6 +18,8 @@ const api = {
   replays: replaysApi,
   path: {
     join: path.join,
+    isAbsolute: path.isAbsolute,
+    relative: path.relative,
   },
   clipboard: {
     writeText: clipboard.writeText,

--- a/src/renderer/components/MultiPathInput.tsx
+++ b/src/renderer/components/MultiPathInput.tsx
@@ -8,7 +8,7 @@ import React, { useState } from "react";
 import { useSettings } from "@/lib/hooks/useSettings";
 import { useToasts } from "@/lib/hooks/useToasts";
 
-const utils = window.electron.utils;
+const { isSubdirectory } = window.electron.utils;
 
 export interface MultiPathInputProps {
   updatePaths: (paths: string[]) => void;

--- a/src/renderer/components/MultiPathInput.tsx
+++ b/src/renderer/components/MultiPathInput.tsx
@@ -7,7 +7,8 @@ import React, { useState } from "react";
 
 import { useSettings } from "@/lib/hooks/useSettings";
 import { useToasts } from "@/lib/hooks/useToasts";
-import { isSubdirectory } from "@/lib/utils";
+
+const utils = window.electron.utils;
 
 export interface MultiPathInputProps {
   updatePaths: (paths: string[]) => void;
@@ -28,7 +29,7 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
       return false;
     }
 
-    if (isSubdirectory(rootFolder, newPath)) {
+    if (utils.isSubdirectory(rootFolder, newPath)) {
       addErrorToast("Cannot add sub directories of the Root SLP Directory.");
       return false;
     }
@@ -36,10 +37,10 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
     let pathsToCheck = paths;
     for (let i = 0; i < pathsToCheck.length; i++) {
       const path = pathsToCheck[i];
-      if (isSubdirectory(path, newPath)) {
+      if (utils.isSubdirectory(path, newPath)) {
         addErrorToast("Cannot add sub directories of the Root SLP Directory.");
         return false;
-      } else if (isSubdirectory(newPath, path)) {
+      } else if (utils.isSubdirectory(newPath, path)) {
         updatePaths(pathsToCheck.splice(i, 1));
         pathsToCheck = pathsToCheck.splice(i--, 1); //decrement i because we are dropping an entry
       }

--- a/src/renderer/components/MultiPathInput.tsx
+++ b/src/renderer/components/MultiPathInput.tsx
@@ -29,7 +29,7 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
       return false;
     }
 
-    if (utils.isSubdirectory(rootFolder, newPath)) {
+    if (isSubdirectory(rootFolder, newPath)) {
       addErrorToast("Cannot add sub directories of the Root SLP Directory.");
       return false;
     }
@@ -37,10 +37,10 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
     let pathsToCheck = paths;
     for (let i = 0; i < pathsToCheck.length; i++) {
       const path = pathsToCheck[i];
-      if (utils.isSubdirectory(path, newPath)) {
+      if (isSubdirectory(path, newPath)) {
         addErrorToast("Cannot add sub directories of the Root SLP Directory.");
         return false;
-      } else if (utils.isSubdirectory(newPath, path)) {
+      } else if (isSubdirectory(newPath, path)) {
         updatePaths(pathsToCheck.splice(i, 1));
         pathsToCheck = pathsToCheck.splice(i--, 1); //decrement i because we are dropping an entry
       }

--- a/src/renderer/components/MultiPathInput.tsx
+++ b/src/renderer/components/MultiPathInput.tsx
@@ -7,7 +7,7 @@ import React, { useState } from "react";
 
 import { useSettings } from "@/lib/hooks/useSettings";
 import { useToasts } from "@/lib/hooks/useToasts";
-import { isSubdir } from "@/lib/utils";
+import { isSubdirectory } from "@/lib/utils";
 
 export interface MultiPathInputProps {
   updatePaths: (paths: string[]) => void;
@@ -28,7 +28,7 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
       return false;
     }
 
-    if (isSubdir(rootFolder, newPath)) {
+    if (isSubdirectory(rootFolder, newPath)) {
       addErrorToast("Cannot add sub directories of the Root SLP Directory.");
       return false;
     }
@@ -36,10 +36,10 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
     let pathsToCheck = paths;
     for (let i = 0; i < pathsToCheck.length; i++) {
       const path = pathsToCheck[i];
-      if (isSubdir(path, newPath)) {
+      if (isSubdirectory(path, newPath)) {
         addErrorToast("Cannot add sub directories of the Root SLP Directory.");
         return false;
-      } else if (isSubdir(newPath, path)) {
+      } else if (isSubdirectory(newPath, path)) {
         updatePaths(pathsToCheck.splice(i, 1));
         pathsToCheck = pathsToCheck.splice(i--, 1); //decrement i because we are dropping an entry
       }

--- a/src/renderer/components/MultiPathInput.tsx
+++ b/src/renderer/components/MultiPathInput.tsx
@@ -7,6 +7,7 @@ import React, { useState } from "react";
 
 import { useSettings } from "@/lib/hooks/useSettings";
 import { useToasts } from "@/lib/hooks/useToasts";
+import { isSubdir } from "@/lib/utils";
 
 export interface MultiPathInputProps {
   updatePaths: (paths: string[]) => void;
@@ -27,7 +28,7 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
       return false;
     }
 
-    if (newPath.includes(rootFolder)) {
+    if (isSubdir(rootFolder, newPath)) {
       addErrorToast("Cannot add sub directories of the Root SLP Directory.");
       return false;
     }
@@ -35,10 +36,10 @@ export const MultiPathInput: React.FC<MultiPathInputProps> = ({ paths, updatePat
     let pathsToCheck = paths;
     for (let i = 0; i < pathsToCheck.length; i++) {
       const path = pathsToCheck[i];
-      if (newPath.includes(path)) {
+      if (isSubdir(path, newPath)) {
         addErrorToast("Cannot add sub directories of the Root SLP Directory.");
         return false;
-      } else if (path.includes(newPath)) {
+      } else if (isSubdir(newPath, path)) {
         updatePaths(pathsToCheck.splice(i, 1));
         pathsToCheck = pathsToCheck.splice(i--, 1); //decrement i because we are dropping an entry
       }

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -63,11 +63,9 @@ export const humanReadableBytes = (bytes: number): string => {
   return `0 ${sizes[0]}`;
 };
 
-export const isSubdir = (parentPath: string, dirPath: string) => {
-  const relativePath = path.relative(parentPath, dirPath);
-  return (
-    relativePath && // value is "" when paths are identical
-    !relativePath.startsWith("..") &&
-    !path.isAbsolute(relativePath) // covers case where different drives are used e.g. 'C:\\A' vs 'D:\\A\\B'
-  );
+export const isSubdirectory = (parentPath: string, dirPath: string) => {
+  const relativePath = path.relative(parentPath, dirPath); // value is "" when paths are identical
+
+  // the absolute path condition covers the case where different drives are used e.g. 'C:\\A' vs 'D:\\A\\B'
+  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
 };

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -5,8 +5,6 @@ import unknownCharacterIcon from "@/styles/images/unknown.png";
 const characterIcons = require.context("../styles/images/characters", true);
 const stageIcons = require.context("../styles/images/stages");
 
-const path = window.electron.path;
-
 export const getCharacterIcon = (characterId: number | null, characterColor: number | null = 0): string => {
   if (characterId !== null) {
     const characterInfo = charUtils.getCharacterInfo(characterId);
@@ -62,11 +60,4 @@ export const humanReadableBytes = (bytes: number): string => {
   }
 
   return `0 ${sizes[0]}`;
-};
-
-export const isSubdirectory = (parentPath: string, dirPath: string) => {
-  const relativePath = path.relative(parentPath, dirPath); // value is "" when paths are identical
-
-  // the absolute path condition covers the case where different drives are used e.g. 'C:\\A' vs 'D:\\A\\B'
-  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
 };

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -1,4 +1,5 @@
 import { characters as charUtils, stages as stageUtils } from "@slippi/slippi-js";
+import path from "path";
 
 import unknownCharacterIcon from "@/styles/images/unknown.png";
 
@@ -60,4 +61,13 @@ export const humanReadableBytes = (bytes: number): string => {
   }
 
   return `0 ${sizes[0]}`;
+};
+
+export const isSubdir = (parentPath: string, dirPath: string) => {
+  const relativePath = path.relative(parentPath, dirPath);
+  return (
+    relativePath && // value is "" when paths are identical
+    !relativePath.startsWith("..") &&
+    !path.isAbsolute(relativePath) // covers case where different drives are used e.g. 'C:\\A' vs 'D:\\A\\B'
+  );
 };

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -1,10 +1,11 @@
 import { characters as charUtils, stages as stageUtils } from "@slippi/slippi-js";
-import path from "path";
 
 import unknownCharacterIcon from "@/styles/images/unknown.png";
 
 const characterIcons = require.context("../styles/images/characters", true);
 const stageIcons = require.context("../styles/images/stages");
+
+const path = window.electron.path;
 
 export const getCharacterIcon = (characterId: number | null, characterColor: number | null = 0): string => {
   if (characterId !== null) {

--- a/src/replays/folderTreeService.ts
+++ b/src/replays/folderTreeService.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra";
 import path from "path";
-import isSubdirectory from "utils/isSubdirectory";
+import { isSubdirectory } from "utils/isSubdirectory";
 
 import type { FolderResult } from "./types";
 

--- a/src/replays/folderTreeService.ts
+++ b/src/replays/folderTreeService.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra";
 import path from "path";
+import isSubdirectory from "utils/isSubdirectory";
 
 import type { FolderResult } from "./types";
 
@@ -71,10 +72,3 @@ export async function generateSubFolderTree(folder: string): Promise<FolderResul
 
   return Promise.all(subdirectories);
 }
-
-// Taken from: https://stackoverflow.com/questions/37521893/determine-if-a-path-is-subdirectory-of-another-in-node-js
-const isSubdirectory = (parent: string, dir: string): boolean => {
-  const relative = path.relative(parent, dir);
-  const isSubdir = Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
-  return isSubdir;
-};

--- a/src/utils/isSubdirectory.ts
+++ b/src/utils/isSubdirectory.ts
@@ -1,0 +1,10 @@
+import path from "path";
+
+// Taken from: https://stackoverflow.com/questions/37521893/determine-if-a-path-is-subdirectory-of-another-in-node-js
+const isSubdirectory = (parent: string, dir: string): boolean => {
+  const relative = path.relative(parent, dir);
+  const isSubdir = Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+  return isSubdir;
+};
+
+export default isSubdirectory;

--- a/src/utils/isSubdirectory.ts
+++ b/src/utils/isSubdirectory.ts
@@ -6,4 +6,3 @@ export const isSubdirectory = (parent: string, dir: string): boolean => {
   const isSubdir = Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
   return isSubdir;
 };
-

--- a/src/utils/isSubdirectory.ts
+++ b/src/utils/isSubdirectory.ts
@@ -1,10 +1,9 @@
 import path from "path";
 
 // Taken from: https://stackoverflow.com/questions/37521893/determine-if-a-path-is-subdirectory-of-another-in-node-js
-const isSubdirectory = (parent: string, dir: string): boolean => {
+export const isSubdirectory = (parent: string, dir: string): boolean => {
   const relative = path.relative(parent, dir);
   const isSubdir = Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
   return isSubdir;
 };
 
-export default isSubdirectory;


### PR DESCRIPTION
Resolves #359

### Description

Previously, attempting to add an additional SLP directory that:
1. was adjacent to the root SLP directory
2. in its name, contained a substring of the root SLP directory name

...would result in a `Cannot add sub directories of the Root SLP Directory` error. 

e.g.
Root = `C:\Users\Nikki\Documents\Slippi`
Adding `C:\Users\Nikki\Documents\Slippi Test` causes an error.

This was occurring because the previous SLP directory path validation used [`includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) to check whether the new path was a subdirectory of the root path.

This PR fixes the issue by leveraging an existing utils function that checks whether a folder is a subdirectory of another.

<img width="348" alt="Screen Shot 2022-12-26 at 6 52 22 AM" src="https://user-images.githubusercontent.com/40980993/209567732-f36166a2-b294-4ead-a807-33b0233d6b41.png">

### Testing


- Create a directory adjacent to the root SLP directory and name it such that it contains a substring of the root SLP directory name (e.g. "Slippi Test" if your root directory is "Slippi")
- Add the directory as an additional SLP directory via Slippi
  - [ ] Verify that no error is displayed and the directory is added successfully
- After adding the directory, create a child directory inside of it and try adding the child as an additional SLP directory
  - [ ] Verify that an error is displayed and the directory is not added
- Remove the parent directory via Slippi
- Add the child directory as an additional SLP directory via Slippi
  - [ ] Verify that no error is displayed and the directory is added successfully
- Add the parent directory as an additional SLP directory via Slippi
  - [ ] Verify that the displayed path changes from the child path to the parent path 

