### PR TITLE
Remove redundant prop

### DIFF
--- a/src/renderer/pages/settings/appearance_settings/rank_display_toggle/rank_display_toggle.tsx
+++ b/src/renderer/pages/settings/appearance_settings/rank_display_toggle/rank_display_toggle.tsx
@@ -9,7 +9,7 @@ export const RankDisplayToggle = React.memo(() => {
   const [enableRankDisplay, setEnableRankDisplay] = useEnableRankDisplay();
 
   return (
-    <SettingItem name="">
+    <SettingItem>
       <Toggle
         value={enableRankDisplay}
         onChange={(checked) => setEnableRankDisplay(checked)}


### PR DESCRIPTION
As of https://github.com/project-slippi/slippi-launcher/commit/34b04f8e2bf8a24118325be956ed120c5068c3fe the empty name prop is no longer required. Apologies as this was added whilst my previous PR was up. I didn't see the new change but just spotted the commit making it optional.