### PR TITLE
fix: remove redundant multi-account sync effect

### DIFF
--- a/src/renderer/app/header/user_menu/user_menu.tsx
+++ b/src/renderer/app/header/user_menu/user_menu.tsx
@@ -67,14 +67,6 @@ export const UserMenu = ({ user, handleError }: { user: AuthUser; handleError: (
   // Get multi-account service
   const multiAccountService = authService.getMultiAccountService();
 
-  // Update accounts in state when they change
-  React.useEffect(() => {
-    const accountsList = multiAccountService.getAccounts();
-    const activeId = multiAccountService.getActiveAccountId();
-    setAccounts(accountsList);
-    setActiveAccountId(activeId);
-  }, [multiAccountService, setAccounts, setActiveAccountId]);
-
   // Handle account switch
   const handleSwitchAccount = async (accountId: string) => {
     if (switching) {


### PR DESCRIPTION
**Summary**

Removes a redundant useEffect in UserMenu that manually synchronized multi-account state.

**Background**

Multi-account state (accounts and activeAccountId) is already kept in sync globally via
multiAccountService.onAccountsChange, which updates the useAccount store whenever the
service changes.
The additional sync performed in UserMenu duplicated this behavior.

**Issue**

In development (React StrictMode), the extra effect caused a feedback loop between:
- the component-level useEffect
- the global onAccountsChange subscription
- Zustand store updates
This resulted in a Maximum update depth exceeded crash.

**Fix**

Remove the redundant component-level sync

Rely solely on the existing global subscription for multi-account state updates in
src/renderer/listeners/install_app_listeners.ts
