### PR TITLE
spectate remote control: add `filePath` to `game-end-event` and `spectating-broadcasts-event`

### DIFF
--- a/src/broadcast/spectate.worker.ts
+++ b/src/broadcast/spectate.worker.ts
@@ -18,7 +18,7 @@ interface Methods {
   connect(authToken: string): Promise<void>;
   disconnect(): Promise<void>;
   refreshBroadcastList(): Promise<void>;
-  getOpenBroadcasts(): Promise<{ broadcastId: string; dolphinId: string }[]>;
+  getOpenBroadcasts(): Promise<{ broadcastId: string; dolphinId: string; filePath: string | null }[]>;
   getLogObservable(): Observable<string>;
   getErrorObservable(): Observable<Error | string>;
   getBroadcastListObservable(): Observable<BroadcasterItem[]>;
@@ -30,7 +30,7 @@ interface Methods {
     broadcasterName: string;
   }>;
   getReconnectObservable(): Observable<Record<never, never>>;
-  getGameEndObservable(): Observable<{ broadcastId: string; dolphinId: string }>;
+  getGameEndObservable(): Observable<{ broadcastId: string; dolphinId: string; filePath: string }>;
 }
 
 export type WorkerSpec = ModuleMethods & Methods;
@@ -48,7 +48,7 @@ const spectateDetailsSubject = new Subject<{
   broadcasterName: string;
 }>();
 const reconnectSubject = new Subject<Record<never, never>>();
-const gameEndSubject = new Subject<{ broadcastId: string; dolphinId: string }>();
+const gameEndSubject = new Subject<{ broadcastId: string; dolphinId: string; filePath: string }>();
 
 // Forward the events to the renderer
 spectateManager.on(SpectateEvent.BROADCAST_LIST_UPDATE, async (data: BroadcasterItem[]) => {
@@ -78,8 +78,8 @@ spectateManager.on(SpectateEvent.RECONNECT, async () => {
   reconnectSubject.next({});
 });
 
-spectateManager.on(SpectateEvent.GAME_END, async (broadcastId: string, dolphinId: string) => {
-  gameEndSubject.next({ broadcastId, dolphinId });
+spectateManager.on(SpectateEvent.GAME_END, async (broadcastId: string, dolphinId: string, filePath: string) => {
+  gameEndSubject.next({ broadcastId, dolphinId, filePath });
 });
 
 const methods: WorkerSpec = {
@@ -141,7 +141,7 @@ const methods: WorkerSpec = {
   getReconnectObservable(): Observable<Record<never, never>> {
     return Observable.from(reconnectSubject);
   },
-  getGameEndObservable(): Observable<{ broadcastId: string; dolphinId: string }> {
+  getGameEndObservable(): Observable<{ broadcastId: string; dolphinId: string; filePath: string }> {
     return Observable.from(gameEndSubject);
   },
 };

--- a/src/broadcast/spectate_manager.ts
+++ b/src/broadcast/spectate_manager.ts
@@ -69,9 +69,6 @@ export class SpectateManager extends EventEmitter {
           this.emit(SpectateEvent.LOG, "Game end explicit");
           broadcastInfo.fileWriter.endCurrentFile();
           broadcastInfo.gameStarted = false;
-
-          // Observers should be able to depend on the file being closed, so emit this last.
-          this.emit(SpectateEvent.GAME_END, broadcastId, broadcastInfo.dolphinId);
           break;
         }
         case "game_event": {
@@ -258,6 +255,9 @@ export class SpectateManager extends EventEmitter {
     slpFileWriter.on(SlpFileWriterEvent.NEW_FILE, (currFilePath) => {
       this._playFile(currFilePath, broadcastId, dolphinPlaybackId, broadcasterName).catch(console.warn);
     });
+    slpFileWriter.on(SlpFileWriterEvent.FILE_COMPLETE, (completedFilePath) => {
+      this.emit(SpectateEvent.GAME_END, broadcastId, dolphinPlaybackId, completedFilePath);
+    });
 
     this.addNewOpenBroadcast(broadcastId, dolphinPlaybackId, slpFileWriter);
 
@@ -313,6 +313,7 @@ export class SpectateManager extends EventEmitter {
     return Object.values(this.openBroadcasts).map((value) => ({
       broadcastId: value.broadcastId,
       dolphinId: value.dolphinId,
+      filePath: value.fileWriter.getCurrentFilename(),
     }));
   }
 

--- a/src/broadcast/types.ts
+++ b/src/broadcast/types.ts
@@ -93,7 +93,7 @@ export interface SpectateController {
   dolphinClosed(playbackId: string): Promise<void>;
   connect(authToken: string): Promise<void>;
   refreshBroadcastList(): Promise<void>;
-  getOpenBroadcasts(): Promise<{ broadcastId: string; dolphinId: string }[]>;
+  getOpenBroadcasts(): Promise<{ broadcastId: string; dolphinId: string; filePath: string | null }[]>;
   getBroadcastListObservable(): Observable<BroadcasterItem[]>;
   getSpectateDetailsObservable(): Observable<{
     broadcastId: string;
@@ -101,6 +101,6 @@ export interface SpectateController {
     filePath: string;
     broadcasterName: string;
   }>;
-  getGameEndObservable(): Observable<{ broadcastId: string; dolphinId: string }>;
+  getGameEndObservable(): Observable<{ broadcastId: string; dolphinId: string; filePath: string }>;
   getErrorObservable(): Observable<Error | string>;
 }


### PR DESCRIPTION
also do not emit game-end until the file is actually closed
also make event_op enum