### PR TITLE
Spectate Remote Control v1

### DIFF
--- a/src/broadcast/setup.ts
+++ b/src/broadcast/setup.ts
@@ -20,6 +20,7 @@ export default function setupBroadcastIpc({
 }) {
   let spectateWorker: SpectateWorker | undefined;
   let broadcastWorker: BroadcastWorker | undefined;
+  let prefixOrdinal = 0;
 
   dolphinManager.events
     .filter<DolphinPlaybackClosedEvent>((event) => {
@@ -46,7 +47,8 @@ export default function setupBroadcastIpc({
     );
 
     const folderPath = settingsManager.get().settings.spectateSlpPath;
-    await spectateWorker.startSpectate(broadcasterId, folderPath);
+    await spectateWorker.startSpectate(broadcasterId, folderPath, { idPostfix: `broadcast${prefixOrdinal}` });
+    prefixOrdinal += 1;
     return { success: true };
   });
 

--- a/src/broadcast/spectate.worker.ts
+++ b/src/broadcast/spectate.worker.ts
@@ -12,7 +12,7 @@ import { SpectateEvent } from "./types";
 
 interface Methods {
   dispose: () => Promise<void>;
-  startSpectate(broadcastId: string, targetPath: string): Promise<void>;
+  startSpectate(broadcastId: string, targetPath: string): Promise<string>;
   stopSpectate(broadcastId: string): Promise<void>;
   dolphinClosed(playbackId: string): Promise<void>;
   refreshBroadcastList(authToken: string): Promise<void>;
@@ -65,8 +65,8 @@ const methods: WorkerSpec = {
 
     spectateManager.removeAllListeners();
   },
-  async startSpectate(broadcastId: string, targetPath: string): Promise<void> {
-    await spectateManager.watchBroadcast(broadcastId, targetPath);
+  async startSpectate(broadcastId: string, targetPath: string): Promise<string> {
+    return await spectateManager.watchBroadcast(broadcastId, targetPath);
   },
   async stopSpectate(broadcastId: string): Promise<void> {
     spectateManager.stopWatchingBroadcast(broadcastId);

--- a/src/broadcast/spectate.worker.ts
+++ b/src/broadcast/spectate.worker.ts
@@ -7,12 +7,12 @@ import { Observable, Subject } from "threads/observable";
 import { expose } from "threads/worker";
 
 import { SpectateManager } from "./spectate_manager";
-import type { BroadcasterItem } from "./types";
+import type { BroadcasterItem, SpectateDolphinOptions } from "./types";
 import { SpectateEvent } from "./types";
 
 interface Methods {
   dispose: () => Promise<void>;
-  startSpectate(broadcastId: string, targetPath: string): Promise<string>;
+  startSpectate(broadcastId: string, targetPath: string, dolphinOptions: SpectateDolphinOptions): Promise<string>;
   stopSpectate(broadcastId: string): Promise<void>;
   dolphinClosed(playbackId: string): Promise<void>;
   refreshBroadcastList(authToken: string): Promise<void>;
@@ -71,8 +71,12 @@ const methods: WorkerSpec = {
 
     spectateManager.removeAllListeners();
   },
-  async startSpectate(broadcastId: string, targetPath: string): Promise<string> {
-    return await spectateManager.watchBroadcast(broadcastId, targetPath);
+  async startSpectate(
+    broadcastId: string,
+    targetPath: string,
+    dolphinOptions: SpectateDolphinOptions,
+  ): Promise<string> {
+    return await spectateManager.watchBroadcast(broadcastId, targetPath, dolphinOptions);
   },
   async stopSpectate(broadcastId: string): Promise<void> {
     spectateManager.stopWatchingBroadcast(broadcastId);

--- a/src/broadcast/spectate.worker.ts
+++ b/src/broadcast/spectate.worker.ts
@@ -21,6 +21,7 @@ interface Methods {
   getBroadcastListObservable(): Observable<BroadcasterItem[]>;
   getSpectateDetailsObservable(): Observable<{ playbackId: string; filePath: string; broadcasterName: string }>;
   getReconnectObservable(): Observable<Record<never, never>>;
+  getGameEndObservable(): Observable<string>;
 }
 
 export type WorkerSpec = ModuleMethods & Methods;
@@ -32,6 +33,7 @@ const errorSubject = new Subject<Error | string>();
 const broadcastListSubject = new Subject<BroadcasterItem[]>();
 const spectateDetailsSubject = new Subject<{ playbackId: string; filePath: string; broadcasterName: string }>();
 const reconnectSubject = new Subject<Record<never, never>>();
+const gameEndSubject = new Subject<string>();
 
 // Forward the events to the renderer
 spectateManager.on(SpectateEvent.BROADCAST_LIST_UPDATE, async (data: BroadcasterItem[]) => {
@@ -52,6 +54,10 @@ spectateManager.on(SpectateEvent.NEW_FILE, async (playbackId: string, filePath: 
 
 spectateManager.on(SpectateEvent.RECONNECT, async () => {
   reconnectSubject.next({});
+});
+
+spectateManager.on(SpectateEvent.GAME_END, async (dolphinId: string) => {
+  gameEndSubject.next(dolphinId);
 });
 
 const methods: WorkerSpec = {
@@ -92,6 +98,9 @@ const methods: WorkerSpec = {
   },
   getReconnectObservable(): Observable<Record<never, never>> {
     return Observable.from(reconnectSubject);
+  },
+  getGameEndObservable(): Observable<string> {
+    return Observable.from(gameEndSubject);
   },
 };
 

--- a/src/broadcast/spectate_manager.ts
+++ b/src/broadcast/spectate_manager.ts
@@ -219,10 +219,10 @@ export class SpectateManager extends EventEmitter {
    *
    * @param {string} broadcastId The ID of the broadcast to watch
    * @param {string} targetPath Where the SLP files should be stored
-   * @param {true} [singleton] If true, it will open the broadcasts only
+   * @param {boolean} [singleton] If true, it will open the broadcasts only
    * in a single Dolphin window. Opens each broadcast in their own window otherwise.
    */
-  public watchBroadcast(broadcastId: string, targetPath: string, singleton?: true) {
+  public watchBroadcast(broadcastId: string, targetPath: string, singleton?: boolean) {
     Preconditions.checkExists(this.wsConnection, "No websocket connection");
 
     const existingBroadcasts = Object.keys(this.openBroadcasts);

--- a/src/broadcast/spectate_manager.ts
+++ b/src/broadcast/spectate_manager.ts
@@ -229,7 +229,7 @@ export class SpectateManager extends EventEmitter {
     if (existingBroadcasts.includes(broadcastId)) {
       // We're already watching this broadcast!
       this.emit(SpectateEvent.LOG, `We are already watching the selected broadcast`);
-      return;
+      return this.openBroadcasts[broadcastId].dolphinId;
     }
 
     let dolphinPlaybackId = generatePlaybackId(broadcastId);
@@ -273,6 +273,7 @@ export class SpectateManager extends EventEmitter {
     // used to clear out any previous file that we were reading for. The file will get updated
     // by the fileWriter
     this._playFile("", dolphinPlaybackId, broadcasterName).catch(console.warn);
+    return dolphinPlaybackId;
   }
 
   public handleClosedDolphin(playbackId: string) {

--- a/src/broadcast/spectate_manager.ts
+++ b/src/broadcast/spectate_manager.ts
@@ -64,6 +64,7 @@ export class SpectateManager extends EventEmitter {
         }
         case "end_game": {
           // End the current game if it's not already ended
+          this.emit(SpectateEvent.GAME_END, broadcastInfo.dolphinId);
           this.emit(SpectateEvent.LOG, "Game end explicit");
           broadcastInfo.fileWriter.endCurrentFile();
           broadcastInfo.gameStarted = false;

--- a/src/broadcast/spectate_manager.ts
+++ b/src/broadcast/spectate_manager.ts
@@ -64,10 +64,12 @@ export class SpectateManager extends EventEmitter {
         }
         case "end_game": {
           // End the current game if it's not already ended
-          this.emit(SpectateEvent.GAME_END, broadcastInfo.dolphinId);
           this.emit(SpectateEvent.LOG, "Game end explicit");
           broadcastInfo.fileWriter.endCurrentFile();
           broadcastInfo.gameStarted = false;
+
+          // Observers should be able to depend on the file being closed, so emit this last.
+          this.emit(SpectateEvent.GAME_END, broadcastInfo.dolphinId);
           break;
         }
         case "game_event": {

--- a/src/broadcast/types.ts
+++ b/src/broadcast/types.ts
@@ -31,6 +31,7 @@ export enum SpectateEvent {
   NEW_FILE = "NEW_FILE",
   LOG = "LOG",
   RECONNECT = "RECONNECT",
+  GAME_END = "GAME_END",
 }
 
 type TypeMap<M extends { [index: string]: any }> = {

--- a/src/broadcast/types.ts
+++ b/src/broadcast/types.ts
@@ -77,3 +77,8 @@ export type BroadcastService = {
   startBroadcast(config: StartBroadcastConfig): Promise<void>;
   stopBroadcast(): Promise<void>;
 };
+
+export type SpectateDolphinOptions = {
+  dolphinId?: string;
+  idPostfix?: string;
+};

--- a/src/main/install_modules.ts
+++ b/src/main/install_modules.ts
@@ -2,6 +2,7 @@ import setupBroadcastIpc from "@broadcast/setup";
 import setupConsoleIpc from "@console/setup";
 import { DolphinManager } from "@dolphin/manager";
 import setupDolphinIpc from "@dolphin/setup";
+import setupRemoteIpc from "@remote/setup";
 import setupReplaysIpc from "@replays/setup";
 import { SettingsManager } from "@settings/settings_manager";
 import setupSettingsIpc from "@settings/setup";
@@ -17,6 +18,7 @@ export function installModules(flags: ConfigFlags) {
   setupReplaysIpc({ enableReplayDatabase: flags.enableReplayDatabase });
   setupSettingsIpc({ settingsManager, dolphinManager });
   setupConsoleIpc({ dolphinManager });
+  setupRemoteIpc({ dolphinManager, settingsManager });
   setupMainIpc({ dolphinManager, flags });
   return { dolphinManager, settingsManager };
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,7 @@
 import broadcastApi from "@broadcast/api";
 import consoleApi from "@console/api";
 import dolphinApi from "@dolphin/api";
+import remoteApi from "@remote/api";
 import replaysApi from "@replays/api";
 import settingsApi from "@settings/api";
 import { clipboard, contextBridge, ipcRenderer, shell } from "electron";
@@ -18,6 +19,7 @@ const api = {
   broadcast: broadcastApi,
   dolphin: dolphinApi,
   replays: replaysApi,
+  remote: remoteApi,
   utils: {
     isSubdirectory,
   },

--- a/src/remote/api.ts
+++ b/src/remote/api.ts
@@ -1,6 +1,7 @@
 import {
   ipc_reconnectRemoteServer,
   ipc_remoteReconnectEvent,
+  ipc_remoteStateEvent,
   ipc_startRemoteServer,
   ipc_stopRemoteServer,
 } from "./ipc";
@@ -10,6 +11,12 @@ const remoteApi: RemoteService = {
   onReconnect(handle: () => void) {
     const { destroy } = ipc_remoteReconnectEvent.renderer!.handle(async () => {
       handle();
+    });
+    return destroy;
+  },
+  onState(handle: (connected: boolean, started: boolean, port?: number) => void) {
+    const { destroy } = ipc_remoteStateEvent.renderer!.handle(async ({ connected, started, port }) => {
+      handle(connected, started, port);
     });
     return destroy;
   },

--- a/src/remote/api.ts
+++ b/src/remote/api.ts
@@ -13,8 +13,8 @@ const remoteApi: RemoteService = {
     });
     return destroy;
   },
-  async startRemoteServer(authToken: string) {
-    const { result } = await ipc_startRemoteServer.renderer!.trigger({ authToken });
+  async startRemoteServer(authToken: string, port: number) {
+    const { result } = await ipc_startRemoteServer.renderer!.trigger({ authToken, port });
     return result;
   },
   async reconnectRemoteServer(authToken: string) {

--- a/src/remote/api.ts
+++ b/src/remote/api.ts
@@ -1,0 +1,29 @@
+import {
+  ipc_reconnectRemoteServer,
+  ipc_remoteReconnectEvent,
+  ipc_startRemoteServer,
+  ipc_stopRemoteServer,
+} from "./ipc";
+import type { RemoteService } from "./types";
+
+const remoteApi: RemoteService = {
+  onReconnect(handle: () => void) {
+    const { destroy } = ipc_remoteReconnectEvent.renderer!.handle(async () => {
+      handle();
+    });
+    return destroy;
+  },
+  async startRemoteServer(authToken: string) {
+    const { result } = await ipc_startRemoteServer.renderer!.trigger({ authToken });
+    return result;
+  },
+  async reconnectRemoteServer(authToken: string) {
+    const { result } = await ipc_reconnectRemoteServer.renderer!.trigger({ authToken });
+    return result;
+  },
+  async stopRemoteServer() {
+    await ipc_stopRemoteServer.renderer!.trigger({});
+  },
+};
+
+export default remoteApi;

--- a/src/remote/ipc.ts
+++ b/src/remote/ipc.ts
@@ -4,8 +4,8 @@ import { _, makeEndpoint } from "utils/ipc";
 export const ipc_remoteReconnectEvent = makeEndpoint.renderer("remote_reconnect", <EmptyPayload>_);
 export const ipc_startRemoteServer = makeEndpoint.main(
   "remote_startServer",
-  <{ authToken: string }>_,
-  <{ port: number }>_,
+  <{ authToken: string; port: number }>_,
+  <{ success: boolean; err?: string }>_,
 );
 export const ipc_reconnectRemoteServer = makeEndpoint.main(
   "remote_reconnectServer",

--- a/src/remote/ipc.ts
+++ b/src/remote/ipc.ts
@@ -1,0 +1,15 @@
+import type { EmptyPayload, SuccessPayload } from "utils/ipc";
+import { _, makeEndpoint } from "utils/ipc";
+
+export const ipc_remoteReconnectEvent = makeEndpoint.renderer("remote_reconnect", <EmptyPayload>_);
+export const ipc_startRemoteServer = makeEndpoint.main(
+  "remote_startServer",
+  <{ authToken: string }>_,
+  <{ port: number }>_,
+);
+export const ipc_reconnectRemoteServer = makeEndpoint.main(
+  "remote_reconnectServer",
+  <{ authToken: string }>_,
+  <{ success: boolean }>_,
+);
+export const ipc_stopRemoteServer = makeEndpoint.main("remote_stopServer", <EmptyPayload>_, <SuccessPayload>_);

--- a/src/remote/ipc.ts
+++ b/src/remote/ipc.ts
@@ -2,6 +2,10 @@ import type { EmptyPayload, SuccessPayload } from "utils/ipc";
 import { _, makeEndpoint } from "utils/ipc";
 
 export const ipc_remoteReconnectEvent = makeEndpoint.renderer("remote_reconnect", <EmptyPayload>_);
+export const ipc_remoteStateEvent = makeEndpoint.renderer(
+  "remote_state",
+  <{ connected: boolean; started: boolean; port?: number }>_,
+);
 export const ipc_startRemoteServer = makeEndpoint.main(
   "remote_startServer",
   <{ authToken: string; port: number }>_,

--- a/src/remote/remote.server.ts
+++ b/src/remote/remote.server.ts
@@ -1,0 +1,153 @@
+import type { BroadcasterItem } from "@broadcast/types";
+import type { DolphinManager } from "@dolphin/manager";
+import type { DolphinPlaybackClosedEvent } from "@dolphin/types";
+import { DolphinEventType, DolphinLaunchType } from "@dolphin/types";
+import type { SettingsManager } from "@settings/settings_manager";
+import log from "electron-log";
+import http from "http";
+import type { AddressInfo } from "net";
+import { server as WebSocketServer } from "websocket";
+
+import type { SpectateWorker } from "./spectate.worker.interface";
+import { createSpectateWorker } from "./spectate.worker.interface";
+
+const SPECTATE_PROTOCOL = "spectate-protocol";
+
+export default class RemoteServer {
+  private dolphinManager: DolphinManager;
+  private settingsManager: SettingsManager;
+  private spectateWorkerPromise: Promise<SpectateWorker>;
+  private authToken: string;
+
+  private httpServer: http.Server | null;
+  private remoteServer: WebSocketServer | null;
+  private hasConnection: boolean;
+
+  constructor(dolphinManager: DolphinManager, settingsManager: SettingsManager) {
+    this.dolphinManager = dolphinManager;
+    this.settingsManager = settingsManager;
+    this.spectateWorkerPromise = createSpectateWorker(this.dolphinManager);
+    dolphinManager.events
+      .filter<DolphinPlaybackClosedEvent>((event) => {
+        return event.type === DolphinEventType.CLOSED && event.dolphinType === DolphinLaunchType.PLAYBACK;
+      })
+      .subscribe(async (event) => {
+        const spectateWorker = await this.spectateWorkerPromise;
+        try {
+          await spectateWorker.dolphinClosed(event.instanceId);
+        } catch (e) {
+          log.error(e);
+        }
+      });
+    this.authToken = "";
+
+    this.httpServer = null;
+    this.remoteServer = null;
+    this.hasConnection = false;
+  }
+
+  public async start(authToken: string): Promise<number> {
+    if (this.httpServer && this.remoteServer) {
+      return (<AddressInfo>this.httpServer.address()).port;
+    }
+
+    this.authToken = authToken;
+    try {
+      const spectateWorker = await this.spectateWorkerPromise;
+
+      this.httpServer = http.createServer();
+      await new Promise<void>((resolve, reject) => {
+        this.httpServer!.once("error", (e) => {
+          reject(e);
+        });
+        this.httpServer!.listen(
+          0, // let the OS decide a port
+          "localhost", // bind only to localhost
+          511, // default backlog queue length
+          () => {
+            this.httpServer!.removeAllListeners("error");
+            resolve();
+          },
+        );
+      });
+
+      this.remoteServer = new WebSocketServer({ httpServer: this.httpServer });
+      this.remoteServer.on("request", async (request) => {
+        if (!this.hasConnection && request.requestedProtocols.includes(SPECTATE_PROTOCOL)) {
+          const newConnection = request.accept(SPECTATE_PROTOCOL, request.origin);
+          newConnection.on("message", async (data) => {
+            if (data.type === "binary") {
+              return;
+            }
+
+            const json = JSON.parse(data.utf8Data);
+            if (json.op === "list-broadcasts-request") {
+              try {
+                await spectateWorker.refreshBroadcastList(this.authToken);
+              } catch (e) {
+                const message = typeof e === "string" ? e : e instanceof Error ? e.message : "unknown";
+                newConnection.sendUTF(JSON.stringify({ op: "list-broadcasts-response", err: message }));
+              }
+            }
+            if (json.op === "spectate-broadcast-request") {
+              if (!json.broadcastId) {
+                newConnection.sendUTF(JSON.stringify({ op: "spectate-broadcast-response", err: "no broadcastId" }));
+                return;
+              }
+
+              try {
+                const path = this.settingsManager.get().settings.spectateSlpPath;
+                await spectateWorker.startSpectate(json.broadcastId, path);
+                newConnection.sendUTF(JSON.stringify({ op: "spectate-broadcast-response", path }));
+              } catch (e) {
+                const message = typeof e === "string" ? e : e instanceof Error ? e.message : "unknown";
+                newConnection.sendUTF(JSON.stringify({ op: "spectate-broadcast-response", err: message }));
+              }
+            }
+          });
+          const subscription = spectateWorker.getBroadcastListObservable().subscribe((data: BroadcasterItem[]) => {
+            newConnection.sendUTF(JSON.stringify({ op: "list-broadcasts-response", broadcasts: data }));
+          });
+          newConnection.on("close", () => {
+            subscription.unsubscribe();
+            this.hasConnection = false;
+          });
+          this.hasConnection = true;
+        } else {
+          request.reject();
+        }
+      });
+
+      return (<AddressInfo>this.httpServer.address()).port;
+    } catch (e: any) {
+      return 0;
+    }
+  }
+
+  public async reconnect(authToken: string) {
+    if (!authToken) {
+      return false;
+    }
+
+    this.authToken = authToken;
+    const spectateWorker = await this.spectateWorkerPromise;
+    try {
+      await spectateWorker.refreshBroadcastList(this.authToken);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  public stop() {
+    this.hasConnection = false;
+    if (this.remoteServer) {
+      this.remoteServer.shutDown();
+      this.remoteServer = null;
+    }
+    if (this.httpServer) {
+      this.httpServer.close();
+      this.httpServer = null;
+    }
+  }
+}

--- a/src/remote/remote.server.ts
+++ b/src/remote/remote.server.ts
@@ -70,6 +70,11 @@ export default class RemoteServer {
             log.error(e);
           }
         });
+        spectateWorker.getGameEndObservable().subscribe((dolphinId: string) => {
+          if (this.connection) {
+            this.connection.sendUTF(JSON.stringify({ op: "game-end-event", dolphinId }));
+          }
+        });
       })
       .catch(log.error);
   }

--- a/src/remote/remote.server.ts
+++ b/src/remote/remote.server.ts
@@ -168,7 +168,7 @@ export default class RemoteServer {
               await throttledRefresh();
             } else if (json.op === "spectate-broadcast-request") {
               const broadcastId = json.broadcastId;
-              if (!broadcastId) {
+              if (!broadcastId || typeof broadcastId !== "string") {
                 newConnection.sendUTF(JSON.stringify({ op: "spectate-broadcast-response", err: "no broadcastId" }));
                 return;
               }

--- a/src/remote/setup.ts
+++ b/src/remote/setup.ts
@@ -12,8 +12,8 @@ export default function setupRemoteIpc({
   settingsManager: SettingsManager;
 }) {
   const remoteServer = new RemoteServer(dolphinManager, settingsManager);
-  ipc_startRemoteServer.main!.handle(async ({ authToken }) => {
-    return { port: await remoteServer.start(authToken) };
+  ipc_startRemoteServer.main!.handle(async ({ authToken, port }) => {
+    return await remoteServer.start(authToken, port);
   });
   ipc_reconnectRemoteServer.main!.handle(async ({ authToken }) => {
     return { success: await remoteServer.reconnect(authToken) };

--- a/src/remote/setup.ts
+++ b/src/remote/setup.ts
@@ -1,0 +1,25 @@
+import type { DolphinManager } from "@dolphin/manager";
+import type { SettingsManager } from "@settings/settings_manager";
+
+import { ipc_reconnectRemoteServer, ipc_startRemoteServer, ipc_stopRemoteServer } from "./ipc";
+import RemoteServer from "./remote.server";
+
+export default function setupRemoteIpc({
+  dolphinManager,
+  settingsManager,
+}: {
+  dolphinManager: DolphinManager;
+  settingsManager: SettingsManager;
+}) {
+  const remoteServer = new RemoteServer(dolphinManager, settingsManager);
+  ipc_startRemoteServer.main!.handle(async ({ authToken }) => {
+    return { port: await remoteServer.start(authToken) };
+  });
+  ipc_reconnectRemoteServer.main!.handle(async ({ authToken }) => {
+    return { success: await remoteServer.reconnect(authToken) };
+  });
+  ipc_stopRemoteServer.main!.handle(async () => {
+    remoteServer.stop();
+    return { success: true };
+  });
+}

--- a/src/remote/spectate.worker.interface.ts
+++ b/src/remote/spectate.worker.interface.ts
@@ -1,0 +1,37 @@
+import type { WorkerSpec } from "@broadcast/spectate.worker";
+import type { DolphinManager } from "@dolphin/manager";
+import type { ReplayCommunication } from "@dolphin/types";
+import electronLog from "electron-log";
+import { Worker } from "threads";
+import type { RegisteredWorker } from "utils/register_worker";
+import { registerWorker } from "utils/register_worker";
+
+import { ipc_remoteReconnectEvent } from "./ipc";
+
+const log = electronLog.scope("remote.spectate.worker");
+
+export type SpectateWorker = RegisteredWorker<WorkerSpec>;
+
+export async function createSpectateWorker(dolphinManager: DolphinManager): Promise<SpectateWorker> {
+  log.debug("spectate: Spawning remote worker");
+  const worker = await registerWorker<WorkerSpec>(new Worker("../broadcast/spectate.worker"));
+
+  worker.getLogObservable().subscribe((logMessage) => {
+    log.info(logMessage);
+  });
+  worker.getErrorObservable().subscribe((err) => {
+    log.error(err);
+  });
+  worker.getSpectateDetailsObservable().subscribe(({ playbackId, filePath, broadcasterName }) => {
+    const replayComm: ReplayCommunication = {
+      mode: "mirror",
+      replay: filePath,
+      gameStation: broadcasterName,
+    };
+    dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(log.error);
+  });
+  worker.getReconnectObservable().subscribe(() => {
+    ipc_remoteReconnectEvent.main!.trigger({}).catch(log.error);
+  });
+  return worker;
+}

--- a/src/remote/spectate.worker.interface.ts
+++ b/src/remote/spectate.worker.interface.ts
@@ -1,6 +1,4 @@
 import type { WorkerSpec } from "@broadcast/spectate.worker";
-import type { DolphinManager } from "@dolphin/manager";
-import type { ReplayCommunication } from "@dolphin/types";
 import electronLog from "electron-log";
 import { Worker } from "threads";
 import type { RegisteredWorker } from "utils/register_worker";
@@ -12,7 +10,7 @@ const log = electronLog.scope("remote.spectate.worker");
 
 export type SpectateWorker = RegisteredWorker<WorkerSpec>;
 
-export async function createSpectateWorker(dolphinManager: DolphinManager): Promise<SpectateWorker> {
+export async function createSpectateWorker(): Promise<SpectateWorker> {
   log.debug("spectate: Spawning remote worker");
   const worker = await registerWorker<WorkerSpec>(new Worker("../broadcast/spectate.worker"));
 
@@ -21,14 +19,6 @@ export async function createSpectateWorker(dolphinManager: DolphinManager): Prom
   });
   worker.getErrorObservable().subscribe((err) => {
     log.error(err);
-  });
-  worker.getSpectateDetailsObservable().subscribe(({ playbackId, filePath, broadcasterName }) => {
-    const replayComm: ReplayCommunication = {
-      mode: "mirror",
-      replay: filePath,
-      gameStation: broadcasterName,
-    };
-    dolphinManager.launchPlaybackDolphin(playbackId, replayComm).catch(log.error);
   });
   worker.getReconnectObservable().subscribe(() => {
     ipc_remoteReconnectEvent.main!.trigger({}).catch(log.error);

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -1,0 +1,6 @@
+export type RemoteService = {
+  onReconnect(handle: () => void): () => void;
+  startRemoteServer(authToken: string): Promise<{ port: number }>;
+  reconnectRemoteServer(authToken: string): Promise<{ success: boolean }>;
+  stopRemoteServer(): Promise<void>;
+};

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -1,6 +1,6 @@
 export type RemoteService = {
   onReconnect(handle: () => void): () => void;
-  startRemoteServer(authToken: string): Promise<{ port: number }>;
+  startRemoteServer(authToken: string, port: number): Promise<{ success: boolean; err?: string }>;
   reconnectRemoteServer(authToken: string): Promise<{ success: boolean }>;
   stopRemoteServer(): Promise<void>;
 };

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -1,5 +1,6 @@
 export type RemoteService = {
   onReconnect(handle: () => void): () => void;
+  onState(handle: (connected: boolean, started: boolean, port?: number) => void): () => void;
   startRemoteServer(authToken: string, port: number): Promise<{ success: boolean; err?: string }>;
   reconnectRemoteServer(authToken: string): Promise<{ success: boolean }>;
   stopRemoteServer(): Promise<void>;

--- a/src/renderer/lib/hooks/use_app_listeners.ts
+++ b/src/renderer/lib/hooks/use_app_listeners.ts
@@ -17,7 +17,7 @@ import { useBroadcast } from "./use_broadcast";
 import { useBroadcastList, useBroadcastListStore } from "./use_broadcast_list";
 import { useConsoleDiscoveryStore } from "./use_console_discovery";
 import { useIsoVerification } from "./use_iso_verification";
-import { useRemoteServer } from "./use_remote_server";
+import { useRemoteServer, useRemoteServerStateStore } from "./use_remote_server";
 import { useReplayBrowserNavigation } from "./use_replay_browser_list";
 import { useSettings } from "./use_settings";
 import { useSettingsModal } from "./use_settings_modal";
@@ -193,8 +193,13 @@ export const useAppListeners = () => {
     return broadcastService.onSpectateReconnect(refreshBroadcasts);
   }, [refreshBroadcasts, broadcastService]);
 
-  const [, reconnectRemoteServer] = useRemoteServer();
+  const [, , reconnectRemoteServer] = useRemoteServer();
   React.useEffect(() => {
     return remoteService.onReconnect(reconnectRemoteServer);
   }, [reconnectRemoteServer, remoteService]);
+
+  const updateRemoteServerState = useRemoteServerStateStore((store) => store.setState);
+  React.useEffect(() => {
+    return remoteService.onState(updateRemoteServerState);
+  }, [updateRemoteServerState, remoteService]);
 };

--- a/src/renderer/lib/hooks/use_app_listeners.ts
+++ b/src/renderer/lib/hooks/use_app_listeners.ts
@@ -17,13 +17,14 @@ import { useBroadcast } from "./use_broadcast";
 import { useBroadcastList, useBroadcastListStore } from "./use_broadcast_list";
 import { useConsoleDiscoveryStore } from "./use_console_discovery";
 import { useIsoVerification } from "./use_iso_verification";
+import { useRemoteServer } from "./use_remote_server";
 import { useReplayBrowserNavigation } from "./use_replay_browser_list";
 import { useSettings } from "./use_settings";
 import { useSettingsModal } from "./use_settings_modal";
 
 export const useAppListeners = () => {
   // Handle app initalization
-  const { authService, broadcastService, consoleService, dolphinService, replayService } = useServices();
+  const { authService, broadcastService, consoleService, dolphinService, remoteService, replayService } = useServices();
   const replayPresenter = useRef(new ReplayPresenter(replayService));
   const initialized = useAppStore((store) => store.initialized);
   const initializeApp = useAppInitialization();
@@ -191,4 +192,9 @@ export const useAppListeners = () => {
   React.useEffect(() => {
     return broadcastService.onSpectateReconnect(refreshBroadcasts);
   }, [refreshBroadcasts, broadcastService]);
+
+  const [, reconnectRemoteServer] = useRemoteServer();
+  React.useEffect(() => {
+    return remoteService.onReconnect(reconnectRemoteServer);
+  }, [reconnectRemoteServer, remoteService]);
 };

--- a/src/renderer/lib/hooks/use_remote_server.ts
+++ b/src/renderer/lib/hooks/use_remote_server.ts
@@ -1,6 +1,33 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
 import { useServices } from "@/services";
 
+export const useRemoteServerStateStore = create(
+  combine(
+    {
+      connected: false,
+      started: false,
+      port: 0,
+    },
+    (set) => ({
+      setState: (connected: boolean, started: boolean, port?: number) => {
+        if (port !== undefined) {
+          set({ connected, started, port });
+        } else {
+          set({ connected, started });
+        }
+      },
+    }),
+  ),
+);
+
 export const useRemoteServer = () => {
+  const state = useRemoteServerStateStore((store) => ({
+    connected: store.connected,
+    started: store.started,
+    port: store.port,
+  }));
   const { authService, remoteService } = useServices();
   const startRemoteServer = async (port: number) => {
     const authToken = await authService.getUserToken();
@@ -13,5 +40,5 @@ export const useRemoteServer = () => {
   const stopRemoteServer = async () => {
     return remoteService.stopRemoteServer();
   };
-  return [startRemoteServer, reconnectRemoteServer, stopRemoteServer] as const;
+  return [state, startRemoteServer, reconnectRemoteServer, stopRemoteServer] as const;
 };

--- a/src/renderer/lib/hooks/use_remote_server.ts
+++ b/src/renderer/lib/hooks/use_remote_server.ts
@@ -1,0 +1,17 @@
+import { useServices } from "@/services";
+
+export const useRemoteServer = () => {
+  const { authService, remoteService } = useServices();
+  const startRemoteServer = async () => {
+    const authToken = await authService.getUserToken();
+    return remoteService.startRemoteServer(authToken);
+  };
+  const reconnectRemoteServer = async () => {
+    const authToken = await authService.getUserToken();
+    return remoteService.reconnectRemoteServer(authToken);
+  };
+  const stopRemoteServer = async () => {
+    return remoteService.stopRemoteServer();
+  };
+  return [startRemoteServer, reconnectRemoteServer, stopRemoteServer] as const;
+};

--- a/src/renderer/lib/hooks/use_remote_server.ts
+++ b/src/renderer/lib/hooks/use_remote_server.ts
@@ -2,9 +2,9 @@ import { useServices } from "@/services";
 
 export const useRemoteServer = () => {
   const { authService, remoteService } = useServices();
-  const startRemoteServer = async () => {
+  const startRemoteServer = async (port: number) => {
     const authToken = await authService.getUserToken();
-    return remoteService.startRemoteServer(authToken);
+    return remoteService.startRemoteServer(authToken, port);
   };
   const reconnectRemoteServer = async () => {
     const authToken = await authService.getUserToken();

--- a/src/renderer/pages/spectate/create.tsx
+++ b/src/renderer/pages/spectate/create.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { useAccount } from "@/lib/hooks/use_account";
 import { useBroadcastList } from "@/lib/hooks/use_broadcast_list";
+import { useRemoteServer } from "@/lib/hooks/use_remote_server";
 
 import { SpectatePage } from "./spectate_page";
 
@@ -20,12 +21,15 @@ export function createSpectatePage({ broadcastService }: CreateSpectatePageArgs)
   const Page = React.memo(() => {
     const user = useAccount((store) => store.user);
     const [currentBroadcasts, refreshBroadcasts] = useBroadcastList();
+    const [startRemoteServer, , stopRemoteServer] = useRemoteServer();
     return (
       <SpectatePage
         userId={user?.uid}
         watchBroadcast={watchBroadcast}
         broadcasts={currentBroadcasts}
         onRefreshBroadcasts={refreshBroadcasts}
+        startRemoteServer={startRemoteServer}
+        stopRemoteServer={stopRemoteServer}
       />
     );
   });

--- a/src/renderer/pages/spectate/create.tsx
+++ b/src/renderer/pages/spectate/create.tsx
@@ -21,13 +21,14 @@ export function createSpectatePage({ broadcastService }: CreateSpectatePageArgs)
   const Page = React.memo(() => {
     const user = useAccount((store) => store.user);
     const [currentBroadcasts, refreshBroadcasts] = useBroadcastList();
-    const [startRemoteServer, , stopRemoteServer] = useRemoteServer();
+    const [remoteServerState, startRemoteServer, , stopRemoteServer] = useRemoteServer();
     return (
       <SpectatePage
         userId={user?.uid}
         watchBroadcast={watchBroadcast}
         broadcasts={currentBroadcasts}
         onRefreshBroadcasts={refreshBroadcasts}
+        remoteServerState={remoteServerState}
         startRemoteServer={startRemoteServer}
         stopRemoteServer={stopRemoteServer}
       />

--- a/src/renderer/pages/spectate/spectate_page.tsx
+++ b/src/renderer/pages/spectate/spectate_page.tsx
@@ -30,7 +30,7 @@ export const SpectatePage = React.memo(
     broadcasts: BroadcasterItem[];
     onRefreshBroadcasts: () => void;
     watchBroadcast: (id: string) => void;
-    startRemoteServer: () => Promise<{ port: number }>;
+    startRemoteServer: (port: number) => Promise<{ success: boolean; err?: string }>;
     stopRemoteServer: () => Promise<void>;
   }) => {
     if (!userId) {

--- a/src/renderer/pages/spectate/spectate_page.tsx
+++ b/src/renderer/pages/spectate/spectate_page.tsx
@@ -28,7 +28,7 @@ export const SpectatePage = React.memo(
   }: {
     userId?: string;
     broadcasts: BroadcasterItem[];
-    onRefreshBroadcasts: () => Promise<void> | undefined;
+    onRefreshBroadcasts: () => void;
     watchBroadcast: (id: string) => void;
     startRemoteServer: () => Promise<{ port: number }>;
     stopRemoteServer: () => Promise<void>;

--- a/src/renderer/pages/spectate/spectate_page.tsx
+++ b/src/renderer/pages/spectate/spectate_page.tsx
@@ -21,6 +21,7 @@ export const SpectatePage = React.memo(
   ({
     userId,
     broadcasts,
+    remoteServerState,
     onRefreshBroadcasts,
     watchBroadcast,
     startRemoteServer,
@@ -28,6 +29,7 @@ export const SpectatePage = React.memo(
   }: {
     userId?: string;
     broadcasts: BroadcasterItem[];
+    remoteServerState: { connected: boolean; started: boolean; port: number };
     onRefreshBroadcasts: () => void;
     watchBroadcast: (id: string) => void;
     startRemoteServer: (port: number) => Promise<{ success: boolean; err?: string }>;
@@ -99,7 +101,11 @@ export const SpectatePage = React.memo(
               >
                 <SpectatorIdBlock userId={userId} />
                 <ShareGameplayBlock />
-                <WebSocketBlock startRemoteServer={startRemoteServer} stopRemoteServer={stopRemoteServer} />
+                <WebSocketBlock
+                  remoteServerState={remoteServerState}
+                  startRemoteServer={startRemoteServer}
+                  stopRemoteServer={stopRemoteServer}
+                />
               </div>
             }
             style={{ gridTemplateColumns: "auto 400px" }}

--- a/src/renderer/pages/spectate/spectate_page.tsx
+++ b/src/renderer/pages/spectate/spectate_page.tsx
@@ -15,6 +15,7 @@ import { Footer } from "./footer";
 import { ShareGameplayBlock } from "./share_gameplay_block/share_gameplay_block";
 import { SpectateItem } from "./spectate_item";
 import { SpectatorIdBlock } from "./spectator_id_block";
+import { WebSocketBlock } from "./websocket_block";
 
 export const SpectatePage = React.memo(
   ({
@@ -22,11 +23,15 @@ export const SpectatePage = React.memo(
     broadcasts,
     onRefreshBroadcasts,
     watchBroadcast,
+    startRemoteServer,
+    stopRemoteServer,
   }: {
     userId?: string;
     broadcasts: BroadcasterItem[];
-    onRefreshBroadcasts: () => void;
+    onRefreshBroadcasts: () => Promise<void> | undefined;
     watchBroadcast: (id: string) => void;
+    startRemoteServer: () => Promise<{ port: number }>;
+    stopRemoteServer: () => Promise<void>;
   }) => {
     if (!userId) {
       return <IconMessage Icon={AccountCircleIcon} label="You must be logged in to use this feature" />;
@@ -94,6 +99,7 @@ export const SpectatePage = React.memo(
               >
                 <SpectatorIdBlock userId={userId} />
                 <ShareGameplayBlock />
+                <WebSocketBlock startRemoteServer={startRemoteServer} stopRemoteServer={stopRemoteServer} />
               </div>
             }
             style={{ gridTemplateColumns: "auto 400px" }}

--- a/src/renderer/pages/spectate/websocket_block.tsx
+++ b/src/renderer/pages/spectate/websocket_block.tsx
@@ -1,0 +1,86 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import Button from "@mui/material/Button";
+import InputBase from "@mui/material/InputBase";
+import React from "react";
+
+import { InfoBlock } from "@/components/info_block";
+
+const StartStopButton = styled(Button)`
+  width: 100%;
+`;
+
+export const WebSocketBlock = React.memo(
+  ({
+    startRemoteServer,
+    stopRemoteServer,
+  }: {
+    startRemoteServer: () => Promise<{ port: number }>;
+    stopRemoteServer: () => Promise<void>;
+  }) => {
+    const [port, setPort] = React.useState(0);
+    const address = "ws://localhost:" + port;
+
+    const [copied, setCopied] = React.useState(false);
+    const onCopy = React.useCallback(() => {
+      // Set the clipboard text
+      window.electron.clipboard.writeText(address);
+
+      // Set copied indication
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    }, [address]);
+
+    const [starting, setStarting] = React.useState(false);
+    const onStart = async () => {
+      setStarting(true);
+      const { port: newPort } = await startRemoteServer();
+      setPort(newPort);
+      setStarting(false);
+    };
+    const onStop = async () => {
+      await stopRemoteServer();
+      setPort(0);
+    };
+
+    return (
+      <InfoBlock title="WebSocket Server">
+        <div style={{ fontSize: 14 }}>
+          <p style={{ marginTop: 0 }}>Remote control Slippi spectate via WebSocket.</p>
+        </div>
+        <div
+          css={css`
+            display: flex;
+            flex-direction: row;
+            margin-bottom: 14px;
+          `}
+        >
+          <InputBase
+            css={css`
+              flex: 1;
+              padding: 5px 10px;
+              margin-right: 10px;
+              border-radius: 10px;
+              background-color: rgba(0, 0, 0, 0.4);
+              font-size: 14px;
+            `}
+            disabled={true}
+            value={port > 0 ? address : "Stopped"}
+          />
+          <Button variant="contained" color="secondary" onClick={onCopy} disabled={port === 0}>
+            {copied ? "Copied!" : "Copy"}
+          </Button>
+        </div>
+        {port > 0 ? (
+          <StartStopButton variant="outlined" color="secondary" onClick={onStop}>
+            Stop
+          </StartStopButton>
+        ) : (
+          <StartStopButton variant="contained" color="primary" onClick={onStart} disabled={starting}>
+            {starting ? "Starting..." : "Start"}
+          </StartStopButton>
+        )}
+      </InfoBlock>
+    );
+  },
+);

--- a/src/renderer/services/install.ts
+++ b/src/renderer/services/install.ts
@@ -23,6 +23,7 @@ export async function installServices(): Promise<Services> {
 
   const broadcastService = window.electron.broadcast;
   const consoleService = window.electron.console;
+  const remoteService = window.electron.remote;
 
   return {
     authService,
@@ -31,6 +32,7 @@ export async function installServices(): Promise<Services> {
     broadcastService,
     consoleService,
     replayService,
+    remoteService,
     notificationService,
   };
 }

--- a/src/renderer/services/types.ts
+++ b/src/renderer/services/types.ts
@@ -1,6 +1,7 @@
 import type { BroadcastService } from "@broadcast/types";
 import type { ConsoleService } from "@console/types";
 import type { DolphinService } from "@dolphin/types";
+import type { RemoteService } from "@remote/types";
 import type { ReplayService } from "@replays/types";
 
 import type { AuthService } from "./auth/types";
@@ -15,4 +16,5 @@ export type Services = {
   consoleService: ConsoleService;
   replayService: ReplayService;
   notificationService: NotificationService;
+  remoteService: RemoteService;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
       "@replays/*": ["replays/*"],
       "@settings/*": ["settings/*"],
       "@console/*": ["console/*"],
-      "@database/*": ["database/*"]
+      "@database/*": ["database/*"],
+      "@remote/*": ["remote/*"],
     },
     "baseUrl": "./src",
     "outDir": "release/app/dist",


### PR DESCRIPTION
Implement Spectate Remote Control v1 per the [design doc](https://docs.google.com/document/d/1EBpabqW6ZM3hBTDd83z7flw9lNI1hXtpxa5FCCQvZGQ/edit?usp=sharing)
# Possible Changes
Please let me know if you'd like me to
* move `spectate.worker.ts` and `spectate_manager.ts` from `broadcast/` to `common/` or something like that
* move the UI control panel to somewhere a bit less discoverable for non-advanced users (maybe Settings -> Advanced? This would also be appropriate for the possibility of extending the remote control functionality to console mirroring and replay playback)
# Screenshots
![Screenshot 2024-03-12 145935](https://github.com/project-slippi/slippi-launcher/assets/3300257/e16ed383-e4ec-49fe-a23f-107a5f297a46)
![Screenshot 2024-03-12 145944](https://github.com/project-slippi/slippi-launcher/assets/3300257/d473b41d-746e-4163-a1db-b981cdd8fca1)

# Spectate Remote Control server: WebSocket API
(accepts only 1 connection at a time)
## `spectate-protocol`
```
> let socket = new WebSocket("ws://localhost:55761", "spectate-protocol");
> socket.onopen = () => { console.log("open") };
> socket.onmessage = (event) => { console.log("message: " + event.data) };
> socket.onerror = (event) => { console.log("error: " + JSON.stringify(event)) };
> socket.onclose = () => { console.log("close") };

open
```
## `new-file-event`
```
message: {"op":"new-file-event","dolphinId":"spectate-q0ejrrUneJcA5v65nUVX13OYr0o2-cYp8HZJ9FB3P3uW72b2dHM","filePath":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate\\Game_20240309T104448.slp"}
```
## `game-end-event`
```
message: {"op":"game-end-event","dolphinId":"spectate-q0ejrrUneJcA5v65nUVX13OYr0o2-cYp8HZJ9FB3P3uW72b2dHM"}
```
## `dolphin-closed-event`
```
message: {"op":"dolphin-closed-event","dolphinId":"spectate-q0ejrrUneJcA5v65nUVX13OYr0o2-cYp8HZJ9FB3P3uW72b2dHM"}
```
## `list-broadcasts-request`
```
> socket.send(JSON.stringify({op: "list-broadcasts-request"}))

message: {"op":"list-broadcasts-response","broadcasts":[{"id":"q0ejrrUneJcA5v65nUVX13OYr0o2-cYp8HZJ9FB3P3uW72b2dHM","name":"LOST#882","broadcaster":{"uid":"q0ejrrUneJcA5v65nUVX13OYr0o2","name":"lostletters"}}]}
```
## `spectate-broadcast-request`
if `dolphinId` is not specified, spectating will begin in a new dolphin window
```
> socket.send(JSON.stringify({op: "spectate-broadcast-request", broadcastId: "PMmdJgqjWzWrMHmq2IbktBKpbcf2-4zXtnoxyBgA2jRwH6wYbtb"}));

message: {"op":"spectate-broadcast-response","dolphinId":"1710210546025remote0","path":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate"}
message: {"op":"new-file-event","dolphinId":"1710210546025remote0","filePath":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate\\Game_20240309T104448.slp"}
```
if `dolphinId` is specified, spectating will begin in the existing dolphin window with that id (if one exists), or a new dolphin window (if none exists)
```
> socket.send(JSON.stringify({op: "spectate-broadcast-request", broadcastId: "PMmdJgqjWzWrMHmq2IbktBKpbcf2-4zXtnoxyBgA2jRwH6wYbtb", dolphinId: "dolphin-id"}));

message: {"op":"spectate-broadcast-response","dolphinId":"dolphin-id","path":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate"}
message: {"op":"new-file-event","dolphinId":"dolphin-id","filePath":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate\\Game_20240312T130151.slp"}

> socket.send(JSON.stringify({op: "spectate-broadcast-request", broadcastId: "q0ejrrUneJcA5v65nUVX13OYr0o2-pb3C5YdjLzCP4sZHhCAbyg", dolphinId: "dolphin-id"}));

message: {"op":"spectate-broadcast-response","dolphinId":"dolphin-id","path":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate"}
message: {"op":"new-file-event","dolphinId":"dolphin-id","filePath":"C:\\Users\\jmlee337\\Documents\\Slippi\\Spectate\\Game_20240312T130208.slp"}
```
## `close-dolphin-request`
```
> socket.send(JSON.stringify({op: "close-dolphin-request", dolphinId: "spectate-q0ejrrUneJcA5v65nUVX13OYr0o2-cYp8HZJ9FB3P3uW72b2dHM"}));

message: {"op":"close-dolphin-response"}
message: {"op":"dolphin-closed-event","dolphinId":"spectate-q0ejrrUneJcA5v65nUVX13OYr0o2-cYp8HZJ9FB3P3uW72b2dHM"}
```
## `err`
Request errors are denoted by the presence of an `err` field in the response
```
> socket.send(JSON.stringify({op: "close-dolphin-request", dolphinId: "nonexistent-dolphin-id"}));
message: {"op":"close-dolphin-response","err":"no such playback dolphin instance"}
```