### PR TITLE
Prevent Electron window title changes resulting from navigation.

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -118,6 +118,11 @@ const createWindow = async () => {
     mainWindow = null;
   });
 
+  mainWindow.on("page-title-updated", (event) => {
+    // Always keep the initial window title
+    event.preventDefault();
+  });
+
   const menuBuilder = new MenuBuilder({
     mainWindow,
     onOpenPreferences: () => {


### PR DESCRIPTION
Fixes #366.

This is one of the ways to fix this, there are others that may be preferable (such as doing `preventDefault` on title changes in the main process). If you'd like a different approach (or to pull this title from the product name during the webpack build or something), let me know, happy to change it!