### PR TITLE
Fix empty player names in replay browser

### DIFF
--- a/src/renderer/containers/ReplayBrowser/replay_file/ReplayFile.container.tsx
+++ b/src/renderer/containers/ReplayBrowser/replay_file/ReplayFile.container.tsx
@@ -114,7 +114,7 @@ export const ReplayFileContainer = React.memo(function ReplayFileContainer({
             port: player.port,
             teamId: teamId ?? undefined,
             variant: names.code ? "code" : "tag",
-            text: names.code ?? (names.tag || backupName),
+            text: names.code || names.tag || backupName,
             isWinner,
           };
         });

--- a/src/renderer/lib/matchNames.ts
+++ b/src/renderer/lib/matchNames.ts
@@ -2,9 +2,9 @@ import type { GameStartType, MetadataType } from "@slippi/slippi-js";
 import get from "lodash/get";
 
 export interface PlayerNames {
-  name: string | null;
-  code: string | null;
-  tag: string | null;
+  name: string;
+  code: string;
+  tag: string;
 }
 
 export function extractPlayerNames(
@@ -13,15 +13,18 @@ export function extractPlayerNames(
   metadata?: MetadataType | null,
 ): PlayerNames {
   const result: PlayerNames = {
-    name: null,
-    code: null,
-    tag: null,
+    name: "",
+    code: "",
+    tag: "",
   };
 
   const player = settings.players.find((player) => player.playerIndex === index);
-  result.tag = player?.nametag || null;
-  result.name = player?.displayName || get(metadata, ["players", index, "names", "netplay"], null);
-  result.code = player?.connectCode || get(metadata, ["players", index, "names", "code"], null);
+  if (player) {
+    result.tag = player.nametag ?? "";
+    result.name = player.displayName || get(metadata, ["players", index, "names", "netplay"], "");
+    result.code = player.connectCode || get(metadata, ["players", index, "names", "code"], "");
+  }
+
   return result;
 }
 

--- a/src/renderer/lib/matchNames.ts
+++ b/src/renderer/lib/matchNames.ts
@@ -19,11 +19,9 @@ export function extractPlayerNames(
   };
 
   const player = settings.players.find((player) => player.playerIndex === index);
-  if (player) {
-    result.tag = player.nametag ?? "";
-    result.name = player.displayName || get(metadata, ["players", index, "names", "netplay"], "");
-    result.code = player.connectCode || get(metadata, ["players", index, "names", "code"], "");
-  }
+  result.tag = player?.nametag ?? "";
+  result.name = player?.displayName || get(metadata, ["players", index, "names", "netplay"], "");
+  result.code = player?.connectCode || get(metadata, ["players", index, "names", "code"], "");
 
   return result;
 }


### PR DESCRIPTION
### Description

This PR fixes the issue where some replays will show up with empty names. This is because in some cases, we check against null instead of an empty string `''`.

Solution: We return empty string by default instead of null when extracting player names.


### Screenshots

#### Before

![Screenshot 2023-05-26 at 17 18 22](https://github.com/project-slippi/slippi-launcher/assets/8384734/2c43d571-e34b-46a0-b325-ed89ff996bc8)


#### After

![Screenshot 2023-05-26 at 17 18 01](https://github.com/project-slippi/slippi-launcher/assets/8384734/3fd139a6-f7ed-40b5-b25b-c843661cce59)
