### PR TITLE
Add lodash linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     createDefaultProgram: true,
   },
-  plugins: ["simple-import-sort", "strict-booleans", "react-hooks", "prettier", "@stylexjs"],
+  plugins: ["simple-import-sort", "strict-booleans", "react-hooks", "prettier", "@stylexjs", "lodash"],
   extends: [
     "plugin:react/recommended",
     "eslint:recommended",
@@ -101,6 +101,7 @@ module.exports = {
     "react/jsx-boolean-value": ["error", "always"],
     "react/no-unstable-nested-components": "error",
     "@stylexjs/valid-styles": "error",
+    "lodash/chaining": "error",
   },
   ignorePatterns: ["/*.js", "node_modules"],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,6 +102,7 @@ module.exports = {
     "react/no-unstable-nested-components": "error",
     "@stylexjs/valid-styles": "error",
     "lodash/chaining": "error",
+    "lodash/import-scope": [2, "method"],
   },
   ignorePatterns: ["/*.js", "node_modules"],
 };

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jest": "^25.3.2",
     "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.28.0",

--- a/src/renderer/pages/home/sidebar/ranked_status.tsx
+++ b/src/renderer/pages/home/sidebar/ranked_status.tsx
@@ -2,7 +2,6 @@ import { Button, Card, Typography } from "@mui/material";
 import * as stylex from "@stylexjs/stylex";
 import type { Duration } from "date-fns";
 import { formatDuration, intervalToDuration } from "date-fns";
-import { chain } from "lodash";
 import React from "react";
 
 import { ExternalLink } from "@/components/external_link";
@@ -70,7 +69,10 @@ const getFullAccessTimes = (now: Date): { isActive: boolean; nextStartTime: Date
 };
 
 const convertCodeToSlug = (code: string | undefined) => {
-  return chain(code).toLower().replace("#", "-").value();
+  if (code) {
+    return code.toLowerCase().replace("#", "-");
+  }
+  return "";
 };
 
 const InternalRankedStatus = ({

--- a/src/renderer/pages/home/sidebar/ranked_status.tsx
+++ b/src/renderer/pages/home/sidebar/ranked_status.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as RankedDayActiveIcon } from "@/styles/images/ranked_da
 import { ReactComponent as RankedDayInactiveIcon } from "@/styles/images/ranked_day_inactive.svg";
 import { colors } from "@/styles/tokens.stylex";
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const FREE_ACCESS_START_AT = new Date(Date.UTC(2024, 3, 15, 14, 0, 0)); // Note: Month is 0-indexed, so 3 is April
 const FREE_ACCESS_OFFSET_FROM = new Date(Date.UTC(2024, 3, 15, 8, 0, 0)); // Note: Month is 0-indexed, so 3 is April
 
@@ -47,24 +48,23 @@ const styles = stylex.create({
 });
 
 const getFullAccessTimes = (now: Date): { isActive: boolean; nextStartTime: Date; nextEndTime: Date } => {
-  const msPerDay = 24 * 60 * 60 * 1000;
   const startTime = FREE_ACCESS_START_AT;
   const offsetTime = FREE_ACCESS_OFFSET_FROM;
   if (now < startTime) {
-    return { isActive: false, nextStartTime: startTime, nextEndTime: new Date(offsetTime.getTime() + msPerDay) };
+    return { isActive: false, nextStartTime: startTime, nextEndTime: new Date(offsetTime.getTime() + MS_PER_DAY) };
   }
 
-  const daysSinceStart = Math.floor((now.getTime() - offsetTime.getTime()) / msPerDay);
+  const daysSinceStart = Math.floor((now.getTime() - offsetTime.getTime()) / MS_PER_DAY);
   let daysUntilNextRankedDay = 4 - (daysSinceStart % 4);
   if (daysUntilNextRankedDay === 4) {
     daysUntilNextRankedDay = 0;
   }
-  const nextRankedDayTime = new Date(offsetTime.getTime() + (daysSinceStart + daysUntilNextRankedDay) * msPerDay);
+  const nextRankedDayTime = new Date(offsetTime.getTime() + (daysSinceStart + daysUntilNextRankedDay) * MS_PER_DAY);
 
   return {
     isActive: daysUntilNextRankedDay === 0,
     nextStartTime: nextRankedDayTime,
-    nextEndTime: new Date(nextRankedDayTime.getTime() + msPerDay),
+    nextEndTime: new Date(nextRankedDayTime.getTime() + MS_PER_DAY),
   };
 };
 
@@ -91,13 +91,7 @@ const InternalRankedStatus = ({
     <div {...stylex.props(styles.container)}>
       <Card {...stylex.props(styles.card)}>
         <div {...stylex.props(styles.centerStack)}>
-          <Typography
-            variant="h6"
-            color={colors.purpleLight}
-            fontSize={"14px"}
-            fontWeight={"semibold"}
-            marginBottom={"8px"}
-          >
+          <Typography variant="h6" color={colors.purpleLight} fontSize="14px" fontWeight="semibold" marginBottom="8px">
             RANKED DAY
           </Typography>
           {isFullAccess ? <RankedDayActiveIcon width={40} /> : <RankedDayInactiveIcon width={40} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9224,6 +9224,13 @@ eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
+eslint-plugin-lodash@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.4.0.tgz#14a761547f126c92ff56789662a20a44f8bb6290"
+  integrity sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==
+  dependencies:
+    lodash "^4.17.21"
+
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"


### PR DESCRIPTION
### Description

This PR adds the lodash eslint plugin and sets the following rules:
* disables usage of `lodash/chain` - imports the whole lodash library
* enforces method based lodash imports e.g. `import blah from 'lodash/blah'` - better for tree shaking

