### PR TITLE
refactor: remove temp files on startup

### DIFF
--- a/src/dolphin/install/ishiiruka_installation.ts
+++ b/src/dolphin/install/ishiiruka_installation.ts
@@ -309,8 +309,5 @@ export class IshiirukaDolphinInstallation implements DolphinInstallation {
         );
       }
     }
-    await fs.remove(assetPath).catch((err) => {
-      log.error(`Could not delete dolphin asset: ${err}`);
-    });
   }
 }

--- a/src/dolphin/install/mainline_installation.ts
+++ b/src/dolphin/install/mainline_installation.ts
@@ -305,8 +305,5 @@ export class MainlineDolphinInstallation implements DolphinInstallation {
         );
       }
     }
-    await fs.remove(assetPath).catch((err) => {
-      log.error(`Could not delete dolphin asset: ${err}`);
-    });
   }
 }

--- a/src/renderer/lib/hooks/use_app.ts
+++ b/src/renderer/lib/hooks/use_app.ts
@@ -92,6 +92,19 @@ export const useAppInitialization = () => {
     // Check if there is an update to the launcher
     promises.push(window.electron.common.checkForAppUpdates());
 
+    // Remove any temp files
+    promises.push(
+      (async () => {
+        window.electron.common.clearTempFolder().catch((err) => {
+          // silently fail since this isn't a critical issue
+          log.error(
+            `Could not clear temp folder on startup due to:
+            ${err instanceof Error ? err.message : JSON.stringify(err)}`,
+          );
+        });
+      })(),
+    );
+
     // Wait for all the promises to complete before completing
     try {
       await Promise.all(promises);


### PR DESCRIPTION
i just don't think we need to delete the dolphin archives immediately, moving it to on startup seems fairly sane