### PR TITLE
fix: don't update settings from playback dolphin and check if update is necessary

### DIFF
--- a/src/dolphin/config/config.ts
+++ b/src/dolphin/config/config.ts
@@ -36,9 +36,9 @@ export async function setSlippiSettings(iniFile: IniFile, options: Partial<Synce
 
 export async function getSlippiSettings(iniFile: IniFile): Promise<SyncedDolphinSettings> {
   const coreSection = iniFile.getOrCreateSection("Core");
+
   const useMonthlySubfolders = coreSection.get("SlippiReplayMonthFolders", "False") === "True";
   const replayPath = coreSection.get("SlippiReplayDir", defaultAppSettings.settings.rootSlpPath);
-
   const enableJukebox = coreSection.get("SlippiJukeboxEnabled", "True") === "True";
 
   return { useMonthlySubfolders, replayPath, enableJukebox };

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -217,9 +217,28 @@ export class DolphinManager {
     const installation = this.getInstallation(launchType);
     const newSettings = await installation.getSettings();
 
-    await this.settingsManager.setRootSlpPath(path.normalize(newSettings.replayPath));
-    await this.settingsManager.setUseMonthlySubfolders(newSettings.useMonthlySubfolders);
-    await this.settingsManager.setEnableJukebox(newSettings.enableJukebox);
+    await this._updateLauncherSetting(
+      this.settingsManager.getRootSlpPath(),
+      path.normalize(newSettings.replayPath),
+      this.settingsManager.setRootSlpPath,
+    );
+    await this._updateLauncherSetting(
+      this.settingsManager.getUseMonthlySubfolders(),
+      newSettings.useMonthlySubfolders,
+      this.settingsManager.setUseMonthlySubfolders,
+    );
+    await this._updateLauncherSetting(
+      this.settingsManager.get().settings.enableJukebox,
+      newSettings.enableJukebox,
+      this.settingsManager.setEnableJukebox,
+    );
+  }
+
+  private async _updateLauncherSetting<T>(currentVal: T, newVal: T, update: (val: T) => Promise<void>) {
+    if (currentVal === newVal) {
+      return;
+    }
+    await update(newVal);
   }
 
   private _onStart(dolphinType: DolphinLaunchType) {

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -217,7 +217,7 @@ export class DolphinManager {
     const installation = this.getInstallation(launchType);
     const newSettings = await installation.getSettings();
 
-    await this.settingsManager.setRootSlpPath(newSettings.replayPath);
+    await this.settingsManager.setRootSlpPath(path.normalize(newSettings.replayPath));
     await this.settingsManager.setUseMonthlySubfolders(newSettings.useMonthlySubfolders);
     await this.settingsManager.setEnableJukebox(newSettings.enableJukebox);
   }

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -57,7 +57,6 @@ export class DolphinManager {
     if (!playbackInstance) {
       playbackInstance = new PlaybackDolphinInstance(dolphinPath, meleeIsoPath);
       playbackInstance.on("close", async (exitCode) => {
-        await this._updateLauncherSettings(DolphinLaunchType.PLAYBACK);
         this.eventSubject.next({
           type: DolphinEventType.CLOSED,
           instanceId: id,
@@ -123,7 +122,9 @@ export class DolphinManager {
       const instance = new DolphinInstance(dolphinPath);
       this.netplayDolphinInstance = instance;
       instance.on("close", async (exitCode) => {
-        await this._updateLauncherSettings(launchType);
+        if (launchType === DolphinLaunchType.NETPLAY) {
+          await this._updateLauncherSettings(launchType);
+        }
         this.eventSubject.next({
           type: DolphinEventType.CLOSED,
           dolphinType: DolphinLaunchType.NETPLAY,


### PR DESCRIPTION
i've removed syncing settings from the playback dolphin because i realized it is unnecessary which immediately fixes the issue when closing dolphin