### PR TITLE
ci: fix windows code signing

### DIFF
--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -11,11 +11,17 @@ exports.default = async (config) => {
   const CODESIGNTOOL_PATH = process.env.CODESIGNTOOL_PATH;
   const fileToSign = config.path ? String(config.path) : "";
 
+  if (!ES_USERNAME) {
+    // we're probably not trying to sign if this isn't set so just exit safely
+    console.log("not signing binaries");
+    return;
+  }
+
   if (process.platform !== "win32") {
     throw new Error(`unexpected platform: ${process.platform}`);
   }
 
-  if ([ES_CREDENTIAL_ID, ES_USERNAME, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)) {
+  if ([ES_CREDENTIAL_ID, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)) {
     throw new Error("missing required secrets");
   }
 

--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -15,8 +15,7 @@ exports.default = async (config) => {
     process.platform !== "win32" ||
     [ES_CREDENTIAL_ID, ES_USERNAME, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)
   ) {
-    console.log("missing something");
-    return;
+    throw new Error("missing required secrets");
   }
 
   const output = execSync(

--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -11,10 +11,11 @@ exports.default = async (config) => {
   const CODESIGNTOOL_PATH = process.env.CODESIGNTOOL_PATH;
   const fileToSign = config.path ? String(config.path) : "";
 
-  if (
-    process.platform !== "win32" ||
-    [ES_CREDENTIAL_ID, ES_USERNAME, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)
-  ) {
+  if (process.platform !== "win32") {
+    throw new Error(`unexpected platform: ${process.platform}`);
+  }
+
+  if ([ES_CREDENTIAL_ID, ES_USERNAME, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)) {
     throw new Error("missing required secrets");
   }
 

--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -12,8 +12,7 @@ const CODESIGNTOOL_PATH = process.env.CODESIGNTOOL_PATH;
 exports.default = async (config) => {
   const fileToSign = config.path ? String(config.path) : "";
 
-  if (!ES_USERNAME) {
-    // we're probably not trying to sign if this isn't set so just exit safely
+  if (process.env.SKIP_CODE_SIGNING === "yes") {
     return;
   }
 
@@ -21,7 +20,7 @@ exports.default = async (config) => {
     throw new Error(`unexpected platform: ${process.platform}`);
   }
 
-  if ([ES_CREDENTIAL_ID, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)) {
+  if ([ES_USERNAME, ES_CREDENTIAL_ID, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)) {
     throw new Error("missing required secrets");
   }
 

--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// Custom Sign hook for use with electron-builder + SSL CodeSignTool
+
+const { execSync } = require("child_process");
+
+exports.default = async (config) => {
+  const ES_CREDENTIAL_ID = process.env.ES_CREDENTIAL_ID;
+  const ES_USERNAME = process.env.ES_USERNAME;
+  const ES_PASSWORD = process.env.ES_PASSWORD;
+  const ES_TOTP_SECRET = process.env.ES_TOTP_SECRET;
+  const CODESIGNTOOL_PATH = process.env.CODESIGNTOOL_PATH;
+  const fileToSign = config.path ? String(config.path) : "";
+
+  if (
+    process.platform !== "win32" ||
+    [ES_CREDENTIAL_ID, ES_USERNAME, ES_PASSWORD, ES_TOTP_SECRET, CODESIGNTOOL_PATH, fileToSign].some((v) => !v)
+  ) {
+    console.log("missing something");
+    return;
+  }
+
+  const output = execSync(
+    `CodeSignTool.bat sign -credential_id="${ES_CREDENTIAL_ID}" -username="${ES_USERNAME}" -password="${ES_PASSWORD}" -totp_secret="${ES_TOTP_SECRET}" -input_file_path="${fileToSign}" -override="true"`,
+    { cwd: CODESIGNTOOL_PATH },
+  )
+    .toString()
+    .trim();
+
+  if (!output.includes("Code signed successfully")) {
+    throw new Error(`Failed to sign file: ${output}`);
+  }
+};

--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -13,7 +13,6 @@ exports.default = async (config) => {
 
   if (!ES_USERNAME) {
     // we're probably not trying to sign if this isn't set so just exit safely
-    console.log("not signing binaries");
     return;
   }
 

--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -3,12 +3,13 @@
 
 const { execSync } = require("child_process");
 
+const ES_CREDENTIAL_ID = process.env.ES_CREDENTIAL_ID;
+const ES_USERNAME = process.env.ES_USERNAME;
+const ES_PASSWORD = process.env.ES_PASSWORD;
+const ES_TOTP_SECRET = process.env.ES_TOTP_SECRET;
+const CODESIGNTOOL_PATH = process.env.CODESIGNTOOL_PATH;
+
 exports.default = async (config) => {
-  const ES_CREDENTIAL_ID = process.env.ES_CREDENTIAL_ID;
-  const ES_USERNAME = process.env.ES_USERNAME;
-  const ES_PASSWORD = process.env.ES_PASSWORD;
-  const ES_TOTP_SECRET = process.env.ES_TOTP_SECRET;
-  const CODESIGNTOOL_PATH = process.env.CODESIGNTOOL_PATH;
   const fileToSign = config.path ? String(config.path) : "";
 
   if (!ES_USERNAME) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,9 @@ jobs:
         shell: bash
         run: |
           msg="$(git log -1 --no-merges --pretty=%B)"
-          if [[ ! $msg =~ "^release.*" ]]; then
+          if [[ ! $msg =~ "^release.*" ]];
+          then
+            echo "not a release, skipping code signing"
             exit 0;
           fi
           echo "ES_USERNAME=${{ secrets.ES_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         run: |
           msg="$(git log -1 --no-merges --pretty=%B)"
-          if [[ ! $msg =~ "^release.*" ]] then;
+          if [[ ! $msg =~ "^release.*" ]]; then
             exit 0;
           fi
           echo "ES_USERNAME=${{ secrets.ES_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,6 @@ jobs:
           echo ${{ secrets.ENVFILE }} > .env
           yarn run package
         env:
-          CI: true
           NODE_OPTIONS: "--max-old-space-size=8192"
           USE_HARD_LINKS: false # because of https://github.com/electron-userland/electron-builder/issues/3179
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
           if [[ ! $msg =~ "^release.*" ]];
           then
             echo "not a release, skipping code signing"
+            echo "SKIP_CODE_SIGNING=yes" >> $GITHUB_ENV
             exit 0;
           fi
           echo "ES_USERNAME=${{ secrets.ES_USERNAME }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,16 +35,16 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Node.js and yarn
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: cache
         with:
           path: node_modules
@@ -56,15 +56,44 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install
-      - name: Load Windows signing certificate and secret
-        if: matrix.os == 'windows-latest' && env.CERTIFICATE_WINDOWS_PASSWORD != null
+      
+      - name: Cache CodeSignTool
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./CodeSignTool/
+          key: ${{ runner.os }}-${{ secrets.CACHE_CONTROL }}
+      - name: Download CodeSignTool
+        env:
+          ES_USERNAME: ${{ secrets.ES_USERNAME }}
+        if: matrix.os == 'windows-latest' && env.ES_USERNAME != null
+        working-directory: ${{ github.workspace }}
+        shell: powershell
+        run: |
+          if (!(Test-Path ".\CodeSignTool\CodeSignTool.bat" -PathType Leaf)) { 
+            Invoke-WebRequest -Uri https://www.ssl.com/download/codesigntool-for-windows/ -UseBasicParsing -OutFile ".\CodeSignTool.zip"
+            7z x CodeSignTool.zip
+            Remove-Item CodeSignTool.zip
+            Get-ChildItem -Path . | Where-Object { $_.Name -like "CodeSignTool*" } | %{ Rename-Item -LiteralPath $_.FullName -NewName "CodeSignTool" }
+          }
+      - name: Load Windows signing secrets
+        env:
+          ES_USERNAME: ${{ secrets.ES_USERNAME }}
+        if: matrix.os == 'windows-latest' && env.ES_USERNAME != null
         shell: bash
         run: |
+          msg="$(git log -1 --no-merges --pretty=%B)"
+          if [[ ! $msg =~ "^release.*" ]] then;
+            exit 0;
+          fi
+          echo "ES_USERNAME=${{ secrets.ES_USERNAME }}" >> $GITHUB_ENV
+          echo "ES_PASSWORD=${{ secrets.ES_PASSWORD }}" >> $GITHUB_ENV
+          echo "ES_CREDENTIAL_ID=${{ secrets.ES_CREDENTIAL_ID }}" >> $GITHUB_ENV
+          echo "ES_TOTP_SECRET=${{ secrets.ES_TOTP_SECRET }}" >> $GITHUB_ENV
           echo "CSC_LINK=${{ secrets.CERTIFICATE_WINDOWS_APPLICATION }}" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${{ secrets.CERTIFICATE_WINDOWS_PASSWORD }}" >> $GITHUB_ENV
-        env:
-          CERTIFICATE_WINDOWS_APPLICATION: ${{ secrets.CERTIFICATE_WINDOWS_APPLICATION }}
-          CERTIFICATE_WINDOWS_PASSWORD: ${{ secrets.CERTIFICATE_WINDOWS_PASSWORD }}
+
       - name: Load macOS signing certificates and secrets
         if: matrix.os == 'macOS-latest' && env.CERTIFICATE_MACOS_PASSWORD != null
         run: |
@@ -79,6 +108,7 @@ jobs:
         env:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
           CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
+
       - name: Build App
         shell: bash
         working-directory: ${{ github.workspace }}
@@ -90,6 +120,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
           USE_HARD_LINKS: false # because of https://github.com/electron-userland/electron-builder/issues/3179
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODESIGNTOOL_PATH: "${{ github.workspace }}/CodeSignTool"
       - name: Run tests
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -105,7 +136,7 @@ jobs:
           mkdir artifacts
           mv release/build/{*.exe*,*.deb,*.AppImage,*.dmg*,*.zip,*.yml} artifacts || true
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.os}}
           path: artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ npm-debug.log.*
 
 # Ignore env variables
 .env
+
+# windows code signing tool
+CodeSignTool

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -57,7 +57,11 @@
   },
   "win": {
     "target": ["nsis"],
-    "icon": "assets/icon.ico"
+    "icon": "assets/icon.ico",
+    "publisherName": "Slippi LLC",
+    "sign": ".erb/scripts/windows-sign.js",
+    "signDlls": true,
+    "signingHashAlgorithms": ["sha256"]
   },
   "nsis": {
     "artifactName": "Slippi-Launcher-Setup-${version}.${ext}",


### PR DESCRIPTION
the gist of it is that signing keys now need to be stored in HSMs which means we won't have the signing cert available for electron-builder to do its thing. instead we have a custom script for signing that will handle calling CodeSignTool for each file that needs to be signed.
this will only sign release commits because we have to pay a service to manage our HSM. i hate this whole situation