### PR TITLE
chore: Improve auto-update experience and fix Windows NSIS update issues

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -4,8 +4,7 @@
   "asar": true,
   "asarUnpack": [
     "**\\*.{node,dll}",
-    "./dist/main/*.js",
-    "./node_modules/**/*.{js,json}"
+    "./dist/main/**/*.worker.js"
   ],
   "files": [
     "dist",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -20,12 +20,14 @@
     "description": "Slippi File Format",
     "icon": "./assets/file.ico"
   },
-  "artifactName": "Slippi-Launcher-${version}-${os}.${ext}",
+  "artifactName": "Slippi-Launcher-${version}-${arch}-${os}.${ext}",
   "mac": {
-    "target": {
-      "target": "default",
-      "arch": "universal"
-    },
+    "target": [
+      {
+        "target": "default",
+        "arch": ["x64", "arm64"]
+      }
+    ],
     "fileAssociations": {
       "ext": "slp",
       "role": "Viewer"
@@ -44,7 +46,7 @@
     "minimumSystemVersion": "10.13.6"
   },
   "dmg": {
-    "artifactName": "Slippi-Launcher-${version}.${ext}",
+    "artifactName": "Slippi-Launcher-${version}-${arch}.${ext}",
     "icon": "assets/icon.icns",
     "contents": [
       {

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -72,6 +72,7 @@
   "nsis": {
     "artifactName": "Slippi-Launcher-Setup-${version}.${ext}",
     "include": ".erb/scripts/installer.nsh",
+    "differentialPackage": false,
     "warningsAsErrors": false,
     "allowElevation": true,
     "oneClick": false,

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -31,7 +31,6 @@
       "role": "Viewer"
     },
     "type": "distribution",
-    "mergeASARs": false,
     "hardenedRuntime": true,
     "entitlements": "assets/entitlements.mac.plist",
     "entitlementsInherit": "assets/entitlements.mac.plist",

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -10,7 +10,6 @@ import {
   ipc_installUpdate,
   ipc_launcherUpdateDownloadingEvent,
   ipc_launcherUpdateFoundEvent,
-  ipc_launcherUpdateNotAvailableEvent,
   ipc_launcherUpdateReadyEvent,
   ipc_openInNewBrowserWindow,
   ipc_runNetworkDiagnostics,
@@ -32,8 +31,9 @@ export default {
   async copyLogsToClipboard(): Promise<void> {
     await ipc_copyLogsToClipboard.renderer!.trigger({});
   },
-  async checkForAppUpdates(silent = false): Promise<void> {
-    await ipc_checkForUpdate.renderer!.trigger({ silent });
+  async checkForAppUpdates(): Promise<{ updateAvailable: boolean }> {
+    const { result } = await ipc_checkForUpdate.renderer!.trigger({});
+    return result;
   },
   async installAppUpdate(): Promise<void> {
     await ipc_installUpdate.renderer!.trigger({});
@@ -71,12 +71,6 @@ export default {
   },
   onAppUpdateReady(handle: () => void) {
     const { destroy } = ipc_launcherUpdateReadyEvent.renderer!.handle(async () => {
-      handle();
-    });
-    return destroy;
-  },
-  onAppUpdateNotAvailable(handle: () => void) {
-    const { destroy } = ipc_launcherUpdateNotAvailableEvent.renderer!.handle(async () => {
       handle();
     });
     return destroy;

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -35,8 +35,9 @@ export default {
     const { result } = await ipc_checkForUpdate.renderer!.trigger({});
     return result;
   },
-  async installAppUpdate(): Promise<void> {
-    await ipc_installUpdate.renderer!.trigger({});
+  async installAppUpdate(): Promise<{ success: boolean; error?: string }> {
+    const { result } = await ipc_installUpdate.renderer!.trigger({});
+    return result;
   },
   async getLatestGithubReleaseVersion(owner: string, repo: string): Promise<string> {
     const { result } = await ipc_getLatestGitHubReleaseVersion.renderer!.trigger({ owner, repo });

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -10,6 +10,7 @@ import {
   ipc_installUpdate,
   ipc_launcherUpdateDownloadingEvent,
   ipc_launcherUpdateFoundEvent,
+  ipc_launcherUpdateNotAvailableEvent,
   ipc_launcherUpdateReadyEvent,
   ipc_openInNewBrowserWindow,
   ipc_runNetworkDiagnostics,
@@ -31,8 +32,8 @@ export default {
   async copyLogsToClipboard(): Promise<void> {
     await ipc_copyLogsToClipboard.renderer!.trigger({});
   },
-  async checkForAppUpdates(): Promise<void> {
-    await ipc_checkForUpdate.renderer!.trigger({});
+  async checkForAppUpdates(silent = false): Promise<void> {
+    await ipc_checkForUpdate.renderer!.trigger({ silent });
   },
   async installAppUpdate(): Promise<void> {
     await ipc_installUpdate.renderer!.trigger({});
@@ -70,6 +71,12 @@ export default {
   },
   onAppUpdateReady(handle: () => void) {
     const { destroy } = ipc_launcherUpdateReadyEvent.renderer!.handle(async () => {
+      handle();
+    });
+    return destroy;
+  },
+  onAppUpdateNotAvailable(handle: () => void) {
+    const { destroy } = ipc_launcherUpdateNotAvailableEvent.renderer!.handle(async () => {
       handle();
     });
     return destroy;

--- a/src/main/app_updater.ts
+++ b/src/main/app_updater.ts
@@ -1,10 +1,19 @@
+import type { SettingsManager } from "@settings/settings_manager";
+import { app } from "electron";
 import log from "electron-log";
 import { autoUpdater } from "electron-updater";
 
+export type UpdateState = {
+  status: "succeeded" | "failed";
+  version: string;
+};
+
 export class AppUpdater {
-  constructor(private readonly shouldAutoUpdate: boolean) {
+  private updateState: UpdateState | undefined;
+
+  constructor(private readonly settingsManager: SettingsManager) {
     autoUpdater.logger = log;
-    autoUpdater.autoInstallOnAppQuit = this.shouldAutoUpdate;
+    autoUpdater.autoInstallOnAppQuit = settingsManager.get().settings.autoUpdateLauncher;
 
     // This is going to be the default at some point, right now if we don't
     // explicitly set this to true then electron-builder prints a (harmless)
@@ -14,5 +23,31 @@ export class AppUpdater {
     // Disable differential downloads to fix Windows NSIS update issues
     // See: https://github.com/electron-userland/electron-builder/issues/9181
     autoUpdater.disableDifferentialDownload = true;
+  }
+
+  public async verifyPendingUpdate(): Promise<void> {
+    const currentVersion = app.getVersion();
+    const pendingVersion = this.settingsManager.get().pendingUpdateVersion;
+
+    if (!pendingVersion) {
+      return;
+    }
+
+    if (currentVersion === pendingVersion) {
+      log.info(`Auto-update succeeded: version ${currentVersion}`);
+      this.updateState = { status: "succeeded", version: currentVersion };
+    } else {
+      log.error(
+        `Auto-update FAILED: expected ${pendingVersion}, running ${currentVersion}. ` +
+          "Update file may have been missing, corrupted, or the installer was interrupted.",
+      );
+      this.updateState = { status: "failed", version: pendingVersion };
+    }
+
+    await this.settingsManager.updateSetting("pendingUpdateVersion", undefined);
+  }
+
+  public getUpdateState(): UpdateState | undefined {
+    return this.updateState;
   }
 }

--- a/src/main/app_updater.ts
+++ b/src/main/app_updater.ts
@@ -1,0 +1,18 @@
+import log from "electron-log";
+import { autoUpdater } from "electron-updater";
+
+export class AppUpdater {
+  constructor(private readonly shouldAutoUpdate: boolean) {
+    autoUpdater.logger = log;
+    autoUpdater.autoInstallOnAppQuit = this.shouldAutoUpdate;
+
+    // This is going to be the default at some point, right now if we don't
+    // explicitly set this to true then electron-builder prints a (harmless)
+    // warning when updating on Windows.
+    // See: https://github.com/electron-userland/electron-builder/pull/6575
+    autoUpdater.disableWebInstaller = true;
+    // Disable differential downloads to fix Windows NSIS update issues
+    // See: https://github.com/electron-userland/electron-builder/issues/9181
+    autoUpdater.disableDifferentialDownload = true;
+  }
+}

--- a/src/main/app_updater.ts
+++ b/src/main/app_updater.ts
@@ -63,9 +63,9 @@ export class AppUpdater {
   }
 
   public async quitAndInstall(): Promise<void> {
+    // The restart _should_ happen instantly.
+    // If we still haven't restarted the app within the timeout, something probably went wrong.
     const timeout = new Promise<void>((_resolve, reject) => {
-      // The restart should happen instantly.
-      // So if we still haven't restarted the app within the timeout, something probably went wrong.
       setTimeout(() => {
         reject(new Error(`Timed out after ${INSTALL_UPDATE_TIMEOUT_MS / 1000}s trying to install update.`));
       }, INSTALL_UPDATE_TIMEOUT_MS);

--- a/src/main/app_updater.ts
+++ b/src/main/app_updater.ts
@@ -8,7 +8,7 @@ export type UpdateState = {
   version: string;
 };
 
-const INSTALL_UPDATE_TIMEOUT_MS = 15000; // 15 seconds
+const INSTALL_UPDATE_TIMEOUT_MS = 5000; // 5 seconds
 
 export class AppUpdater {
   private updateState: UpdateState | undefined;
@@ -64,7 +64,8 @@ export class AppUpdater {
 
   public async quitAndInstall(): Promise<void> {
     const timeout = new Promise<void>((_resolve, reject) => {
-      // If we still haven't restarted the app within the timeout, something probably went wrong.
+      // The restart should happen instantly.
+      // So if we still haven't restarted the app within the timeout, something probably went wrong.
       setTimeout(() => {
         reject(new Error(`Timed out after ${INSTALL_UPDATE_TIMEOUT_MS / 1000}s trying to install update.`));
       }, INSTALL_UPDATE_TIMEOUT_MS);

--- a/src/main/app_updater.ts
+++ b/src/main/app_updater.ts
@@ -8,6 +8,8 @@ export type UpdateState = {
   version: string;
 };
 
+const INSTALL_UPDATE_TIMEOUT_MS = 15000; // 15 seconds
+
 export class AppUpdater {
   private updateState: UpdateState | undefined;
 
@@ -49,5 +51,25 @@ export class AppUpdater {
 
   public getUpdateState(): UpdateState | undefined {
     return this.updateState;
+  }
+
+  private async _installUpdate(): Promise<void> {
+    const pendingVersion = this.settingsManager.get().pendingUpdateVersion;
+    if (!pendingVersion) {
+      throw new Error("No update has been downloaded.");
+    }
+
+    autoUpdater.quitAndInstall(false, true);
+  }
+
+  public async quitAndInstall(): Promise<void> {
+    const timeout = new Promise<void>((_resolve, reject) => {
+      // If we still haven't restarted the app within the timeout, something probably went wrong.
+      setTimeout(() => {
+        reject(new Error(`Timed out after ${INSTALL_UPDATE_TIMEOUT_MS / 1000}s trying to install update.`));
+      }, INSTALL_UPDATE_TIMEOUT_MS);
+    });
+
+    await Promise.race([timeout, this._installUpdate()]);
   }
 }

--- a/src/main/bootstrap.ts
+++ b/src/main/bootstrap.ts
@@ -3,6 +3,7 @@ import log from "electron-log";
 import os from "os";
 import osName from "os-name";
 
+import type { UpdateState } from "./app_updater";
 import type { ConfigFlags } from "./flags/flags";
 
 export type AppBootstrap = {
@@ -13,9 +14,10 @@ export type AppBootstrap = {
   isLinux: boolean;
   isWindows: boolean;
   locale: string;
+  updateState?: UpdateState;
 };
 
-export function getAppBootstrap(flags: ConfigFlags): AppBootstrap {
+export function getAppBootstrap(flags: ConfigFlags, updateState?: UpdateState): AppBootstrap {
   let release = os.release();
   try {
     const name = osName(os.platform(), release);
@@ -32,6 +34,7 @@ export function getAppBootstrap(flags: ConfigFlags): AppBootstrap {
     isLinux: process.platform === "linux",
     isWindows: process.platform === "win32",
     locale: app.getLocale(),
+    updateState,
   };
   return bootstrap;
 }

--- a/src/main/install_modules.ts
+++ b/src/main/install_modules.ts
@@ -7,12 +7,14 @@ import setupReplaysIpc from "@replays/setup";
 import { SettingsManager } from "@settings/settings_manager";
 import setupSettingsIpc from "@settings/setup";
 
+import { AppUpdater } from "./app_updater";
 import { BrowserWindowManager } from "./browser_window_manager";
 import type { ConfigFlags } from "./flags/flags";
 import setupMainIpc from "./setup";
 
 export function installModules(flags: ConfigFlags) {
   const settingsManager = new SettingsManager();
+  const appUpdater = new AppUpdater(settingsManager);
   const dolphinManager = new DolphinManager(settingsManager);
   setupDolphinIpc({ dolphinManager });
   const { getSpectateController } = setupBroadcastIpc({ settingsManager, dolphinManager });
@@ -21,6 +23,6 @@ export function installModules(flags: ConfigFlags) {
   setupConsoleIpc({ dolphinManager });
   setupRemoteIpc({ dolphinManager, settingsManager, getSpectateController });
   const browserWindowManager = new BrowserWindowManager();
-  setupMainIpc({ dolphinManager, settingsManager, flags, browserWindowManager });
-  return { dolphinManager, settingsManager, browserWindowManager };
+  setupMainIpc({ dolphinManager, settingsManager, flags, browserWindowManager, appUpdater });
+  return { dolphinManager, settingsManager, browserWindowManager, appUpdater };
 }

--- a/src/main/install_modules.ts
+++ b/src/main/install_modules.ts
@@ -21,6 +21,6 @@ export function installModules(flags: ConfigFlags) {
   setupConsoleIpc({ dolphinManager });
   setupRemoteIpc({ dolphinManager, settingsManager, getSpectateController });
   const browserWindowManager = new BrowserWindowManager();
-  setupMainIpc({ dolphinManager, flags, browserWindowManager });
+  setupMainIpc({ dolphinManager, settingsManager, flags, browserWindowManager });
   return { dolphinManager, settingsManager, browserWindowManager };
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,7 +12,7 @@ export const ipc_checkValidIso = makeEndpoint.main(
 
 export const ipc_copyLogsToClipboard = makeEndpoint.main("copyLogsToClipboard", <EmptyPayload>_, <SuccessPayload>_);
 
-export const ipc_checkForUpdate = makeEndpoint.main("checkForUpdate", <{ silent?: boolean }>_, <SuccessPayload>_);
+export const ipc_checkForUpdate = makeEndpoint.main("checkForUpdate", <EmptyPayload>_, <{ updateAvailable: boolean }>_);
 
 export const ipc_installUpdate = makeEndpoint.main("installUpdate", <EmptyPayload>_, <SuccessPayload>_);
 
@@ -52,8 +52,3 @@ export const ipc_launcherUpdateDownloadingEvent = makeEndpoint.renderer(
 );
 
 export const ipc_launcherUpdateReadyEvent = makeEndpoint.renderer("launcherupdate_ready", <EmptyPayload>_);
-
-export const ipc_launcherUpdateNotAvailableEvent = makeEndpoint.renderer(
-  "launcherupdate_not_available",
-  <EmptyPayload>_,
-);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -14,7 +14,11 @@ export const ipc_copyLogsToClipboard = makeEndpoint.main("copyLogsToClipboard", 
 
 export const ipc_checkForUpdate = makeEndpoint.main("checkForUpdate", <EmptyPayload>_, <{ updateAvailable: boolean }>_);
 
-export const ipc_installUpdate = makeEndpoint.main("installUpdate", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_installUpdate = makeEndpoint.main(
+  "installUpdate",
+  <EmptyPayload>_,
+  <{ success: boolean; error?: string }>_,
+);
 
 export const ipc_getLatestGitHubReleaseVersion = makeEndpoint.main(
   "getLatestGitHubReleaseVersion",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,7 +12,7 @@ export const ipc_checkValidIso = makeEndpoint.main(
 
 export const ipc_copyLogsToClipboard = makeEndpoint.main("copyLogsToClipboard", <EmptyPayload>_, <SuccessPayload>_);
 
-export const ipc_checkForUpdate = makeEndpoint.main("checkForUpdate", <EmptyPayload>_, <SuccessPayload>_);
+export const ipc_checkForUpdate = makeEndpoint.main("checkForUpdate", <{ silent?: boolean }>_, <SuccessPayload>_);
 
 export const ipc_installUpdate = makeEndpoint.main("installUpdate", <EmptyPayload>_, <SuccessPayload>_);
 
@@ -52,3 +52,8 @@ export const ipc_launcherUpdateDownloadingEvent = makeEndpoint.renderer(
 );
 
 export const ipc_launcherUpdateReadyEvent = makeEndpoint.renderer("launcherupdate_ready", <EmptyPayload>_);
+
+export const ipc_launcherUpdateNotAvailableEvent = makeEndpoint.renderer(
+  "launcherupdate_not_available",
+  <EmptyPayload>_,
+);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -337,6 +337,26 @@ const playReplayAndShowStats = async (filePath: string, startFrame?: number) => 
   }
 };
 
+const verifyPendingUpdate = async () => {
+  const currentVersion = app.getVersion();
+  const pendingVersion = settingsManager.get().pendingUpdateVersion;
+
+  if (!pendingVersion) {
+    return;
+  }
+
+  if (currentVersion === pendingVersion) {
+    log.info(`Auto-update succeeded: version ${currentVersion}`);
+  } else {
+    log.error(
+      `Auto-update FAILED: expected ${pendingVersion}, running ${currentVersion}. ` +
+        "Update file may have been missing, corrupted, or the installer was interrupted.",
+    );
+  }
+
+  await settingsManager.updateSetting("pendingUpdateVersion", undefined);
+};
+
 app
   .whenReady()
   .then(() => {
@@ -344,6 +364,7 @@ app
       return;
     }
 
+    void verifyPendingUpdate();
     void createWindow();
 
     // Handle Slippi URI if provided

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -17,7 +17,6 @@ import { ipc_openSettingsModalEvent } from "@settings/ipc";
 import type CrossProcessExports from "electron";
 import { app, BrowserWindow, shell } from "electron";
 import log from "electron-log";
-import { autoUpdater } from "electron-updater";
 import * as fs from "fs-extra";
 import get from "lodash/get";
 import last from "lodash/last";
@@ -26,6 +25,7 @@ import url from "url";
 import { download } from "utils/download";
 import { fileExists } from "utils/file_exists";
 
+import { AppUpdater } from "./app_updater";
 import { getConfigFlags } from "./flags/flags";
 import { installModules } from "./install_modules";
 import { MenuBuilder } from "./menu";
@@ -60,22 +60,6 @@ if (!lockObtained) {
 
 const flags = getConfigFlags();
 const { dolphinManager, settingsManager, browserWindowManager } = installModules(flags);
-
-class AppUpdater {
-  constructor() {
-    autoUpdater.logger = log;
-    autoUpdater.autoInstallOnAppQuit = settingsManager.get().settings.autoUpdateLauncher;
-
-    // This is going to be the default at some point, right now if we don't
-    // explicitly set this to true then electron-builder prints a (harmless)
-    // warning when updating on Windows.
-    // See: https://github.com/electron-userland/electron-builder/pull/6575
-    autoUpdater.disableWebInstaller = true;
-    // Disable differential downloads to fix Windows NSIS update issues
-    // See: https://github.com/electron-userland/electron-builder/issues/9181
-    autoUpdater.disableDifferentialDownload = true;
-  }
-}
 
 if (process.env.NODE_ENV === "production") {
   const sourceMapSupport = require("source-map-support");
@@ -179,9 +163,7 @@ const createWindow = async () => {
     return { action: "deny" };
   });
 
-  // Remove this if your app does not use auto updates
-  // eslint-disable-next-line
-  new AppUpdater();
+  new AppUpdater(settingsManager.get().settings.autoUpdateLauncher);
 };
 
 /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -307,6 +307,14 @@ app.on("second-instance", (_, argv) => {
   handleSlippiURI(lastItem);
 });
 
+app.on("activate", () => {
+  // On macOS it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    void createWindow();
+  }
+});
+
 const playReplayAndShowStats = async (filePath: string, startFrame?: number) => {
   // Ensure playback dolphin is actually installed
   await dolphinManager.installDolphin(DolphinLaunchType.PLAYBACK);
@@ -325,31 +333,21 @@ const playReplayAndShowStats = async (filePath: string, startFrame?: number) => 
   }
 };
 
-app
-  .whenReady()
-  .then(async () => {
-    if (!lockObtained) {
-      return;
-    }
+const main = async () => {
+  await app.whenReady();
+  if (!lockObtained) {
+    return;
+  }
 
-    await appUpdater.verifyPendingUpdate();
-    void createWindow();
+  await appUpdater.verifyPendingUpdate();
+  await createWindow();
 
-    // Handle Slippi URI if provided
-    const argURI = get(process.argv, 1);
-    if (argURI) {
-      handleSlippiURI(argURI);
-    }
-
-    app.on("activate", () => {
-      // On macOS it's common to re-create a window in the app when the
-      // dock icon is clicked and there are no other windows open.
-      if (mainWindow === null) {
-        void createWindow();
-      }
-    });
-  })
-  .catch(log.error);
+  // Handle Slippi URI if provided
+  const argURI = get(process.argv, 1);
+  if (argURI) {
+    handleSlippiURI(argURI);
+  }
+};
 
 const openPreferences = async () => {
   if (!mainWindow) {
@@ -357,3 +355,5 @@ const openPreferences = async () => {
   }
   await ipc_openSettingsModalEvent.main!.trigger({});
 };
+
+main().catch(log.error);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -25,7 +25,6 @@ import url from "url";
 import { download } from "utils/download";
 import { fileExists } from "utils/file_exists";
 
-import { AppUpdater } from "./app_updater";
 import { getConfigFlags } from "./flags/flags";
 import { installModules } from "./install_modules";
 import { MenuBuilder } from "./menu";
@@ -59,7 +58,7 @@ if (!lockObtained) {
 }
 
 const flags = getConfigFlags();
-const { dolphinManager, settingsManager, browserWindowManager } = installModules(flags);
+const { dolphinManager, appUpdater, browserWindowManager } = installModules(flags);
 
 if (process.env.NODE_ENV === "production") {
   const sourceMapSupport = require("source-map-support");
@@ -162,8 +161,6 @@ const createWindow = async () => {
     void shell.openExternal(edata.url);
     return { action: "deny" };
   });
-
-  new AppUpdater(settingsManager.get().settings.autoUpdateLauncher);
 };
 
 /**
@@ -328,34 +325,14 @@ const playReplayAndShowStats = async (filePath: string, startFrame?: number) => 
   }
 };
 
-const verifyPendingUpdate = async () => {
-  const currentVersion = app.getVersion();
-  const pendingVersion = settingsManager.get().pendingUpdateVersion;
-
-  if (!pendingVersion) {
-    return;
-  }
-
-  if (currentVersion === pendingVersion) {
-    log.info(`Auto-update succeeded: version ${currentVersion}`);
-  } else {
-    log.error(
-      `Auto-update FAILED: expected ${pendingVersion}, running ${currentVersion}. ` +
-        "Update file may have been missing, corrupted, or the installer was interrupted.",
-    );
-  }
-
-  await settingsManager.updateSetting("pendingUpdateVersion", undefined);
-};
-
 app
   .whenReady()
-  .then(() => {
+  .then(async () => {
     if (!lockObtained) {
       return;
     }
 
-    void verifyPendingUpdate();
+    await appUpdater.verifyPendingUpdate();
     void createWindow();
 
     // Handle Slippi URI if provided

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -65,6 +65,15 @@ class AppUpdater {
   constructor() {
     autoUpdater.logger = log;
     autoUpdater.autoInstallOnAppQuit = settingsManager.get().settings.autoUpdateLauncher;
+
+    // This is going to be the default at some point, right now if we don't
+    // explicitly set this to true then electron-builder prints a (harmless)
+    // warning when updating on Windows.
+    // See: https://github.com/electron-userland/electron-builder/pull/6575
+    autoUpdater.disableWebInstaller = true;
+    // Disable differential downloads to fix Windows NSIS update issues
+    // See: https://github.com/electron-userland/electron-builder/issues/9181
+    autoUpdater.disableDifferentialDownload = true;
   }
 }
 

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -39,8 +39,6 @@ const log = electronLog.scope("main/listeners");
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
 
-autoUpdater.logger = log;
-
 const LINES_TO_READ = 200;
 
 export default function setupMainIpc({

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -147,10 +147,18 @@ export default function setupMainIpc({
 
   ipc_installUpdate.main!.handle(async () => {
     log.info("Installing update via quitAndInstall");
+
+    const pendingVersion = settingsManager.get().pendingUpdateVersion;
+    if (!pendingVersion) {
+      log.error("No pending update version found — update may not have been downloaded");
+      return { success: false, error: "No update has been downloaded." };
+    }
+
     try {
       autoUpdater.quitAndInstall(false, true);
     } catch (err) {
       log.error("Failed to install update:", err);
+      return { success: false, error: String(err) };
     }
     return { success: true };
   });

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -10,6 +10,7 @@ import { autoUpdater } from "electron-updater";
 import path from "path";
 import { fileExists } from "utils/file_exists";
 
+import type { AppUpdater } from "./app_updater";
 import { getAppBootstrap } from "./bootstrap";
 import type { BrowserWindowManager } from "./browser_window_manager";
 import { getLatestRelease } from "./fetch_cross_origin/github";
@@ -47,11 +48,13 @@ export default function setupMainIpc({
   settingsManager,
   flags,
   browserWindowManager,
+  appUpdater,
 }: {
   dolphinManager: DolphinManager;
   settingsManager: SettingsManager;
   flags: ConfigFlags;
   browserWindowManager: BrowserWindowManager;
+  appUpdater: AppUpdater;
 }) {
   ipcMain.on("onDragStart", (event, files: string[]) => {
     // The Electron.Item type declaration is missing the files attribute
@@ -63,7 +66,7 @@ export default function setupMainIpc({
   });
 
   ipcMain.on("getAppBootstrapSync", (event) => {
-    event.returnValue = getAppBootstrap(flags);
+    event.returnValue = getAppBootstrap(flags, appUpdater.getUpdateState());
   });
 
   ipc_fetchNewsFeed.main!.handle(async () => {

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -2,6 +2,7 @@ import { exists } from "@common/exists";
 import { IsoValidity } from "@common/types";
 import type { DolphinManager } from "@dolphin/manager";
 import { DolphinLaunchType } from "@dolphin/types";
+import type { SettingsManager } from "@settings/settings_manager";
 import { app, clipboard, dialog, ipcMain, nativeImage } from "electron";
 import electronLog from "electron-log";
 import type { ProgressInfo, UpdateInfo } from "electron-updater";
@@ -44,10 +45,12 @@ const LINES_TO_READ = 200;
 
 export default function setupMainIpc({
   dolphinManager,
+  settingsManager,
   flags,
   browserWindowManager,
 }: {
   dolphinManager: DolphinManager;
+  settingsManager: SettingsManager;
   flags: ConfigFlags;
   browserWindowManager: BrowserWindowManager;
 }) {
@@ -135,7 +138,8 @@ export default function setupMainIpc({
     }
   });
 
-  autoUpdater.on("update-downloaded", () => {
+  autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    settingsManager.updateSetting("pendingUpdateVersion", info.version).catch(log.error);
     ipc_launcherUpdateReadyEvent.main!.trigger({}).catch(log.warn);
   });
 

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -145,40 +145,15 @@ export default function setupMainIpc({
     ipc_launcherUpdateReadyEvent.main!.trigger({}).catch(log.warn);
   });
 
-  const installUpdate = async () => {
-    log.info("Installing update via quitAndInstall");
-
-    const pendingVersion = settingsManager.get().pendingUpdateVersion;
-    if (!pendingVersion) {
-      log.error("No pending update version found — update may not have been downloaded");
-      return { success: false, error: "No update has been downloaded." };
-    }
-
+  ipc_installUpdate.main!.handle(async () => {
     try {
-      autoUpdater.quitAndInstall(false, true);
+      log.info("Installing update via quitAndInstall");
+      await appUpdater.quitAndInstall();
       return { success: true };
     } catch (err) {
       log.error("Failed to install update:", err);
-      return { success: false, error: String(err) };
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
-  };
-
-  const installUpdateTimeoutMs = 15000; // 15 seconds
-
-  ipc_installUpdate.main!.handle(async () => {
-    const timeout = new Promise<void>((_resolve, reject) => {
-      // If we still haven't restarted the app within the timeout, something probably went wrong.
-      setTimeout(() => {
-        reject(new Error(`Timed out after ${installUpdateTimeoutMs / 1000}s trying to install update.`));
-      }, installUpdateTimeoutMs);
-    });
-
-    const res = await Promise.race([timeout, installUpdate()]);
-    if (!res?.success) {
-      throw new Error(res?.error ?? "Failed to install update");
-    }
-
-    return res;
   });
 
   ipc_checkForUpdate.main!.handle(async () => {

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -24,7 +24,6 @@ import {
   ipc_installUpdate,
   ipc_launcherUpdateDownloadingEvent,
   ipc_launcherUpdateFoundEvent,
-  ipc_launcherUpdateNotAvailableEvent,
   ipc_launcherUpdateReadyEvent,
   ipc_openInNewBrowserWindow,
   ipc_runNetworkDiagnostics,
@@ -143,10 +142,6 @@ export default function setupMainIpc({
     ipc_launcherUpdateReadyEvent.main!.trigger({}).catch(log.warn);
   });
 
-  autoUpdater.on("update-not-available", () => {
-    ipc_launcherUpdateNotAvailableEvent.main!.trigger({}).catch(log.warn);
-  });
-
   ipc_installUpdate.main!.handle(async () => {
     log.info("Installing update via quitAndInstall");
     try {
@@ -158,8 +153,8 @@ export default function setupMainIpc({
   });
 
   ipc_checkForUpdate.main!.handle(async () => {
-    autoUpdater.checkForUpdatesAndNotify().catch(log.error);
-    return { success: true };
+    const result = await autoUpdater.checkForUpdatesAndNotify();
+    return { updateAvailable: result != null };
   });
 
   ipc_getLatestGitHubReleaseVersion.main!.handle(async ({ owner, repo }) => {

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -23,6 +23,7 @@ import {
   ipc_installUpdate,
   ipc_launcherUpdateDownloadingEvent,
   ipc_launcherUpdateFoundEvent,
+  ipc_launcherUpdateNotAvailableEvent,
   ipc_launcherUpdateReadyEvent,
   ipc_openInNewBrowserWindow,
   ipc_runNetworkDiagnostics,
@@ -138,8 +139,17 @@ export default function setupMainIpc({
     ipc_launcherUpdateReadyEvent.main!.trigger({}).catch(log.warn);
   });
 
+  autoUpdater.on("update-not-available", () => {
+    ipc_launcherUpdateNotAvailableEvent.main!.trigger({}).catch(log.warn);
+  });
+
   ipc_installUpdate.main!.handle(async () => {
-    autoUpdater.quitAndInstall(false, true);
+    log.info("Installing update via quitAndInstall");
+    try {
+      autoUpdater.quitAndInstall(false, true);
+    } catch (err) {
+      log.error("Failed to install update:", err);
+    }
     return { success: true };
   });
 

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -145,7 +145,7 @@ export default function setupMainIpc({
     ipc_launcherUpdateReadyEvent.main!.trigger({}).catch(log.warn);
   });
 
-  ipc_installUpdate.main!.handle(async () => {
+  const installUpdate = async () => {
     log.info("Installing update via quitAndInstall");
 
     const pendingVersion = settingsManager.get().pendingUpdateVersion;
@@ -156,11 +156,29 @@ export default function setupMainIpc({
 
     try {
       autoUpdater.quitAndInstall(false, true);
+      return { success: true };
     } catch (err) {
       log.error("Failed to install update:", err);
       return { success: false, error: String(err) };
     }
-    return { success: true };
+  };
+
+  const installUpdateTimeoutMs = 15000; // 15 seconds
+
+  ipc_installUpdate.main!.handle(async () => {
+    const timeout = new Promise<void>((_resolve, reject) => {
+      // If we still haven't restarted the app within the timeout, something probably went wrong.
+      setTimeout(() => {
+        reject(new Error(`Timed out after ${installUpdateTimeoutMs / 1000}s trying to install update.`));
+      }, installUpdateTimeoutMs);
+    });
+
+    const res = await Promise.race([timeout, installUpdate()]);
+    if (!res?.success) {
+      throw new Error(res?.error ?? "Failed to install update");
+    }
+
+    return res;
   });
 
   ipc_checkForUpdate.main!.handle(async () => {

--- a/src/renderer/app/header/header.messages.ts
+++ b/src/renderer/app/header/header.messages.ts
@@ -3,6 +3,7 @@ export const HeaderMessages = {
   checkForUpdates: () => "Check for updates",
   checkingForUpdates: () => "Checking for updates...",
   failedToGetUpdates: () => "Failed to get updates",
+  noUpdateAvailable: () => "No update available",
   noMeleeIsoFile: () => "No Melee ISO file specified",
   settings: () => "Settings",
   chooseAConnectCode: () => "Choose a connect code",

--- a/src/renderer/app/header/header.tsx
+++ b/src/renderer/app/header/header.tsx
@@ -182,8 +182,10 @@ const CheckForUpdatesButton = () => {
     const checkForUpdates = async () => {
       setCheckingForUpdates(true);
       try {
-        showInfo(Messages.checkingForUpdates());
-        await checkForAppUpdates();
+        const updateResult = await checkForAppUpdates();
+        if (updateResult && !updateResult.updateAvailable) {
+          showInfo(Messages.noUpdateAvailable());
+        }
         await updateDolphin();
       } catch (err) {
         log.error(err);
@@ -196,7 +198,7 @@ const CheckForUpdatesButton = () => {
   }, [checkForAppUpdates, updateDolphin, showInfo, showError]);
 
   return (
-    <Tooltip title={Messages.checkForUpdates()}>
+    <Tooltip title={checkingForUpdates ? Messages.checkingForUpdates() : Messages.checkForUpdates()}>
       <Button
         style={isMac ? { marginTop: 10 } : undefined}
         onClick={checkForUpdatesHandler}

--- a/src/renderer/components/persistent_notification/persistent_notification.messages.ts
+++ b/src/renderer/components/persistent_notification/persistent_notification.messages.ts
@@ -1,5 +1,8 @@
 export const PersistentNotificationMessages = {
   downloadingVersion: (version: string) => `Downloading version {0}...`,
   installUpdate: () => "Install update",
+  installingUpdate: () => "Installing...",
   versionIsNowAvailable: (version: string) => `Version {0} is now available!`,
+  installFailed: () => "Installation failed. Try downloading manually.",
+  downloadManually: () => "Open slippi.gg",
 };

--- a/src/renderer/components/persistent_notification/persistent_notification.messages.ts
+++ b/src/renderer/components/persistent_notification/persistent_notification.messages.ts
@@ -2,6 +2,6 @@ export const PersistentNotificationMessages = {
   downloadingVersion: (version: string) => `Downloading version {0}...`,
   installUpdate: () => "Install update",
   versionIsNowAvailable: (version: string) => `Version {0} is now available!`,
-  installFailed: () => "Installation failed. Try downloading manually.",
-  downloadManually: () => "Open slippi.gg",
+  installFailed: () => "Installation failed.",
+  downloadManually: () => "Download manually",
 };

--- a/src/renderer/components/persistent_notification/persistent_notification.messages.ts
+++ b/src/renderer/components/persistent_notification/persistent_notification.messages.ts
@@ -1,7 +1,6 @@
 export const PersistentNotificationMessages = {
   downloadingVersion: (version: string) => `Downloading version {0}...`,
   installUpdate: () => "Install update",
-  installingUpdate: () => "Installing...",
   versionIsNowAvailable: (version: string) => `Version {0} is now available!`,
   installFailed: () => "Installation failed. Try downloading manually.",
   downloadManually: () => "Open slippi.gg",

--- a/src/renderer/components/persistent_notification/persistent_notification.tsx
+++ b/src/renderer/components/persistent_notification/persistent_notification.tsx
@@ -35,6 +35,13 @@ export const PersistentNotification = React.memo(() => {
     window.electron.shell.openExternal("https://slippi.gg/downloads").catch(log.error);
   }, []);
 
+  // The handleInstall callback should provide immediate feedback i.e. it should immediately restart the
+  // launcher so I don't think it's worth showing an 'Installing...' message that would need to be localised.
+  // Instead we'll just show nothing as the feedback.
+  if (isInstalling) {
+    return null;
+  }
+
   if (installError) {
     return (
       <Outer>
@@ -42,10 +49,6 @@ export const PersistentNotification = React.memo(() => {
         <RestartButton onClick={handleDownloadManually}>{Messages.downloadManually()}</RestartButton>
       </Outer>
     );
-  }
-
-  if (isInstalling) {
-    return <Outer>{Messages.installingUpdate()}</Outer>;
   }
 
   if (!updateReady && updateDownloadProgress) {

--- a/src/renderer/components/persistent_notification/persistent_notification.tsx
+++ b/src/renderer/components/persistent_notification/persistent_notification.tsx
@@ -31,7 +31,7 @@ export const PersistentNotification = React.memo(() => {
     }
   }, [installAppUpdate]);
 
-  const handleDownloadManually = useCallback(() => {
+  const handleManualDownload = useCallback(() => {
     window.electron.shell.openExternal("https://slippi.gg/downloads").catch(log.error);
   }, []);
 
@@ -46,7 +46,7 @@ export const PersistentNotification = React.memo(() => {
     return (
       <Outer>
         <span>{Messages.installFailed()}</span>
-        <RestartButton onClick={handleDownloadManually}>{Messages.downloadManually()}</RestartButton>
+        <RestartButton onClick={handleManualDownload}>{Messages.downloadManually()}</RestartButton>
       </Outer>
     );
   }

--- a/src/renderer/components/persistent_notification/persistent_notification.tsx
+++ b/src/renderer/components/persistent_notification/persistent_notification.tsx
@@ -1,7 +1,8 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import ButtonBase from "@mui/material/ButtonBase";
-import React from "react";
+import log from "electron-log";
+import React, { useCallback, useState } from "react";
 
 import { useAppStore } from "@/lib/hooks/use_app_store";
 import { useAppUpdate } from "@/lib/hooks/use_app_update";
@@ -15,6 +16,37 @@ export const PersistentNotification = React.memo(() => {
   const updateDownloadProgress = useAppStore((store) => store.updateDownloadProgress);
 
   const { installAppUpdate } = useAppUpdate();
+  const [isInstalling, setIsInstalling] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  const handleInstall = useCallback(async () => {
+    setIsInstalling(true);
+    setInstallError(null);
+
+    const result = await installAppUpdate();
+
+    if (!result.success) {
+      setIsInstalling(false);
+      setInstallError(result.error || "Unknown error");
+    }
+  }, [installAppUpdate]);
+
+  const handleDownloadManually = useCallback(() => {
+    window.electron.shell.openExternal("https://slippi.gg/downloads").catch(log.error);
+  }, []);
+
+  if (installError) {
+    return (
+      <Outer>
+        <span>{Messages.installFailed()}</span>
+        <RestartButton onClick={handleDownloadManually}>{Messages.downloadManually()}</RestartButton>
+      </Outer>
+    );
+  }
+
+  if (isInstalling) {
+    return <Outer>{Messages.installingUpdate()}</Outer>;
+  }
 
   if (!updateReady && updateDownloadProgress) {
     return (
@@ -50,7 +82,9 @@ export const PersistentNotification = React.memo(() => {
         >
           {Messages.versionIsNowAvailable(updateVersion)}
         </span>
-        <RestartButton onClick={installAppUpdate}>{Messages.installUpdate()}</RestartButton>
+        <RestartButton disabled={isInstalling} onClick={handleInstall}>
+          {Messages.installUpdate()}
+        </RestartButton>
       </div>
     </Outer>
   );
@@ -58,8 +92,10 @@ export const PersistentNotification = React.memo(() => {
 
 const Outer = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: center;
+  align-items: center;
+  gap: 10px;
   position: relative;
   height: 30px;
   background-color: ${cssVar("purpleLight")};

--- a/src/renderer/initialize_app.messages.ts
+++ b/src/renderer/initialize_app.messages.ts
@@ -6,7 +6,7 @@ export const InitializeAppMessages = {
     "Failed to install {0}. Try closing all Dolphin instances and restarting the launcher.",
   netplayDolphin: () => "Netplay Dolphin",
   playbackDolphin: () => "Playback Dolphin",
-  updatedToVersion: (version: string) => `Successfully updated to version {0}!`,
+  updatedToVersion: (version: string) => `Slippi Launcher has been updated to version {0}`,
   updateFailed: (version: string) =>
     `Auto-update to version {0} failed. Try manually downloading the latest version from slippi.gg.`,
 };

--- a/src/renderer/initialize_app.messages.ts
+++ b/src/renderer/initialize_app.messages.ts
@@ -8,5 +8,5 @@ export const InitializeAppMessages = {
   playbackDolphin: () => "Playback Dolphin",
   updatedToVersion: (version: string) => `Successfully updated to version {0}!`,
   updateFailed: (version: string) =>
-    `Auto-update to {0} failed. Try manually downloading the latest version from slippi.gg.`,
+    `Auto-update to version {0} failed. Try manually downloading the latest version from slippi.gg.`,
 };

--- a/src/renderer/initialize_app.messages.ts
+++ b/src/renderer/initialize_app.messages.ts
@@ -6,4 +6,7 @@ export const InitializeAppMessages = {
     "Failed to install {0}. Try closing all Dolphin instances and restarting the launcher.",
   netplayDolphin: () => "Netplay Dolphin",
   playbackDolphin: () => "Playback Dolphin",
+  updatedToVersion: (version: string) => `Successfully updated to version {0}!`,
+  updateFailed: (version: string) =>
+    `Auto-update to {0} failed. Try manually downloading the latest version from slippi.gg.`,
 };

--- a/src/renderer/initialize_app.ts
+++ b/src/renderer/initialize_app.ts
@@ -70,10 +70,12 @@ export async function initializeApp(services: Services) {
       log.error(result.reason);
     });
 
+  // Show the update result after awaiting the promises since we load the app
+  // via React.Suspense so nothing is visible anyway while the promises are being awaited.
   const updateState = window.electron.bootstrap.updateState;
   if (updateState) {
     if (updateState.status === "succeeded") {
-      notificationService.showSuccess(Messages.updatedToVersion(updateState.version));
+      notificationService.showInfo(Messages.updatedToVersion(updateState.version));
     } else {
       showError(Messages.updateFailed(updateState.version));
     }

--- a/src/renderer/initialize_app.ts
+++ b/src/renderer/initialize_app.ts
@@ -69,4 +69,13 @@ export async function initializeApp(services: Services) {
     .forEach((result) => {
       log.error(result.reason);
     });
+
+  const updateState = window.electron.bootstrap.updateState;
+  if (updateState) {
+    if (updateState.status === "succeeded") {
+      notificationService.showSuccess(Messages.updatedToVersion(updateState.version));
+    } else {
+      showError(Messages.updateFailed(updateState.version));
+    }
+  }
 }

--- a/src/renderer/initialize_app.ts
+++ b/src/renderer/initialize_app.ts
@@ -56,8 +56,8 @@ export async function initializeApp(services: Services) {
     });
   });
 
-  // Check if there is an update to the launcher
-  promises.push(window.electron.common.checkForAppUpdates());
+  // Check if there is an update to the launcher (silent — no toast on "no update")
+  promises.push(window.electron.common.checkForAppUpdates(true));
 
   // Ensure the fonts are loaded to prevent FOUT (Flash of Unstyled Text)
   promises.push(document.fonts.ready);

--- a/src/renderer/initialize_app.ts
+++ b/src/renderer/initialize_app.ts
@@ -56,8 +56,8 @@ export async function initializeApp(services: Services) {
     });
   });
 
-  // Check if there is an update to the launcher (silent — no toast on "no update")
-  promises.push(window.electron.common.checkForAppUpdates(true));
+  // Check if there is an update to the launcher
+  promises.push(window.electron.common.checkForAppUpdates());
 
   // Ensure the fonts are loaded to prevent FOUT (Flash of Unstyled Text)
   promises.push(document.fonts.ready);

--- a/src/renderer/lib/hooks/use_app_update.ts
+++ b/src/renderer/lib/hooks/use_app_update.ts
@@ -15,11 +15,12 @@ export const useAppUpdate = () => {
     }
   }, [showError]);
 
-  const installAppUpdate = React.useCallback(async () => {
+  const installAppUpdate = React.useCallback(async (): Promise<{ success: boolean; error?: string }> => {
     try {
-      await window.electron.common.installAppUpdate();
+      return await window.electron.common.installAppUpdate();
     } catch (err) {
       showError(err);
+      return { success: false, error: String(err) };
     }
   }, [showError]);
 

--- a/src/renderer/lib/hooks/use_app_update.ts
+++ b/src/renderer/lib/hooks/use_app_update.ts
@@ -11,6 +11,7 @@ export const useAppUpdate = () => {
       return result;
     } catch (err) {
       showError(err);
+      return null;
     }
   }, [showError]);
 

--- a/src/renderer/lib/hooks/use_app_update.ts
+++ b/src/renderer/lib/hooks/use_app_update.ts
@@ -7,7 +7,8 @@ export const useAppUpdate = () => {
 
   const checkForAppUpdates = React.useCallback(async () => {
     try {
-      await window.electron.common.checkForAppUpdates();
+      const result = await window.electron.common.checkForAppUpdates();
+      return result;
     } catch (err) {
       showError(err);
     }

--- a/src/renderer/listeners/install_app_listeners.ts
+++ b/src/renderer/listeners/install_app_listeners.ts
@@ -72,6 +72,10 @@ export function installAppListeners(services: Services) {
     useAppStore.getState().setUpdateVersion(version);
   });
 
+  window.electron.common.onAppUpdateNotAvailable(() => {
+    notificationService.showInfo("No update available");
+  });
+
   // Track online/offline status
   window.addEventListener("online", () => {
     useAppStore.getState().setIsOnline(true);

--- a/src/renderer/listeners/install_app_listeners.ts
+++ b/src/renderer/listeners/install_app_listeners.ts
@@ -72,10 +72,6 @@ export function installAppListeners(services: Services) {
     useAppStore.getState().setUpdateVersion(version);
   });
 
-  window.electron.common.onAppUpdateNotAvailable(() => {
-    notificationService.showInfo("No update available");
-  });
-
   // Track online/offline status
   window.addEventListener("online", () => {
     useAppStore.getState().setIsOnline(true);

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -77,6 +77,7 @@ export interface RootSettingsSchema {
   connections: StoredConnection[];
   accounts: AccountData;
   previousVersion?: string;
+  pendingUpdateVersion?: string;
   netplayPromotedToStable: boolean;
   playbackPromotedToStable: boolean;
 }


### PR DESCRIPTION
### Summary

This PR refactors the auto-updater into its own module, adds post-update verification, improves UI feedback during manual update checks, and fixes Windows NSIS update failures by disabling differential downloads. Also refines the electron-builder config to produce separate x64/arm64 builds instead of universal macOS binaries and narrows the `asarUnpack` pattern.


### Problem

The existing auto-update flow had several gaps:
1. no feedback when no update was available
2. no verification that an update actually applied
3. Windows users experienced silent update failures likely due to differential download corruption. We seem to often get users complaining about JS errors when opening the app, with the recommended solution to be to redownload the app.
4. Mac users have really large downloads due to the universal build.

I believe point 3 is caused primarily by two things: 1. anti-virus removing certain files, and 2. failed auto-update. I've noticed an increase in users posting this issue, right after a new update is released so it's likely related to that.

### Solution

We attempt to address these issues by making a couple of key changes:

- **`src/main/app_updater.ts`** — Extracted inline `AppUpdater` class into its own file
- **Post-update verification** — Saves the pending update version to settings when downloaded, then on next launch verifies the running version matches and logs success/failure
- **`checkForUpdates` returns availability** — The IPC handler now returns whether an update was actually found, so the UI can show "No update available" instead of being silent
- **Button tooltip updates** — Shows "Checking for updates…" during the check and "No update available" when none is found
- **`disableDifferentialDownload = true`** — Works around [electron-builder#9181](https://github.com/electron-userland/electron-builder/issues/9181) to fix Windows NSIS update corruption
- **Build config** — Switches from universal macOS to separate x64/arm64 targets; removes `mergeASARs: false`; narrows `asarUnpack` to only worker.js files; disables differential packages for NSIS; adds arch to artifact names
