### PR TITLE
Add notification service

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "mousetrap": "^1.6.5",
     "node-stream-zip": "^1.15.0",
     "nodejs-traceroute": "2.0.0",
-    "notistack": "^3.0.0-alpha.2",
+    "notistack": "^3.0.1",
     "obs-websocket-js": "^5.0.1",
     "observable-fns": "^0.6.1",
     "os-name": "^5.1.0",

--- a/src/renderer/lib/hooks/use_toasts.ts
+++ b/src/renderer/lib/hooks/use_toasts.ts
@@ -1,27 +1,6 @@
-import { useSnackbar } from "notistack";
-import React from "react";
+import { useServices } from "@/services";
 
 export const useToasts = () => {
-  const { enqueueSnackbar } = useSnackbar();
-  const toastHandlers = React.useMemo(
-    () => ({
-      showError: (error: Error | string | unknown) => {
-        let message: string;
-        if (error instanceof Error) {
-          message = error.message;
-        } else if (typeof error === "string") {
-          message = error;
-        } else {
-          message = JSON.stringify(error);
-        }
-        // Let's not automatically hide error messages
-        enqueueSnackbar(message, { variant: "error", persist: true });
-      },
-      showSuccess: (message: string) => enqueueSnackbar(message, { variant: "success", autoHideDuration: 2500 }),
-      showWarning: (message: string) => enqueueSnackbar(message, { variant: "warning" }),
-      showInfo: (message: string) => enqueueSnackbar(message, { variant: "info" }),
-    }),
-    [enqueueSnackbar],
-  );
-  return toastHandlers;
+  const { notificationService } = useServices();
+  return notificationService;
 };

--- a/src/renderer/services/install.ts
+++ b/src/renderer/services/install.ts
@@ -3,6 +3,7 @@ import { appVersion } from "@common/constants";
 
 import createAuthClient from "./auth/auth.service";
 import createDolphinClient from "./dolphin/dolphin.service";
+import createNotificationClient from "./notification/notification.service";
 import createReplayClient from "./replay/replay.service";
 import createSlippiClient from "./slippi/slippi.service";
 import type { Services } from "./types";
@@ -18,6 +19,7 @@ export async function installServices(): Promise<Services> {
     dolphinService,
     `${appVersion}${isDevelopment ? "-dev" : ""}`,
   );
+  const notificationService = createNotificationClient();
 
   const broadcastService = window.electron.broadcast;
   const consoleService = window.electron.console;
@@ -29,5 +31,6 @@ export async function installServices(): Promise<Services> {
     broadcastService,
     consoleService,
     replayService,
+    notificationService,
   };
 }

--- a/src/renderer/services/notification/notification.service.ts
+++ b/src/renderer/services/notification/notification.service.ts
@@ -1,0 +1,23 @@
+import { enqueueSnackbar } from "notistack";
+
+import type { NotificationService } from "./types";
+
+export default function createNotificationClient(): NotificationService {
+  return {
+    showError: (error: Error | string | unknown) => {
+      let message: string;
+      if (error instanceof Error) {
+        message = error.message;
+      } else if (typeof error === "string") {
+        message = error;
+      } else {
+        message = JSON.stringify(error);
+      }
+      // Let's not automatically hide error messages
+      enqueueSnackbar(message, { variant: "error", persist: true });
+    },
+    showSuccess: (message: string) => enqueueSnackbar(message, { variant: "success", autoHideDuration: 2500 }),
+    showWarning: (message: string) => enqueueSnackbar(message, { variant: "warning" }),
+    showInfo: (message: string) => enqueueSnackbar(message, { variant: "info" }),
+  };
+}

--- a/src/renderer/services/notification/types.ts
+++ b/src/renderer/services/notification/types.ts
@@ -1,0 +1,6 @@
+export interface NotificationService {
+  showError: (error: Error | string | unknown) => void;
+  showSuccess: (message: string) => void;
+  showWarning: (message: string) => void;
+  showInfo: (message: string) => void;
+}

--- a/src/renderer/services/types.ts
+++ b/src/renderer/services/types.ts
@@ -4,6 +4,7 @@ import type { DolphinService } from "@dolphin/types";
 import type { ReplayService } from "@replays/types";
 
 import type { AuthService } from "./auth/types";
+import type { NotificationService } from "./notification/types";
 import type { SlippiBackendService } from "./slippi/types";
 
 export type Services = {
@@ -13,4 +14,5 @@ export type Services = {
   broadcastService: BroadcastService;
   consoleService: ConsoleService;
   replayService: ReplayService;
+  notificationService: NotificationService;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10485,7 +10485,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -13549,14 +13549,13 @@ normalize-url@^6.0.1, normalize-url@^6.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
-notistack@^3.0.0-alpha.2:
-  version "3.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.0-alpha.2.tgz#47fb09fdd21e425a5403fbdc159723bfda27f323"
-  integrity sha512-MojdM5PtM/2SXjB1bU6IGZQMAHtRAB932TzyfBuTKyztO+I47yGBD/2niiAYd2a9IzmC2Qqq0cXIryOuSE8j8w==
+notistack@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.1.tgz#daf59888ab7e2c30a1fa8f71f9cba2978773236e"
+  integrity sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==
   dependencies:
     clsx "^1.1.0"
     goober "^2.0.33"
-    hoist-non-react-statics "^3.3.0"
 
 npm-conf@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
### Description

Currently we can only show notifications by using the `useToasts()` hook inside a React component. This PR allows us to show notifications outside of a React component logic by introducing a `NotificationService`.
