### PR TITLE
feat: open live streams inside an internal BrowserWindow

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,7 +1,6 @@
 import { ipcRenderer } from "electron";
 
 import {
-  type OpenInNewBrowserWindowOptions,
   ipc_checkForUpdate,
   ipc_checkValidIso,
   ipc_clearTempFolder,
@@ -54,8 +53,8 @@ export default {
     const { result } = await ipc_runNetworkDiagnostics.renderer!.trigger({});
     return result;
   },
-  async openInNewBrowserWindow(url: string, options?: OpenInNewBrowserWindowOptions): Promise<void> {
-    await ipc_openInNewBrowserWindow.renderer!.trigger({ url, options });
+  async openInNewBrowserWindow(url: string): Promise<void> {
+    await ipc_openInNewBrowserWindow.renderer!.trigger({ url });
   },
   onAppUpdateFound(handle: (version: string) => void) {
     const { destroy } = ipc_launcherUpdateFoundEvent.renderer!.handle(async ({ version }) => {

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from "electron";
 
 import {
+  type OpenInNewBrowserWindowOptions,
   ipc_checkForUpdate,
   ipc_checkValidIso,
   ipc_clearTempFolder,
@@ -11,6 +12,7 @@ import {
   ipc_launcherUpdateDownloadingEvent,
   ipc_launcherUpdateFoundEvent,
   ipc_launcherUpdateReadyEvent,
+  ipc_openInNewBrowserWindow,
   ipc_runNetworkDiagnostics,
   ipc_showOpenDialog,
 } from "./ipc";
@@ -51,6 +53,9 @@ export default {
   async runNetworkDiagnostics() {
     const { result } = await ipc_runNetworkDiagnostics.renderer!.trigger({});
     return result;
+  },
+  async openInNewBrowserWindow(url: string, options?: OpenInNewBrowserWindowOptions): Promise<void> {
+    await ipc_openInNewBrowserWindow.renderer!.trigger({ url, options });
   },
   onAppUpdateFound(handle: (version: string) => void) {
     const { destroy } = ipc_launcherUpdateFoundEvent.renderer!.handle(async ({ version }) => {

--- a/src/main/browser_window_manager.ts
+++ b/src/main/browser_window_manager.ts
@@ -19,6 +19,7 @@ export class BrowserWindowManager {
       return;
     }
 
+    const { hostname } = new URL(url);
     const win = new BrowserWindow({
       width: 960,
       height: 540,
@@ -29,6 +30,8 @@ export class BrowserWindowManager {
       autoHideMenuBar: true,
       webPreferences: {
         sandbox: true,
+        // We partition by hostname to isolate cookies and other data
+        partition: `temp:${hostname}`,
       },
     });
 

--- a/src/main/browser_window_manager.ts
+++ b/src/main/browser_window_manager.ts
@@ -1,0 +1,55 @@
+import { BrowserWindow } from "electron";
+import log from "electron-log";
+
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+const BACKGROUND_COLOR = "#1B0B28";
+
+export class BrowserWindowManager {
+  private externalWindowsByUrl = new Map<string, BrowserWindow>();
+
+  public openInNewBrowserWindow(url: string) {
+    const existing = this.externalWindowsByUrl.get(url);
+    if (existing && !existing.isDestroyed()) {
+      if (existing.isMinimized()) {
+        existing.restore();
+      }
+      existing.show();
+      existing.focus();
+      return;
+    }
+
+    const win = new BrowserWindow({
+      width: 960,
+      height: 540,
+      alwaysOnTop: true,
+      fullscreenable: false, // When a website requests fullscreen, fill only the browser window
+      show: false,
+      backgroundColor: BACKGROUND_COLOR,
+      autoHideMenuBar: true,
+      webPreferences: {
+        sandbox: true,
+      },
+    });
+
+    if (isDevelopment) {
+      // Devtools automatically opens when a new browser window is created in development mode.
+      // We don't really care about devtools in this situation so just close it immediately.
+      win.webContents.on("devtools-opened", () => {
+        win.webContents.closeDevTools();
+      });
+    }
+
+    win.loadURL(url).catch(log.error);
+
+    win.on("closed", () => {
+      this.externalWindowsByUrl.delete(url);
+    });
+
+    win.on("ready-to-show", () => {
+      win.show();
+    });
+
+    this.externalWindowsByUrl.set(url, win);
+  }
+}

--- a/src/main/browser_window_manager.ts
+++ b/src/main/browser_window_manager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, shell } from "electron";
 import log from "electron-log";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -48,6 +48,11 @@ export class BrowserWindowManager {
 
     win.on("ready-to-show", () => {
       win.show();
+    });
+
+    win.webContents.setWindowOpenHandler((edata) => {
+      void shell.openExternal(edata.url);
+      return { action: "deny" };
     });
 
     this.externalWindowsByUrl.set(url, win);

--- a/src/main/fetch_cross_origin/melee_majors.ts
+++ b/src/main/fetch_cross_origin/melee_majors.ts
@@ -163,9 +163,8 @@ export type MeleeMajorsTournament = Omit<Tournament, "startTimestamp" | "endTime
 function mapMeleeMajorsTournament(tournament: Tournament): MeleeMajorsTournament {
   return {
     ...tournament,
-    startTimestamp: new Date(),
+    startTimestamp: new Date(tournament.startTimestamp),
     endTimestamp: new Date(tournament.endTimestamp),
     players: tournament.players.filter(exists),
-    streamUrl: "https://www.twitch.tv/x_pilot",
   };
 }

--- a/src/main/fetch_cross_origin/melee_majors.ts
+++ b/src/main/fetch_cross_origin/melee_majors.ts
@@ -163,8 +163,9 @@ export type MeleeMajorsTournament = Omit<Tournament, "startTimestamp" | "endTime
 function mapMeleeMajorsTournament(tournament: Tournament): MeleeMajorsTournament {
   return {
     ...tournament,
-    startTimestamp: new Date(tournament.startTimestamp),
+    startTimestamp: new Date(),
     endTimestamp: new Date(tournament.endTimestamp),
     players: tournament.players.filter(exists),
+    streamUrl: "https://www.twitch.tv/x_pilot",
   };
 }

--- a/src/main/install_modules.ts
+++ b/src/main/install_modules.ts
@@ -7,6 +7,7 @@ import setupReplaysIpc from "@replays/setup";
 import { SettingsManager } from "@settings/settings_manager";
 import setupSettingsIpc from "@settings/setup";
 
+import { BrowserWindowManager } from "./browser_window_manager";
 import type { ConfigFlags } from "./flags/flags";
 import setupMainIpc from "./setup";
 
@@ -19,6 +20,7 @@ export function installModules(flags: ConfigFlags) {
   setupSettingsIpc({ settingsManager, dolphinManager });
   setupConsoleIpc({ dolphinManager });
   setupRemoteIpc({ dolphinManager, settingsManager, getSpectateController });
-  setupMainIpc({ dolphinManager, flags });
+  const browserWindowManager = new BrowserWindowManager();
+  setupMainIpc({ dolphinManager, flags, browserWindowManager });
   return { dolphinManager, settingsManager };
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -38,15 +38,9 @@ export const ipc_runNetworkDiagnostics = makeEndpoint.main(
 
 // Events
 
-export type OpenInNewBrowserWindowOptions = {
-  width?: number;
-  height?: number;
-  alwaysOnTop?: boolean;
-};
-
 export const ipc_openInNewBrowserWindow = makeEndpoint.main(
   "openInNewBrowserWindow",
-  <{ url: string; options?: OpenInNewBrowserWindowOptions }>_,
+  <{ url: string }>_,
   <SuccessPayload>_,
 );
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -38,6 +38,18 @@ export const ipc_runNetworkDiagnostics = makeEndpoint.main(
 
 // Events
 
+export type OpenInNewBrowserWindowOptions = {
+  width?: number;
+  height?: number;
+  alwaysOnTop?: boolean;
+};
+
+export const ipc_openInNewBrowserWindow = makeEndpoint.main(
+  "openInNewBrowserWindow",
+  <{ url: string; options?: OpenInNewBrowserWindowOptions }>_,
+  <SuccessPayload>_,
+);
+
 export const ipc_launcherUpdateFoundEvent = makeEndpoint.renderer("launcherupdate_found", <{ version: string }>_);
 
 export const ipc_launcherUpdateDownloadingEvent = makeEndpoint.renderer(

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -190,7 +190,7 @@ export default function setupMainIpc({
       width: 960,
       height: 540,
       alwaysOnTop: true,
-      fullscreenable: false,
+      fullscreenable: false, // When a website requests fullscreen, fill only the browser window
       show: false,
       backgroundColor: BACKGROUND_COLOR,
       autoHideMenuBar: true,

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -2,7 +2,7 @@ import { exists } from "@common/exists";
 import { IsoValidity } from "@common/types";
 import type { DolphinManager } from "@dolphin/manager";
 import { DolphinLaunchType } from "@dolphin/types";
-import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeImage } from "electron";
+import { app, clipboard, dialog, ipcMain, nativeImage } from "electron";
 import electronLog from "electron-log";
 import type { ProgressInfo, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
@@ -10,6 +10,7 @@ import path from "path";
 import { fileExists } from "utils/file_exists";
 
 import { getAppBootstrap } from "./bootstrap";
+import type { BrowserWindowManager } from "./browser_window_manager";
 import { getLatestRelease } from "./fetch_cross_origin/github";
 import type { ConfigFlags } from "./flags/flags";
 import {
@@ -32,8 +33,6 @@ import { fetchNewsFeedData } from "./news_feed";
 import { clearTempFolder, getAssetPath, readLastLines } from "./util";
 import { verifyIso } from "./verify_iso";
 
-const BACKGROUND_COLOR = "#1B0B28";
-
 const log = electronLog.scope("main/listeners");
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
@@ -45,9 +44,11 @@ const LINES_TO_READ = 200;
 export default function setupMainIpc({
   dolphinManager,
   flags,
+  browserWindowManager,
 }: {
   dolphinManager: DolphinManager;
   flags: ConfigFlags;
+  browserWindowManager: BrowserWindowManager;
 }) {
   ipcMain.on("onDragStart", (event, files: string[]) => {
     // The Electron.Item type declaration is missing the files attribute
@@ -173,52 +174,8 @@ export default function setupMainIpc({
     return getNetworkDiagnostics();
   });
 
-  const externalWindowsByUrl = new Map<string, BrowserWindow>();
-
-  ipc_openInNewBrowserWindow.main!.handle(async ({ url }) => {
-    const existing = externalWindowsByUrl.get(url);
-    if (existing && !existing.isDestroyed()) {
-      if (existing.isMinimized()) {
-        existing.restore();
-      }
-      existing.show();
-      existing.focus();
-      return { success: true };
-    }
-
-    const win = new BrowserWindow({
-      width: 960,
-      height: 540,
-      alwaysOnTop: true,
-      fullscreenable: false, // When a website requests fullscreen, fill only the browser window
-      show: false,
-      backgroundColor: BACKGROUND_COLOR,
-      autoHideMenuBar: true,
-      webPreferences: {
-        sandbox: true,
-      },
-    });
-
-    if (isDevelopment) {
-      // Devtools automatically opens when a new browser window is created in development mode.
-      // We don't really care about devtools in this situation so just close it immediately.
-      win.webContents.on("devtools-opened", () => {
-        win.webContents.closeDevTools();
-      });
-    }
-
-    win.loadURL(url).catch(log.error);
-
-    win.on("closed", () => {
-      externalWindowsByUrl.delete(url);
-    });
-
-    win.on("ready-to-show", () => {
-      win.show();
-    });
-
-    externalWindowsByUrl.set(url, win);
-
+  ipc_openInNewBrowserWindow.main!.handle(async ({ url }: { url: string }) => {
+    browserWindowManager.openInNewBrowserWindow(url);
     return { success: true };
   });
 }

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -2,7 +2,7 @@ import { exists } from "@common/exists";
 import { IsoValidity } from "@common/types";
 import type { DolphinManager } from "@dolphin/manager";
 import { DolphinLaunchType } from "@dolphin/types";
-import { app, clipboard, dialog, ipcMain, nativeImage } from "electron";
+import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeImage } from "electron";
 import electronLog from "electron-log";
 import type { ProgressInfo, UpdateInfo } from "electron-updater";
 import { autoUpdater } from "electron-updater";
@@ -13,6 +13,7 @@ import { getAppBootstrap } from "./bootstrap";
 import { getLatestRelease } from "./fetch_cross_origin/github";
 import type { ConfigFlags } from "./flags/flags";
 import {
+  type OpenInNewBrowserWindowOptions,
   ipc_checkForUpdate,
   ipc_checkValidIso,
   ipc_clearTempFolder,
@@ -23,6 +24,7 @@ import {
   ipc_launcherUpdateDownloadingEvent,
   ipc_launcherUpdateFoundEvent,
   ipc_launcherUpdateReadyEvent,
+  ipc_openInNewBrowserWindow,
   ipc_runNetworkDiagnostics,
   ipc_showOpenDialog,
 } from "./ipc";
@@ -30,6 +32,8 @@ import { getNetworkDiagnostics } from "./network_diagnostics";
 import { fetchNewsFeedData } from "./news_feed";
 import { clearTempFolder, getAssetPath, readLastLines } from "./util";
 import { verifyIso } from "./verify_iso";
+
+const BACKGROUND_COLOR = "#1B0B28";
 
 const log = electronLog.scope("main/listeners");
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -168,5 +172,53 @@ export default function setupMainIpc({
 
   ipc_runNetworkDiagnostics.main!.handle(async () => {
     return getNetworkDiagnostics();
+  });
+
+  const externalWindowsByUrl = new Map<string, BrowserWindow>();
+
+  ipc_openInNewBrowserWindow.main!.handle(async ({ url, options }) => {
+    const existing = externalWindowsByUrl.get(url);
+    if (existing && !existing.isDestroyed()) {
+      if (existing.isMinimized()) {
+        existing.restore();
+      }
+      existing.show();
+      existing.focus();
+      return { success: true };
+    }
+
+    const defaultOptions: Required<OpenInNewBrowserWindowOptions> = {
+      width: 960,
+      height: 540,
+      alwaysOnTop: false,
+    };
+    const resolved = { ...defaultOptions, ...options };
+
+    const win = new BrowserWindow({
+      width: resolved.width,
+      height: resolved.height,
+      alwaysOnTop: resolved.alwaysOnTop,
+      show: false,
+      backgroundColor: BACKGROUND_COLOR,
+      titleBarStyle: "hiddenInset",
+      autoHideMenuBar: true,
+      webPreferences: {
+        sandbox: true,
+      },
+    });
+
+    win.loadURL(url).catch(log.error);
+
+    win.on("closed", () => {
+      externalWindowsByUrl.delete(url);
+    });
+
+    win.on("ready-to-show", () => {
+      win.show();
+    });
+
+    externalWindowsByUrl.set(url, win);
+
+    return { success: true };
   });
 }

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -207,6 +207,14 @@ export default function setupMainIpc({
       },
     });
 
+    if (isDevelopment) {
+      // Devtools automatically opens when a new browser window is created in development mode.
+      // We don't really care about devtools in this situation so just close it immediately.
+      win.webContents.on("devtools-opened", () => {
+        win.webContents.closeDevTools();
+      });
+    }
+
     win.loadURL(url).catch(log.error);
 
     win.on("closed", () => {

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -201,7 +201,6 @@ export default function setupMainIpc({
       fullscreenable: false, // When a website requests fullscreen, fill only the browser window
       show: false,
       backgroundColor: BACKGROUND_COLOR,
-      titleBarStyle: "hiddenInset",
       autoHideMenuBar: true,
       webPreferences: {
         sandbox: true,

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -13,7 +13,6 @@ import { getAppBootstrap } from "./bootstrap";
 import { getLatestRelease } from "./fetch_cross_origin/github";
 import type { ConfigFlags } from "./flags/flags";
 import {
-  type OpenInNewBrowserWindowOptions,
   ipc_checkForUpdate,
   ipc_checkValidIso,
   ipc_clearTempFolder,
@@ -176,7 +175,7 @@ export default function setupMainIpc({
 
   const externalWindowsByUrl = new Map<string, BrowserWindow>();
 
-  ipc_openInNewBrowserWindow.main!.handle(async ({ url, options }) => {
+  ipc_openInNewBrowserWindow.main!.handle(async ({ url }) => {
     const existing = externalWindowsByUrl.get(url);
     if (existing && !existing.isDestroyed()) {
       if (existing.isMinimized()) {
@@ -187,18 +186,11 @@ export default function setupMainIpc({
       return { success: true };
     }
 
-    const defaultOptions: Required<OpenInNewBrowserWindowOptions> = {
+    const win = new BrowserWindow({
       width: 960,
       height: 540,
-      alwaysOnTop: false,
-    };
-    const resolved = { ...defaultOptions, ...options };
-
-    const win = new BrowserWindow({
-      width: resolved.width,
-      height: resolved.height,
-      alwaysOnTop: resolved.alwaysOnTop,
-      fullscreenable: false, // When a website requests fullscreen, fill only the browser window
+      alwaysOnTop: true,
+      fullscreenable: false,
       show: false,
       backgroundColor: BACKGROUND_COLOR,
       autoHideMenuBar: true,

--- a/src/main/setup.ts
+++ b/src/main/setup.ts
@@ -198,6 +198,7 @@ export default function setupMainIpc({
       width: resolved.width,
       height: resolved.height,
       alwaysOnTop: resolved.alwaysOnTop,
+      fullscreenable: false, // When a website requests fullscreen, fill only the browser window
       show: false,
       backgroundColor: BACKGROUND_COLOR,
       titleBarStyle: "hiddenInset",

--- a/src/renderer/pages/home/overview/carousel/carousel.tsx
+++ b/src/renderer/pages/home/overview/carousel/carousel.tsx
@@ -142,7 +142,18 @@ export const Carousel = React.memo(function Carousel({ items, durationMs = 5000 
                         size="large"
                         startIcon={<PlayArrowIcon />}
                         style={{ fontSize: 14 }}
-                        onClick={() => window.electron.common.openInNewBrowserWindow(item.streamUrl!)}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          const isModifiedClick = window.electron.bootstrap.isMac
+                            ? event.metaKey // Cmd on macOS
+                            : event.ctrlKey; // Ctrl elsewhere
+                          if (isModifiedClick) {
+                            void window.electron.shell.openExternal(item.streamUrl!);
+                          } else {
+                            void window.electron.common.openInNewBrowserWindow(item.streamUrl!);
+                          }
+                        }}
                       >
                         {Messages.viewStream()}
                       </Button>

--- a/src/renderer/pages/home/overview/carousel/carousel.tsx
+++ b/src/renderer/pages/home/overview/carousel/carousel.tsx
@@ -142,7 +142,13 @@ export const Carousel = React.memo(function Carousel({ items, durationMs = 5000 
                         size="large"
                         startIcon={<PlayArrowIcon />}
                         style={{ fontSize: 14 }}
-                        onClick={() => window.electron.shell.openExternal(item.streamUrl!)}
+                        onClick={() =>
+                          window.electron.common.openInNewBrowserWindow(item.streamUrl!, {
+                            alwaysOnTop: true,
+                            width: 960,
+                            height: 540,
+                          })
+                        }
                       >
                         {Messages.viewStream()}
                       </Button>

--- a/src/renderer/pages/home/overview/carousel/carousel.tsx
+++ b/src/renderer/pages/home/overview/carousel/carousel.tsx
@@ -142,13 +142,7 @@ export const Carousel = React.memo(function Carousel({ items, durationMs = 5000 
                         size="large"
                         startIcon={<PlayArrowIcon />}
                         style={{ fontSize: 14 }}
-                        onClick={() =>
-                          window.electron.common.openInNewBrowserWindow(item.streamUrl!, {
-                            alwaysOnTop: true,
-                            width: 960,
-                            height: 540,
-                          })
-                        }
+                        onClick={() => window.electron.common.openInNewBrowserWindow(item.streamUrl!)}
                       >
                         {Messages.viewStream()}
                       </Button>

--- a/src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.tsx
+++ b/src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.tsx
@@ -57,10 +57,17 @@ const FeaturedMajor = ({
               size="large"
               startIcon={<PlayArrowIcon />}
               style={{ fontSize: 16 }}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                void window.electron.common.openInNewBrowserWindow(major.streamUrl!);
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const isModifiedClick = window.electron.bootstrap.isMac
+                  ? event.metaKey // Cmd on macOS
+                  : event.ctrlKey; // Ctrl elsewhere
+                if (isModifiedClick) {
+                  void window.electron.shell.openExternal(major.streamUrl!);
+                } else {
+                  void window.electron.common.openInNewBrowserWindow(major.streamUrl!);
+                }
               }}
             >
               {Messages.viewStream()}

--- a/src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.tsx
+++ b/src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.tsx
@@ -60,11 +60,7 @@ const FeaturedMajor = ({
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                void window.electron.common.openInNewBrowserWindow(major.streamUrl!, {
-                  alwaysOnTop: true,
-                  width: 960,
-                  height: 540,
-                });
+                void window.electron.common.openInNewBrowserWindow(major.streamUrl!);
               }}
             >
               {Messages.viewStream()}

--- a/src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.tsx
+++ b/src/renderer/pages/home/upcoming_tournaments/upcoming_tournaments.tsx
@@ -60,7 +60,11 @@ const FeaturedMajor = ({
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                void window.electron.shell.openExternal(major.streamUrl!);
+                void window.electron.common.openInNewBrowserWindow(major.streamUrl!, {
+                  alwaysOnTop: true,
+                  width: 960,
+                  height: 540,
+                });
               }}
             >
               {Messages.viewStream()}


### PR DESCRIPTION
### Description

This PR updates the "View Stream" button handlers to open a new Electron BrowserWindow with the url instead. The idea here is that it's easier to keep track of windows rather than tabs, and by default the BrowserWindow has `alwaysOnTop: true`. I believe this feature should make watching currently ongoing tournaments much easier.