### PR TITLE
feat: Sorting for replay folders

### DIFF
--- a/src/renderer/pages/replays/replay_browser/folder_tree_node.tsx
+++ b/src/renderer/pages/replays/replay_browser/folder_tree_node.tsx
@@ -15,16 +15,41 @@ type FolderTreeNodeProps = {
   nestLevel?: number;
   folder: FolderResult;
   collapsedFolders: readonly string[];
+  isReversed: boolean;
   onClick: (fullPath: string) => void;
   onToggle: (fullPath: string) => void;
 };
 
-export const FolderTreeNode = ({ nestLevel = 0, folder, collapsedFolders, onClick, onToggle }: FolderTreeNodeProps) => {
+export const FolderTreeNode = ({
+  nestLevel = 0,
+  folder,
+  collapsedFolders,
+  isReversed,
+  onClick,
+  onToggle,
+}: FolderTreeNodeProps) => {
   const currentFolder = useReplays((store) => store.currentFolder);
   const hasChildren = folder.subdirectories.length > 0;
   const isCollapsed = collapsedFolders.includes(folder.fullPath);
   const isSelected = currentFolder === folder.fullPath;
   const labelColor = isSelected ? colors.grayDark : "rgba(255, 255, 255, 0.5)";
+
+  const getSubdirectoryNodes = () => {
+    const subdirectories = folder.subdirectories.map((f) => (
+      <FolderTreeNode
+        nestLevel={nestLevel + 1}
+        key={f.fullPath}
+        folder={f}
+        collapsedFolders={collapsedFolders}
+        isReversed={isReversed}
+        onClick={onClick}
+        onToggle={onToggle}
+      />
+    ));
+
+    return isReversed ? subdirectories.reverse() : subdirectories;
+  };
+
   return (
     <div>
       <ListItem
@@ -74,16 +99,7 @@ export const FolderTreeNode = ({ nestLevel = 0, folder, collapsedFolders, onClic
       </ListItem>
       {folder.subdirectories.length === 0 || isCollapsed ? null : (
         <List dense={true} style={{ padding: 0 }}>
-          {folder.subdirectories.map((f) => (
-            <FolderTreeNode
-              nestLevel={nestLevel + 1}
-              key={f.fullPath}
-              folder={f}
-              collapsedFolders={collapsedFolders}
-              onClick={onClick}
-              onToggle={onToggle}
-            />
-          ))}
+          {getSubdirectoryNodes()}
         </List>
       )}
     </div>

--- a/src/renderer/pages/replays/replay_browser/replay_browser.tsx
+++ b/src/renderer/pages/replays/replay_browser/replay_browser.tsx
@@ -1,6 +1,7 @@
 import { exists } from "@common/exists";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
 import FolderIcon from "@mui/icons-material/Folder";
 import SearchIcon from "@mui/icons-material/Search";
 import Button from "@mui/material/Button";
@@ -8,7 +9,7 @@ import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import React, { useState } from "react";
 
 import { DualPane } from "@/components/dual_pane";
 import { BasicFooter } from "@/components/footer/footer";
@@ -50,6 +51,8 @@ export const ReplayBrowser = React.memo(() => {
   const { files: filteredFiles, hiddenFileCount } = useReplayBrowserList();
   const { goToReplayStatsPage } = useReplayBrowserNavigation();
 
+  const [isFolderTreeReversed, setIsFolderTreeReversed] = useState<boolean>(true);
+
   const setSelectedItem = (index: number | null) => {
     if (index === null) {
       void presenter.current.clearSelectedFile();
@@ -84,6 +87,23 @@ export const ReplayBrowser = React.memo(() => {
     [showError, showSuccess],
   );
 
+  const onFolderTreeSortClick = () => {
+    setIsFolderTreeReversed(!isFolderTreeReversed);
+  };
+
+  const folderTreeNodes = folderTree.map((folder) => {
+    return (
+      <FolderTreeNode
+        folder={folder}
+        key={folder.fullPath}
+        collapsedFolders={collapsedFolders}
+        isReversed={isFolderTreeReversed}
+        onClick={onFolderTreeNodeClick}
+        onToggle={(folder) => presenter.current.toggleFolder(folder)}
+      />
+    );
+  });
+
   return (
     <Outer>
       <div
@@ -103,17 +123,13 @@ export const ReplayBrowser = React.memo(() => {
           leftSide={
             <List dense={true} style={{ flex: 1, padding: 0 }}>
               <div style={{ position: "relative", minHeight: "100%" }}>
-                {folderTree.map((folder) => {
-                  return (
-                    <FolderTreeNode
-                      folder={folder}
-                      key={folder.fullPath}
-                      collapsedFolders={collapsedFolders}
-                      onClick={onFolderTreeNodeClick}
-                      onToggle={(folder) => presenter.current.toggleFolder(folder)}
-                    />
-                  );
-                })}
+                <Button
+                  onClick={onFolderTreeSortClick}
+                  startIcon={isFolderTreeReversed ? <ArrowDownward /> : <ArrowUpward />}
+                >
+                  Sort
+                </Button>
+                {isFolderTreeReversed ? folderTreeNodes.reverse() : folderTreeNodes}
                 {loading && (
                   <div
                     style={{


### PR DESCRIPTION
I made a few changes to add a sort button to the left pane of the replay page that toggles the sort order of the folder names and their subdirectories. Picked this up after seeing a [very old feature request](https://discord.com/channels/328261477372919811/459910213286363136/989646534301859890) and wanting it for myself. This would mainly be useful for people who are organizing their replays into monthly subfolders and need to scroll down to get the most recent replays. This also adjusts the default sort order so those with monthly replay folders will see their most recent replays appear at the top by default.

This is my first time contributing so apologies if I didn't follow any code or PR standards correctly. I'm also definitely open to feedback on the UI and placement of the sort button.

Default sorting:
![image](https://github.com/project-slippi/slippi-launcher/assets/48635776/941f1561-6294-4824-89b5-7ca8e55da3f1)

Toggled sorting (same as the current default): 
![image](https://github.com/project-slippi/slippi-launcher/assets/48635776/5988b0c7-a348-4351-8d14-d6af94f34941)

