### PR TITLE
refactor: remove moment dependency

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -4,7 +4,6 @@
 
 import { execSync } from "child_process";
 import Dotenv from "dotenv-webpack";
-import moment from "moment";
 import path from "path";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import webpack from "webpack";
@@ -13,7 +12,7 @@ import pkg from "../../release/app/package.json";
 import webpackPaths from "./webpack.paths";
 
 const isDevelop = process.env.NODE_ENV === "development";
-const buildDate = moment().toISOString();
+const buildDate = new Date().toISOString();
 const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
 
 const configuration: webpack.Configuration = {

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -145,8 +145,6 @@ const configuration: webpack.Configuration = {
       isBrowser: false,
       isDevelopment,
     }),
-
-    new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "async-mutex": "^0.4.0",
     "compare-func": "^2.0.0",
     "cross-fetch": "^3.1.5",
+    "date-fns": "^3.3.0",
     "default-gateway": "^7.2.2",
     "dmg": "^0.1.0",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "jdenticon": "^3.1.1",
     "lodash": "^4.17.21",
     "medium-json-feed": "^0.0.3",
-    "moment": "^2.29.4",
     "mousetrap": "^1.6.5",
     "node-stream-zip": "^1.15.0",
     "nodejs-traceroute": "2.0.0",

--- a/src/console/connection_scanner.ts
+++ b/src/console/connection_scanner.ts
@@ -1,6 +1,5 @@
 import dgram from "dgram";
 import electronLog from "electron-log";
-import moment from "moment";
 
 import { ipc_discoveredConsolesUpdatedEvent } from "./ipc";
 import type { DiscoveredConsoleInfo } from "./types";
@@ -71,7 +70,7 @@ export class ConnectionScanner {
       ip: ip,
       mac: macAddr,
       name: nick,
-      firstFound: previous ? previous.firstFound : moment().toISOString(),
+      firstFound: previous ? previous.firstFound : new Date().toISOString(),
     };
     this.availableConnectionsByIp[ip] = newConsole;
 

--- a/src/renderer/containers/build_info.tsx
+++ b/src/renderer/containers/build_info.tsx
@@ -79,7 +79,7 @@ export const BuildInfo = ({ className, enableAdvancedUserClick }: BuildInfoProps
             margin-left: 4px;
           `}
         >
-          {format(buildDate, "yyyymmdd")}
+          {format(buildDate, "yyyyMMdd")}
         </span>
       </div>
       <div>{osInfo}</div>

--- a/src/renderer/containers/build_info.tsx
+++ b/src/renderer/containers/build_info.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import format from "date-fns/format";
+import { format } from "date-fns";
 import React from "react";
 
 import { ExternalLink as A } from "@/components/external_link";

--- a/src/renderer/containers/build_info.tsx
+++ b/src/renderer/containers/build_info.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import moment from "moment";
+import format from "date-fns/format";
 import React from "react";
 
 import { ExternalLink as A } from "@/components/external_link";
@@ -9,7 +9,7 @@ import { useToasts } from "@/lib/hooks/use_toasts";
 const osInfo = window.electron.bootstrap.operatingSystem;
 
 const appVersion = __VERSION__;
-const buildDate = moment.utc(__DATE__);
+const buildDate = new Date(__DATE__);
 const commitHash = __COMMIT__;
 
 type BuildInfoProps = {
@@ -79,7 +79,7 @@ export const BuildInfo = ({ className, enableAdvancedUserClick }: BuildInfoProps
             margin-left: 4px;
           `}
         >
-          {buildDate.format("YYYYMMDD")}
+          {format(buildDate, "yyyymmdd")}
         </span>
       </div>
       <div>{osInfo}</div>

--- a/src/renderer/lib/time.ts
+++ b/src/renderer/lib/time.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import moment from "moment";
 
 export function convertFrameCountToDurationString(frameCount: number, format = "m:ss"): string {
@@ -5,7 +6,21 @@ export function convertFrameCountToDurationString(frameCount: number, format = "
   return moment.utc(duration.as("milliseconds")).format(format);
 }
 
-export function monthDayHourFormat(time: moment.Moment): string | null {
+export function monthDayHourFormat(moment: moment.Moment): string | null;
+export function monthDayHourFormat(date: Date): string | null;
+export function monthDayHourFormat(momentOrDate: moment.Moment | Date): string | null {
+  if (moment.isMoment(momentOrDate)) {
+    return monthDayHourFormatFromMoment(momentOrDate);
+  }
+
+  return monthDayHourFormatFromDate(momentOrDate);
+}
+
+function monthDayHourFormatFromDate(time: Date): string | null {
+  return null;
+}
+
+function monthDayHourFormatFromMoment(time: moment.Moment): string | null {
   if (!moment.isMoment(time)) {
     return null;
   }

--- a/src/renderer/lib/time.ts
+++ b/src/renderer/lib/time.ts
@@ -1,29 +1,21 @@
-import { format } from "date-fns";
-import moment from "moment";
+import format from "date-fns/format";
+import intervalToDuration from "date-fns/intervalToDuration";
 
-export function convertFrameCountToDurationString(frameCount: number, format = "m:ss"): string {
-  const duration = moment.duration((frameCount + 123) / 60, "seconds");
-  return moment.utc(duration.as("milliseconds")).format(format);
-}
+export function convertFrameCountToDurationString(frameCount: number, format: "short" | "long" = "short"): string {
+  const duration = intervalToDuration({ start: 0, end: ((frameCount + 123) / 60) * 1000 });
 
-export function monthDayHourFormat(moment: moment.Moment): string | null;
-export function monthDayHourFormat(date: Date): string | null;
-export function monthDayHourFormat(momentOrDate: moment.Moment | Date): string | null {
-  if (moment.isMoment(momentOrDate)) {
-    return monthDayHourFormatFromMoment(momentOrDate);
+  const minutes = String(duration.minutes ?? 0);
+  const seconds = String(duration.seconds ?? 0).padStart(2, "0");
+  switch (format) {
+    case "short":
+      // m:ss
+      return `${minutes}:${seconds}`;
+    case "long":
+      // m'm' ss's'
+      return `${minutes}m ${seconds}s`;
   }
-
-  return monthDayHourFormatFromDate(momentOrDate);
 }
 
-function monthDayHourFormatFromDate(time: Date): string | null {
-  return format(time, "PP · p");
-}
-
-function monthDayHourFormatFromMoment(time: moment.Moment): string | null {
-  if (!moment.isMoment(time)) {
-    return null;
-  }
-
-  return time.format("ll · LT");
+export function monthDayHourFormat(date: Date): string {
+  return format(date, "PP · p");
 }

--- a/src/renderer/lib/time.ts
+++ b/src/renderer/lib/time.ts
@@ -1,5 +1,4 @@
-import format from "date-fns/format";
-import intervalToDuration from "date-fns/intervalToDuration";
+import { format, intervalToDuration } from "date-fns";
 
 export function convertFrameCountToDurationString(frameCount: number, format: "short" | "long" = "short"): string {
   const duration = intervalToDuration({ start: 0, end: ((frameCount + 123) / 60) * 1000 });

--- a/src/renderer/lib/time.ts
+++ b/src/renderer/lib/time.ts
@@ -17,7 +17,7 @@ export function monthDayHourFormat(momentOrDate: moment.Moment | Date): string |
 }
 
 function monthDayHourFormatFromDate(time: Date): string | null {
-  return null;
+  return format(time, "PP · p");
 }
 
 function monthDayHourFormatFromMoment(time: moment.Moment): string | null {

--- a/src/renderer/pages/home/news_feed/news_article/news_article.tsx
+++ b/src/renderer/pages/home/news_feed/news_article/news_article.tsx
@@ -7,7 +7,7 @@ import CardMedia from "@mui/material/CardMedia";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import stylex from "@stylexjs/stylex";
-import moment from "moment";
+import format from "date-fns/format";
 import React from "react";
 import TimeAgo from "react-timeago";
 
@@ -35,7 +35,7 @@ const styles = stylex.create({
 
 export const NewsArticle = React.memo(function NewsArticle({ item }: { item: NewsItem }) {
   const { imageUrl, title, subtitle, permalink, body, publishedAt } = item;
-  const localDateString = moment(publishedAt).format("LLL");
+  const localDateString = format(new Date(publishedAt), "PPP p");
 
   return (
     <div {...stylex.props(styles.container)}>

--- a/src/renderer/pages/home/news_feed/news_article/news_article.tsx
+++ b/src/renderer/pages/home/news_feed/news_article/news_article.tsx
@@ -7,7 +7,7 @@ import CardMedia from "@mui/material/CardMedia";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import stylex from "@stylexjs/stylex";
-import format from "date-fns/format";
+import { format } from "date-fns";
 import React from "react";
 import TimeAgo from "react-timeago";
 

--- a/src/renderer/pages/replays/replay_browser/replay_file/replay_file.container.tsx
+++ b/src/renderer/pages/replays/replay_browser/replay_file/replay_file.container.tsx
@@ -181,7 +181,7 @@ const generateReplayDetails = ({
       label:
         gameMode === GameMode.TARGET_TEST
           ? frameToGameTimer(lastFrame, { timerType, startingTimerSeconds })
-          : convertFrameCountToDurationString(lastFrame, "m[m] ss[s]"),
+          : convertFrameCountToDurationString(lastFrame, "long"),
     });
   }
 

--- a/src/renderer/pages/replays/replay_browser/replay_file/replay_file.container.tsx
+++ b/src/renderer/pages/replays/replay_browser/replay_file/replay_file.container.tsx
@@ -11,7 +11,6 @@ import TrackChangesIcon from "@mui/icons-material/TrackChanges";
 import type { FileResult } from "@replays/types";
 import { frameToGameTimer, GameMode, stages as stageUtils } from "@slippi/slippi-js";
 import groupBy from "lodash/groupBy";
-import moment from "moment";
 import React, { useCallback, useMemo } from "react";
 
 import { DraggableFile } from "@/components/draggable_file";
@@ -172,7 +171,7 @@ const generateReplayDetails = ({
   const replayDetails: ReplayDetail[] = [
     {
       Icon: EventIcon,
-      label: monthDayHourFormat(moment(date)) ?? "",
+      label: monthDayHourFormat(new Date(date)) ?? "",
     },
   ];
 

--- a/src/renderer/pages/replays/replay_file_stats/game_profile_header.tsx
+++ b/src/renderer/pages/replays/replay_file_stats/game_profile_header.tsx
@@ -192,7 +192,7 @@ const GameDetails = ({
             startingTimerSeconds: game.startingTimerSeconds ?? null,
             timerType: game.timerType ?? null,
           })
-        : convertFrameCountToDurationString(lastFrame, "m[m] ss[s]")
+        : convertFrameCountToDurationString(lastFrame, "long")
       : "Unknown";
 
   const distance = get(stadiumStats, "distance");

--- a/src/renderer/pages/replays/replay_file_stats/game_profile_header.tsx
+++ b/src/renderer/pages/replays/replay_file_stats/game_profile_header.tsx
@@ -19,7 +19,6 @@ import type { StadiumStatsType, StatsType } from "@slippi/slippi-js";
 import { frameToGameTimer, GameMode, stages as stageUtils } from "@slippi/slippi-js";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
-import moment from "moment";
 import React from "react";
 
 import { DolphinStatus, useDolphinStore } from "@/lib/dolphin/use_dolphin_store";
@@ -201,7 +200,7 @@ const GameDetails = ({
 
   const eventDisplay = {
     label: <EventIcon />,
-    content: monthDayHourFormat(moment(startAtDisplay)),
+    content: monthDayHourFormat(startAtDisplay),
   };
 
   const timerDisplay = {

--- a/src/renderer/pages/spectate/share_gameplay_block/broadcast_panel.tsx
+++ b/src/renderer/pages/spectate/share_gameplay_block/broadcast_panel.tsx
@@ -2,8 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Button from "@mui/material/Button";
 import { ConnectionStatus } from "@slippi/slippi-js";
-import formatDuration from "date-fns/formatDuration";
-import intervalToDuration from "date-fns/intervalToDuration";
+import { formatDuration, intervalToDuration } from "date-fns";
 import React from "react";
 import TimeAgo from "react-timeago";
 

--- a/src/renderer/pages/spectate/share_gameplay_block/broadcast_panel.tsx
+++ b/src/renderer/pages/spectate/share_gameplay_block/broadcast_panel.tsx
@@ -2,7 +2,8 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Button from "@mui/material/Button";
 import { ConnectionStatus } from "@slippi/slippi-js";
-import moment from "moment";
+import formatDuration from "date-fns/formatDuration";
+import intervalToDuration from "date-fns/intervalToDuration";
 import React from "react";
 import TimeAgo from "react-timeago";
 
@@ -32,7 +33,13 @@ export const BroadcastPanel = ({
     slippiServerStatus === ConnectionStatus.DISCONNECTED && dolphinStatus === ConnectionStatus.DISCONNECTED;
   const isConnected = slippiServerStatus === ConnectionStatus.CONNECTED && dolphinStatus === ConnectionStatus.CONNECTED;
 
-  const broadcastDuration = startTime && endTime ? moment.duration(moment(endTime).diff(moment(startTime))) : null;
+  const broadcastDuration =
+    startTime && endTime
+      ? intervalToDuration({
+          start: startTime,
+          end: endTime,
+        })
+      : null;
 
   return (
     <div>
@@ -89,7 +96,7 @@ export const BroadcastPanel = ({
             Broadcast started <TimeAgo date={startTime} />
           </div>
         )}
-        {isDisconnected && broadcastDuration && <div>Broadcast ended after {broadcastDuration.humanize()}</div>}
+        {isDisconnected && broadcastDuration && <div>Broadcast ended after {formatDuration(broadcastDuration)}</div>}
       </div>
       <StartBroadcastDialog open={modalOpen} onClose={() => setModalOpen(false)} onSubmit={onStartBroadcast} />
     </div>

--- a/src/replays/database_replay_provider/infer_start_time.ts
+++ b/src/replays/database_replay_provider/infer_start_time.ts
@@ -31,7 +31,7 @@ function inferDateFromFilename(fileName: string): Date | null {
   const timeReg = /\d{8}T\d{6}/g;
   const filenameTime = fileName.match(timeReg);
 
-  if (filenameTime === null) {
+  if (filenameTime == null) {
     return null;
   }
 

--- a/src/replays/database_replay_provider/infer_start_time.ts
+++ b/src/replays/database_replay_provider/infer_start_time.ts
@@ -1,4 +1,4 @@
-import parse from "date-fns/parse";
+import { parse } from "date-fns";
 
 export function inferStartTime(
   gameStartAt: string | null,

--- a/src/replays/database_replay_provider/infer_start_time.ts
+++ b/src/replays/database_replay_provider/infer_start_time.ts
@@ -1,4 +1,4 @@
-import moment from "moment";
+import parse from "date-fns/parse";
 
 export function inferStartTime(
   gameStartAt: string | null,
@@ -19,27 +19,22 @@ export function inferStartTime(
   return startAt?.toISOString() ?? null;
 }
 
-function convertToDateAndTime(dateTimeString: moment.MomentInput): moment.Moment | null {
+function convertToDateAndTime(dateTimeString: string | null | undefined): Date | null {
   if (dateTimeString == null) {
     return null;
   }
 
-  const asMoment = moment(dateTimeString);
-  if (asMoment.isValid()) {
-    return asMoment.local();
-  }
-
-  return null;
+  return new Date(dateTimeString);
 }
 
-function inferDateFromFilename(fileName: string): moment.Moment | null {
+function inferDateFromFilename(fileName: string): Date | null {
   const timeReg = /\d{8}T\d{6}/g;
   const filenameTime = fileName.match(timeReg);
 
-  if (filenameTime == null) {
+  if (filenameTime === null) {
     return null;
   }
 
-  const time = moment(filenameTime[0]).local();
+  const time = parse(filenameTime[0], "yyyyMMdd'T'HHmmss", new Date());
   return time;
 }

--- a/src/replays/file_system_replay_provider/load_file.ts
+++ b/src/replays/file_system_replay_provider/load_file.ts
@@ -92,7 +92,7 @@ function filenameToDateAndTime(fileName: string): Date | null {
   const timeReg = /\d{8}T\d{6}/g;
   const filenameTime = fileName.match(timeReg);
 
-  if (filenameTime === null) {
+  if (filenameTime == null) {
     return null;
   }
 

--- a/src/replays/file_system_replay_provider/load_file.ts
+++ b/src/replays/file_system_replay_provider/load_file.ts
@@ -1,7 +1,7 @@
 import { exists } from "@common/exists";
 import type { GameStartType, MetadataType } from "@slippi/slippi-js";
 import { SlippiGame } from "@slippi/slippi-js";
-import parse from "date-fns/parse";
+import { parse } from "date-fns";
 import * as fs from "fs-extra";
 import path from "path";
 

--- a/src/replays/file_system_replay_provider/load_file.ts
+++ b/src/replays/file_system_replay_provider/load_file.ts
@@ -1,8 +1,8 @@
 import { exists } from "@common/exists";
 import type { GameStartType, MetadataType } from "@slippi/slippi-js";
 import { SlippiGame } from "@slippi/slippi-js";
+import parse from "date-fns/parse";
 import * as fs from "fs-extra";
-import moment from "moment";
 import path from "path";
 
 import type { FileResult, PlayerInfo } from "../types";
@@ -61,24 +61,19 @@ export async function loadFile(fullPath: string): Promise<FileResult> {
   return result;
 }
 
-function convertToDateAndTime(dateTimeString: moment.MomentInput): moment.Moment | null {
+function convertToDateAndTime(dateTimeString: string | undefined | null): Date | null {
   if (!exists(dateTimeString)) {
     return null;
   }
 
-  const asMoment = moment(dateTimeString);
-  if (asMoment.isValid()) {
-    return asMoment.local();
-  }
-
-  return null;
+  return new Date(dateTimeString);
 }
 
 async function fileToDateAndTime(
   dateTimeString: string | undefined | null,
   fileName: string,
   fullPath: string,
-): Promise<moment.Moment | null> {
+): Promise<Date | null> {
   let startAt = convertToDateAndTime(dateTimeString);
   if (startAt) {
     return startAt;
@@ -90,12 +85,10 @@ async function fileToDateAndTime(
   }
 
   const { birthtime } = await fs.stat(fullPath);
-  startAt = convertToDateAndTime(birthtime);
-
-  return startAt;
+  return birthtime;
 }
 
-function filenameToDateAndTime(fileName: string): moment.Moment | null {
+function filenameToDateAndTime(fileName: string): Date | null {
   const timeReg = /\d{8}T\d{6}/g;
   const filenameTime = fileName.match(timeReg);
 
@@ -103,6 +96,6 @@ function filenameToDateAndTime(fileName: string): moment.Moment | null {
     return null;
   }
 
-  const time = moment(filenameTime[0]).local();
+  const time = parse(filenameTime[0], "yyyyMMdd'T'HHmmss", new Date());
   return time;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8158,6 +8158,11 @@ date-fns@^2.16.1, date-fns@^2.28.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
+date-fns@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.3.0.tgz#c1681691cf751a1d371279099a45e71409c7c761"
+  integrity sha512-xuouT0GuI2W8yXhCMn/AXbSl1Av3wu2hJXxMnnILTY3bYY0UgNK0qOwVXqdFBrobW5qbX1TuOTgMw7c2H2OuhA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13465,11 +13465,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.29.4:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
 mousetrap@^1.6.5:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.5.tgz#8a766d8c272b08393d5f56074e0b5ec183485bf9"


### PR DESCRIPTION
### Description

This PR removes the deprecated `moment` dependency in favour of a lighter package `date-fns`.

This reduces our package bundle size by around 30KB, from 1.06MB to 1.03MB.

