### PR TITLE
fix: expired firebase account conflicts

### DIFF
--- a/src/renderer/services/auth/types.ts
+++ b/src/renderer/services/auth/types.ts
@@ -39,6 +39,7 @@ export interface MultiAccountService {
   init(): Promise<void>;
 
   // Account Management
+  signUp(email: string, password: string, displayName: string): Promise<StoredAccount>;
   addAccount(email: string, password: string): Promise<StoredAccount>;
   removeAccount(accountId: string): Promise<void>;
   switchAccount(accountId: string): Promise<void>;


### PR DESCRIPTION
# Firebase Authentication Fix - Re-authentication Failure

## Problem

Users couldn't log in after session expiration despite correct credentials:
- Wrong password → shows error ✅
- Correct password → no error, no login ❌
- Error: `FirebaseError: auth/invalid-credential`

## Root Cause

**IndexedDB persistence conflicts** when re-authenticating existing accounts:

Original flow couldn't check if account existed until AFTER sign-in, but sign-in was failing due to persistence conflicts with expired session data in IndexedDB.

```
❌ OLD: Create temp app → Sign in (FAILS) → Check if exists
```

## Solution

Check for existing account by email **before** attempting authentication:

```
✅ NEW: Check if exists by email → Use existing Firebase app → Re-authenticate
```

**File:** `src/renderer/services/auth/multi_account.service.ts`

- Check if account exists by email before creating temp app
- If exists: re-authenticate using the account's existing Firebase app (avoids IndexedDB conflicts)
- If new: use temp app with clean IndexedDB storage (no conflicts)

## Scenarios Covered

### Scenario 1: Existing Multi-Account User
User has account stored in settings with expired session:
- ✅ Email check finds account → uses existing app → re-authenticates successfully

### Scenario 2: First-Time Multi-Account User (Upgrading)
User had logged in with old app (no multi-account), then:
1. Session expires
2. Updates to multi-account version
3. Tries to log in

Flow:
- Settings empty (no accounts stored yet)
- Migration finds expired session → skips (no account added)
- Email check finds nothing → creates temp app with clean IndexedDB
- ✅ Authentication succeeds → account saved to settings

### Scenario 3: Brand New User
- ✅ No existing data → temp app → clean authentication
