### PR TITLE
ci: Fix MacOS stapling issue

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -1,8 +1,32 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 const electronNotarize = require("@electron/notarize");
 const electronBuilderConfig = require("../../electron-builder.json");
+
+// Helper to add delay
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Helper to staple with retries
+async function stapleWithRetries(appPath, maxRetries = 5, retryDelay = 30000) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      console.log(`Stapling attempt ${attempt}/${maxRetries}...`);
+      execSync(`xcrun stapler staple "${appPath}"`, { stdio: "inherit" });
+      console.log("Successfully stapled!");
+      return true;
+    } catch (error) {
+      console.warn(`Stapling attempt ${attempt} failed:`, error.message);
+      if (attempt < maxRetries) {
+        console.log(`Waiting ${retryDelay / 1000}s before retry...`);
+        await delay(retryDelay);
+      }
+    }
+  }
+  console.warn("Stapling failed after all retries - app is notarized but ticket not stapled");
+  return false;
+}
 
 module.exports = async function (params) {
   if (process.platform !== "darwin" || !process.env.SLIPPI_ENABLE_SIGNING) {
@@ -29,6 +53,7 @@ module.exports = async function (params) {
   const keyPath = path.join(process.env.HOME, `private_keys/AuthKey_${process.env.APPLE_API_KEY_ID}.p8`);
 
   try {
+    // Notarize but don't staple automatically
     await electronNotarize.notarize({
       tool: "notarytool",
       appBundleId: appId,
@@ -39,7 +64,21 @@ module.exports = async function (params) {
     });
 
     console.log(`Successfully notarized ${appId}`);
+
+    // Wait a bit for the ticket to propagate in Apple's systems
+    console.log("Waiting 30s for notarization ticket to propagate...");
+    await delay(30000);
+
+    // Try to staple with retries
+    await stapleWithRetries(appPath);
   } catch (error) {
-    console.error(error);
+    console.error("Notarization error:", error);
+    // Stapling failures (code 65) are non-fatal - app is still notarized
+    if (error.message && error.message.includes("code: 65")) {
+      console.warn("Stapling failed - app is notarized but ticket not stapled");
+      console.warn("This is usually safe and the ticket will be fetched online");
+      return;
+    }
+    throw error; // Re-throw actual notarization errors
   }
 };


### PR DESCRIPTION
## Fix macOS notarization stapling failures (Error 65)

### Problem
macOS builds were failing during the stapling step with error code 65:

```
Error: Failed to staple your application with code: 65
CloudKit query failed due to "Record not found"
```

This occurred because Apple's CloudKit servers hadn't made the notarization ticket available yet when stapling was attempted - a race condition between successful notarization and ticket propagation.

### Solution
Updated `.erb/scripts/notarize.js` to handle stapling timing issues:
- Add 30s delay after notarization for ticket propagation
- Implement retry logic: up to 5 stapling attempts with 30s delays
- Use direct `xcrun stapler` calls for better control
- Gracefully continue build if stapling fails (app remains properly notarized)

### Why This Works
- **Notarization is what matters for security** - app is still properly signed and notarized
- **Stapling is an optimization** - embeds the ticket for offline verification; macOS fetches it online if missing
- **Retries handle propagation delays** - usually succeeds once Apple's systems sync

This is a common macOS notarization issue and the retry approach is the industry-standard solution.

