### PR TITLE
Fix: Linux AppImage nesting causes slow file picker in dolphin

### DIFF
--- a/src/dolphin/instance.ts
+++ b/src/dolphin/instance.ts
@@ -102,11 +102,14 @@ export class DolphinInstance extends EventEmitter {
           });
         } else {
           const appdir = process.env.APPDIR;
+          const dolphinEnv = {};
           for (const key in process.env) {
             const split_val = process.env[key].split(":");
-            process.env[key] = split_val.filter((val) => !val.includes(appdir)).join(":");
+            dolphinEnv[key] = split_val.filter((val) => !val.includes(appdir)).join(":");
           }
-          child = spawn(executablePath, params);
+          child = spawn(executablePath, params, {
+            env: dolphinEnv,
+          });
         }
 
         child.once("spawn", () => {

--- a/src/dolphin/instance.ts
+++ b/src/dolphin/instance.ts
@@ -101,6 +101,11 @@ export class DolphinInstance extends EventEmitter {
             maxBuffer: 1000 * 1000 * 100,
           });
         } else {
+          const appdir = process.env.APPDIR;
+          for (const key in process.env) {
+            const split_val = process.env[key].split(":");
+            process.env[key] = split_val.filter((val) => !val.includes(appdir)).join(":");
+          }
           child = spawn(executablePath, params);
         }
 

--- a/src/dolphin/instance.ts
+++ b/src/dolphin/instance.ts
@@ -101,12 +101,8 @@ export class DolphinInstance extends EventEmitter {
             maxBuffer: 1000 * 1000 * 100,
           });
         } else {
-          const appdir = process.env.APPDIR;
-          const dolphinEnv = {};
-          for (const key in process.env) {
-            const split_val = process.env[key].split(":");
-            dolphinEnv[key] = split_val.filter((val) => !val.includes(appdir)).join(":");
-          }
+          const appDir = process.env.APPDIR;
+          const dolphinEnv = appDir ? this.cleanAppImageEnv(appDir) : process.env;
           child = spawn(executablePath, params, {
             env: dolphinEnv,
           });
@@ -131,6 +127,20 @@ export class DolphinInstance extends EventEmitter {
         reject(err);
       }
     });
+  }
+
+  private cleanAppImageEnv(appDir: string): NodeJS.ProcessEnv {
+    const cleanedEnv: NodeJS.ProcessEnv = {};
+
+    for (const key in process.env) {
+      const envVar = process.env[key];
+      if (envVar) {
+        const split_val = envVar.split(":");
+        cleanedEnv[key] = split_val.filter((val) => !val.includes(appDir)).join(":");
+      }
+    }
+
+    return cleanedEnv;
   }
 }
 


### PR DESCRIPTION
Launching the mainline beta from the Slippi launcher caused dolphin file pickers to be extremely slow to open & navigate. Root cause was the AppImage environment of dolphin mainline also including environment variables from the Slippi launcher AppImage. This led to various icons being searched for in the Slippi AppImage directory rather than the proper user directories:
```
# There are thousands of these syscalls upon opening a file picker in dolphin mainline
# /tmp/.mount_SlippiJ7w6Ag is the mount point of the launcher AppImage

access("/tmp/.mount_SlippiJ7w6Ag/usr/share/icons/hicolor/96x96@2/actions/text-plain.png", F_OK) = -1 ENOENT (No such file or directory)
```

Originally encountered on Fedora 43 KDE Plasma 6.6, Reproduced on Debian 14 KDE.

This PR resolves the issue by spawning the dolphin process with a cleaned environment, where any references to the parent app image mount point removed.