### PR TITLE
i18n: update Japanese translations

### DIFF
--- a/locales/ja.po
+++ b/locales/ja.po
@@ -632,7 +632,7 @@ msgstr "ニュースの取得に失敗しました。後でもう一度お試し
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:12:36
 #. {0} errorMessage: string
 msgid "Failed to fetch tournaments. Error: {0}"
-msgstr "トーナメント情報の取得に失敗しました。エラー: {0}"
+msgstr "大会情報の取得に失敗しました。エラー: {0}"
 
 #: src/renderer/app/header/header.messages.ts:5:29
 msgid "Failed to get updates"
@@ -678,7 +678,7 @@ msgstr "パスワードをお忘れですか？"
 #. {1} city: string - The approximate city the user is in. e.g. Shimomeguro
 #. {2} greaterRegion: string - The greater region/state/prefecture the city is contained in. e.g. Tokyo
 msgid "Found {0, plural, one {# tournament} other {# tournaments}} near {1}, {2}."
-msgstr "{1}、{2}の近くで{0}件のトーナメントが見つかりました。"
+msgstr "{1}、{2}の近くで{0}件の大会が見つかりました。"
 
 #: src/renderer/pages/settings/create.messages.ts:3:15
 msgid "Game"
@@ -1394,7 +1394,7 @@ msgstr "検索"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:11:18
 msgid "Searching for nearby tournaments..."
-msgstr "近くのトーナメントを検索中..."
+msgstr "近くの大会を検索中..."
 
 #: src/renderer/components/path_input/path_input.messages.ts:2:17
 #: src/renderer/pages/quick_start/steps/iso_selection_step/iso_selection_step.messages.ts:12:17
@@ -1719,7 +1719,7 @@ msgstr "合計サイズ: {0}"
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:2:16
 #: src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.messages.ts:6:28
 msgid "Tournaments Near Me"
-msgstr "近くのトーナメント"
+msgstr "近くの大会"
 
 #: src/renderer/components/activate_online_form/activate_online_form.messages.ts:4:26
 msgid "Trailing numbers will be auto-generated"
@@ -1791,7 +1791,7 @@ msgstr "今後のメジャー大会"
 #: src/renderer/pages/home/home_page.messages.ts:4:30
 #: src/renderer/pages/home/overview/overview.messages.ts:3:30
 msgid "Upcoming Tournaments"
-msgstr "今後のトーナメント"
+msgstr "今後の大会"
 
 #: src/renderer/app/header/play_button/play_button.messages.ts:3:19
 msgid "Updating"
@@ -1864,7 +1864,7 @@ msgstr "メールを開き、確認メール内のリンクをクリックして
 
 #: src/renderer/components/location_guard/location_guard.messages.ts:3:22
 msgid "We need access to your approximate location to show you nearby tournaments."
-msgstr "近くのトーナメントを表示するには、おおよその位置情報へのアクセスが必要です。"
+msgstr "近くの大会を表示するには、おおよその位置情報へのアクセスが必要です。"
 
 #: src/renderer/pages/console_mirror/console_mirror.messages.ts:4:26
 msgid "What is Mirroring?"

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -50,7 +50,7 @@ msgstr "追加"
 
 #: src/renderer/app/header/account_switcher/account_switcher.messages.ts:2:28
 msgid "Add another account"
-msgstr ""
+msgstr "別のアカウントを追加"
 
 #: src/renderer/pages/settings/replay_settings/replay_settings.messages.ts:10:31
 msgid "Additional SLP Folders"
@@ -63,15 +63,15 @@ msgstr "詳細"
 #: src/renderer/pages/replays/replay_browser/file_selection_toolbar/file_selection_toolbar.messages.ts:3:40
 #. {0} count: number
 msgid "All {0, plural, one {# file} other {# files}} selected"
-msgstr ""
+msgstr "{0}件すべて選択中"
 
 #: src/renderer/components/location_guard/location_guard.messages.ts:6:16
 msgid "Allow"
-msgstr ""
+msgstr "許可"
 
 #: src/renderer/components/location_guard/location_guard.messages.ts:2:16
 msgid "Allow Approximate Location Access"
-msgstr ""
+msgstr "おおよその位置情報へのアクセスを許可"
 
 #: src/renderer/pages/settings/advanced_app_settings/advanced_app_settings.messages.ts:6:5
 msgid ""
@@ -79,6 +79,8 @@ msgid ""
 "tournaments. This data will be sent to a third-party service. Slippi does "
 "NOT collect this data."
 msgstr ""
+"おおよその位置情報へのアクセスを許可すると、近くの大会が表示されるようになります。"
+"このデータはサードパーティサービスに送信されます。Slippiはこのデータを収集しません。"
 
 #: src/renderer/pages/console_mirror/add_connection_dialog/add_connection_form.messages.ts:15:5
 msgid ""
@@ -467,7 +469,7 @@ msgstr ""
 
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:17:39
 msgid "Dolphin is currently running. Close Dolphin to switch accounts"
-msgstr ""
+msgstr "Dolphinが実行中です。アカウントを切り替えるにはDolphinを終了してください。"
 
 #: src/renderer/pages/replays/replay_browser/replay_file/replay_file.messages.ts:6:28
 #: src/renderer/pages/replays/replay_file_stats/game_profile_header/game_profile_header.messages.ts:6:28
@@ -522,7 +524,7 @@ msgstr "メールアドレス確認完了"
 
 #: src/renderer/pages/settings/advanced_app_settings/advanced_app_settings.messages.ts:4:31
 msgid "Enable Approximate Location Access"
-msgstr ""
+msgstr "おおよその位置情報へのアクセスを有効化"
 
 #: src/renderer/pages/settings/advanced_app_settings/advanced_app_settings.messages.ts:2:28
 msgid "Enable Auto Updates"
@@ -542,7 +544,7 @@ msgstr "音楽を有効化"
 
 #: src/renderer/pages/settings/replay_settings/replay_settings.messages.ts:13:31
 msgid "Enable Netplay Replays"
-msgstr ""
+msgstr "ネットプレイのリプレイを有効化"
 
 #: src/renderer/pages/console_mirror/add_connection_dialog/add_connection_form.messages.ts:7:29
 msgid "Enable Real-time Mode"
@@ -617,7 +619,7 @@ msgstr "ポートマッピングの可用性の判定に失敗しました"
 #: src/renderer/components/location_guard/location_guard.messages.ts:7:36
 #. {0} errorMessage: string
 msgid "Failed to fetch location information. Error: {0}"
-msgstr ""
+msgstr "位置情報の取得に失敗しました。エラー: {0}"
 
 #: src/renderer/pages/home/news_feed/news_feed.messages.ts:4:24
 msgid "Failed to fetch news articles."
@@ -625,12 +627,12 @@ msgstr "ニュース記事の取得に失敗しました。"
 
 #: src/renderer/pages/home/overview/news_preview/news_preview.messages.ts:2:28
 msgid "Failed to fetch news. Try again later."
-msgstr ""
+msgstr "ニュースの取得に失敗しました。後でもう一度お試しください。"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:12:36
 #. {0} errorMessage: string
 msgid "Failed to fetch tournaments. Error: {0}"
-msgstr ""
+msgstr "トーナメント情報の取得に失敗しました。エラー: {0}"
 
 #: src/renderer/app/header/header.messages.ts:5:29
 msgid "Failed to get updates"
@@ -650,11 +652,11 @@ msgstr "Geckoコードの読み込みに失敗しました"
 
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:12:32
 msgid "Failed to remove account"
-msgstr ""
+msgstr "アカウントの削除に失敗しました"
 
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:13:32
 msgid "Failed to switch account"
-msgstr ""
+msgstr "アカウントの切り替えに失敗しました"
 
 #: src/renderer/pages/spectate/spectator_id_block/spectator_id_block.messages.ts:6:5
 msgid ""
@@ -676,7 +678,7 @@ msgstr "パスワードをお忘れですか？"
 #. {1} city: string - The approximate city the user is in. e.g. Shimomeguro
 #. {2} greaterRegion: string - The greater region/state/prefecture the city is contained in. e.g. Tokyo
 msgid "Found {0, plural, one {# tournament} other {# tournaments}} near {1}, {2}."
-msgstr ""
+msgstr "{1}、{2}の近くで{0}件のトーナメントが見つかりました。"
 
 #: src/renderer/pages/settings/create.messages.ts:3:15
 msgid "Game"
@@ -754,7 +756,7 @@ msgstr "エラーが続く場合は、コンピューターのターミナルア
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:17:21
 #: src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.messages.ts:3:21
 msgid "In progress"
-msgstr ""
+msgstr "進行中"
 
 #: src/renderer/pages/settings/game_settings/game_music_toggle/game_music_toggle.messages.ts:4:33
 msgid "Incompatible with WASAPI."
@@ -887,7 +889,7 @@ msgstr "アカウントを管理"
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:14:40
 #. {0} max: number
 msgid "Maximum {0} accounts reached. Remove an account to add another."
-msgstr ""
+msgstr "最大{0}アカウントに達しました。追加するにはアカウントを削除してください。"
 
 #: src/renderer/pages/settings/game_settings/game_settings.messages.ts:2:23
 msgid "Melee ISO File"
@@ -917,7 +919,7 @@ msgstr "新しい順"
 
 #: src/renderer/pages/home/overview/my_ranking/my_ranking.messages.ts:2:20
 msgid "My Ranking"
-msgstr ""
+msgstr "自分の順位"
 
 #: src/renderer/pages/settings/help_page/support_box/network_diagnostics_button/network_diagnostic_result/network_diagnostics_result.messages.ts:12:18
 msgid "NAT Type"
@@ -1017,11 +1019,11 @@ msgstr "ネットワーク接続なし"
 
 #: src/renderer/pages/home/overview/news_preview/news_preview.messages.ts:3:17
 msgid "No news to show"
-msgstr ""
+msgstr "表示できるニュースはありません"
 
 #: src/renderer/pages/home/overview/my_ranking/my_ranking.messages.ts:4:20
 msgid "No ranking"
-msgstr ""
+msgstr "順位なし"
 
 #: src/renderer/pages/console_mirror/saved_connections_list/saved_connections_list.messages.ts:4:29
 msgid "No saved console connections"
@@ -1069,7 +1071,7 @@ msgstr "OBS Websocketポート"
 
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:7:18
 msgid "Offline"
-msgstr ""
+msgstr "オフライン"
 
 #: src/renderer/pages/home/overview/ranked_status/ranked_status.messages.ts:10:5
 msgid ""
@@ -1100,11 +1102,11 @@ msgstr "設定フォルダを開く"
 #: src/renderer/pages/settings/replay_settings/replay_settings.messages.ts:15:60
 #. {0} currentDate: string
 msgid "Organize into monthly subfolders (e.g. {0})."
-msgstr ""
+msgstr "月別のサブフォルダに整理（例：{0}）。"
 
 #: src/renderer/pages/home/home_page.messages.ts:2:19
 msgid "Overview"
-msgstr ""
+msgstr "概要"
 
 #: src/renderer/components/login_form/login_form.messages.ts:7:19
 msgid "Password"
@@ -1241,7 +1243,7 @@ msgstr ""
 
 #: src/renderer/pages/home/overview/my_ranking/my_ranking.messages.ts:5:22
 msgid "Rank pending"
-msgstr ""
+msgstr "順位確定待ち"
 
 #: src/renderer/pages/home/overview/overview.messages.ts:4:20
 #: src/renderer/pages/home/overview/ranked_status/ranked_status.messages.ts:2:20
@@ -1256,7 +1258,7 @@ msgstr "現在、ランクマッチは誰でもプレイできます。今すぐ
 
 #: src/renderer/app/header/account_switcher/account_switcher.messages.ts:3:32
 msgid "Re-authenticate account"
-msgstr ""
+msgstr "アカウントを再認証"
 
 #: src/renderer/pages/home/news_feed/news_article/news_article.messages.ts:5:19
 msgid "Read more"
@@ -1264,7 +1266,7 @@ msgstr "続きを読む"
 
 #: src/renderer/pages/home/overview/news_preview/news_preview.messages.ts:4:19
 msgid "Read post"
-msgstr ""
+msgstr "記事を読む"
 
 #: src/renderer/pages/console_mirror/saved_connections_list/saved_connection_item.messages.ts:4:23
 msgid "Reconnecting"
@@ -1292,7 +1294,7 @@ msgstr "削除"
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:15:44
 #. {0} accountName: string
 msgid "Removed {0}"
-msgstr ""
+msgstr "{0}を削除しました"
 
 #: src/renderer/pages/settings/advanced_app_settings/advanced_app_settings.messages.ts:9:5
 msgid ""
@@ -1376,7 +1378,7 @@ msgstr "保存"
 
 #: src/renderer/pages/settings/replay_settings/replay_settings.messages.ts:14:42
 msgid "Save replays for netplay games to the Root SLP Folder."
-msgstr ""
+msgstr "ネットプレイのリプレイをルートSLPフォルダに保存します。"
 
 #: src/renderer/pages/console_mirror/add_connection_dialog/add_connection_form.messages.ts:6:34
 msgid "Save replays to subfolders based on console nickname"
@@ -1392,7 +1394,7 @@ msgstr "検索"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:11:18
 msgid "Searching for nearby tournaments..."
-msgstr ""
+msgstr "近くのトーナメントを検索中..."
 
 #: src/renderer/components/path_input/path_input.messages.ts:2:17
 #: src/renderer/pages/quick_start/steps/iso_selection_step/iso_selection_step.messages.ts:12:17
@@ -1433,7 +1435,7 @@ msgstr "詳細オプションを表示"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:13:27
 msgid "Show map of events"
-msgstr ""
+msgstr "イベントマップを表示"
 
 #: src/renderer/pages/home/news_feed/news_feed.messages.ts:6:19
 msgid "Show more"
@@ -1503,15 +1505,15 @@ msgstr "問題が発生しました。"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:15:21
 msgid "Sort by date"
-msgstr ""
+msgstr "日付順"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:14:25
 msgid "Sort by distance"
-msgstr ""
+msgstr "距離順"
 
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:16:25
 msgid "Sort by entrants"
-msgstr ""
+msgstr "参加者順"
 
 #: src/renderer/app/create.messages.ts:4:19
 #: src/renderer/pages/settings/create.messages.ts:6:19
@@ -1562,7 +1564,7 @@ msgstr "まもなく開始"
 #: src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.messages.ts:4:38
 #. {0} countdown: string
 msgid "Starting in {0}"
-msgstr ""
+msgstr "{0}後に開始"
 
 #: src/renderer/pages/spectate/spectate_remote_control_block/spectate_remote_control_block.messages.ts:8:19
 msgid "Starting..."
@@ -1609,7 +1611,7 @@ msgstr "Slippiを支援"
 #: src/renderer/app/header/user_menu/user_menu.messages.ts:16:40
 #. {0} accountName: string
 msgid "Switched to {0}"
-msgstr ""
+msgstr "{0}に切り替えました"
 
 #: src/renderer/pages/settings/help_page/support_box/network_diagnostics_button/network_diagnostic_result/network_diagnostics_result.messages.ts:15:23
 msgid "Symmetric NAT"
@@ -1717,7 +1719,7 @@ msgstr "合計サイズ: {0}"
 #: src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.messages.ts:2:16
 #: src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.messages.ts:6:28
 msgid "Tournaments Near Me"
-msgstr ""
+msgstr "近くのトーナメント"
 
 #: src/renderer/components/activate_online_form/activate_online_form.messages.ts:4:26
 msgid "Trailing numbers will be auto-generated"
@@ -1784,12 +1786,12 @@ msgstr "上"
 
 #: src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.messages.ts:5:25
 msgid "Upcoming Majors"
-msgstr ""
+msgstr "今後のメジャー大会"
 
 #: src/renderer/pages/home/home_page.messages.ts:4:30
 #: src/renderer/pages/home/overview/overview.messages.ts:3:30
 msgid "Upcoming Tournaments"
-msgstr ""
+msgstr "今後のトーナメント"
 
 #: src/renderer/app/header/play_button/play_button.messages.ts:3:19
 msgid "Updating"
@@ -1852,7 +1854,7 @@ msgstr "プロフィールを表示"
 #: src/renderer/pages/home/overview/carousel/carousel.messages.ts:3:21
 #: src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.messages.ts:2:21
 msgid "View stream"
-msgstr ""
+msgstr "配信を見る"
 
 #: src/renderer/pages/quick_start/steps/verify_email_step/verify_email_step.messages.ts:3:25
 msgid ""
@@ -1862,7 +1864,7 @@ msgstr "メールを開き、確認メール内のリンクをクリックして
 
 #: src/renderer/components/location_guard/location_guard.messages.ts:3:22
 msgid "We need access to your approximate location to show you nearby tournaments."
-msgstr ""
+msgstr "近くのトーナメントを表示するには、おおよその位置情報へのアクセスが必要です。"
 
 #: src/renderer/pages/console_mirror/console_mirror.messages.ts:4:26
 msgid "What is Mirroring?"
@@ -1887,7 +1889,7 @@ msgstr "オフラインです。"
 
 #: src/renderer/pages/home/overview/ranked_status/ranked_status.messages.ts:12:29
 msgid "You have an active subscription! Enjoy ranked play at any time!"
-msgstr ""
+msgstr "サブスクリプションが有効です！いつでもランクマッチをお楽しみいただけます！"
 
 #: src/renderer/pages/settings/help_page/support_box/network_diagnostics_button/network_diagnostic_result/network_diagnostics_result.messages.ts:34:28
 msgid "You may have trouble connecting to other players."
@@ -1940,6 +1942,8 @@ msgid ""
 "Your location data will be sent to a third-party service. Slippi does NOT "
 "collect this data. You can turn this feature off again in the settings."
 msgstr ""
+"あなたの位置情報はサードパーティサービスに送信されます。Slippiはこのデータを収集しません。"
+"この機能は設定で再度オフにできます。"
 
 #: src/renderer/pages/quick_start/steps/iso_selection_step/iso_selection_step.messages.ts:5:28
 msgid "or drag and drop here"
@@ -1949,7 +1953,7 @@ msgstr "またはここにドラッグ＆ドロップ"
 #. {0} count: number
 #. {1} total: number
 msgid "{0, number} of {1, plural, one {# replay} other {# replays}} processed."
-msgstr ""
+msgstr "{1}件中{0}件処理済み"
 
 #: src/renderer/pages/replays/replay_browser/file_selection_toolbar/file_selection_toolbar.messages.ts:2:37
 #. {0} count: number
@@ -1969,7 +1973,7 @@ msgstr "{0}件削除されます"
 #: src/renderer/pages/replays/replay_browser/replay_browser.messages.ts:10:43
 #. {0} count: number
 msgid "{0, plural, one {# replay} other {# replays}} filtered."
-msgstr "{0}件リプレイター済み"
+msgstr "{0}件フィルター済み"
 
 #: src/renderer/pages/replays/replay_browser/replay_browser.messages.ts:9:40
 #. {0} count: number


### PR DESCRIPTION
This PR adds Japanese machine translations for the missing strings. Will await @Kounotori-ssbm to double check these before merging.