### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/.erb/scripts/windows-sign.js
+++ b/.erb/scripts/windows-sign.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Custom Sign hook for use with electron-builder + SSL CodeSignTool
 
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 
 const ES_CREDENTIAL_ID = process.env.ES_CREDENTIAL_ID;
 const ES_USERNAME = process.env.ES_USERNAME;
@@ -24,8 +24,17 @@ exports.default = async (config) => {
     throw new Error("missing required secrets");
   }
 
-  const output = execSync(
-    `CodeSignTool.bat sign -credential_id="${ES_CREDENTIAL_ID}" -username="${ES_USERNAME}" -password="${ES_PASSWORD}" -totp_secret="${ES_TOTP_SECRET}" -input_file_path="${fileToSign}" -override="true"`,
+  const output = execFileSync(
+    "CodeSignTool.bat",
+    [
+      "sign",
+      `-credential_id=${ES_CREDENTIAL_ID}`,
+      `-username=${ES_USERNAME}`,
+      `-password=${ES_PASSWORD}`,
+      `-totp_secret=${ES_TOTP_SECRET}`,
+      `-input_file_path=${fileToSign}`,
+      `-override=true`,
+    ],
     { cwd: CODESIGNTOOL_PATH },
   )
     .toString()

--- a/src/dolphin/install/execute_command.ts
+++ b/src/dolphin/install/execute_command.ts
@@ -24,7 +24,7 @@ export async function executeCommand(command: string, args: string[]): Promise<s
       // Dolphin often outputs version info to stderr, so prioritize stderr if stdout is empty
       const output = stdout.trim() || stderr.trim();
 
-      if (code === 0 || output) {
+      if (code === 0) {
         resolve(output);
       } else {
         reject(new Error(`Command failed with code ${code}: ${stderr}`));


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `src/dolphin/install/execute_command.ts:L14`

The `executeCommand` function in `src/dolphin/install/execute_command.ts` uses `spawn` with a command string and args array. While `spawn` with array arguments is generally safer than `exec`, the function is exported and could be called with untrusted input. More critically, the function resolves on `code === 0 || output` which means commands that fail with non-zero exit codes but produce any output (even to stderr) are treated as successful. This could mask failures or allow unexpected behavior if callers rely on exit codes.

## Solution

Add input validation for the `command` parameter to ensure it only contains expected commands. Consider using a whitelist of allowed commands. Also, reconsider the success condition - failing commands should probably not be treated as successful just because they produced stderr output.

## Changes

- `src/dolphin/install/execute_command.ts` (modified)
- `.erb/scripts/windows-sign.js` (modified)