### PR TITLE
i18n: use proper localization for region and city

### DIFF
--- a/locales/ja.po
+++ b/locales/ja.po
@@ -678,7 +678,7 @@ msgstr "パスワードをお忘れですか？"
 #. {1} city: string - The approximate city the user is in. e.g. Shimomeguro
 #. {2} greaterRegion: string - The greater region/state/prefecture the city is contained in. e.g. Tokyo
 msgid "Found {0, plural, one {# tournament} other {# tournaments}} near {1}, {2}."
-msgstr "{1}、{2}の近くで{0}件の大会が見つかりました。"
+msgstr "{2}の{1}の近くで{0}件の大会が見つかりました。"
 
 #: src/renderer/pages/settings/create.messages.ts:3:15
 msgid "Game"

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -699,7 +699,7 @@ msgstr "Забыли пароль?"
 msgid "Found {0, plural, one {# tournament} other {# tournaments}} near {1}, {2}."
 msgstr ""
 "{0, plural, one {Найден # турнир} few {Найдено # турнира} other {Найдено # турниров}} "
-"рядом с {1}, {2}."
+"рядом с {1} ({2})."
 
 #: src/renderer/pages/settings/create.messages.ts:3:15
 msgid "Game"

--- a/src/main/fetch_cross_origin/ip_api.ts
+++ b/src/main/fetch_cross_origin/ip_api.ts
@@ -35,19 +35,59 @@ type IpApiResponse = {
 
 export type UserLocationInfo = Pick<IpApiResponse, "lat" | "lon" | "country" | "countryCode" | "city" | "regionName">;
 
-export async function fetchCurrentLocation(): Promise<UserLocationInfo> {
-  const cachedResponse = cache.get(API);
+/**
+ * Fetches the user's current location based on their IP address.
+ * @param lang The language to use for the response, e.g. country, region, city names. Defaults to English if not provided.
+ * @returns The user's current location information.
+ */
+export async function fetchCurrentLocation(lang?: string): Promise<UserLocationInfo> {
+  const url = generateApiUrl(lang);
+  const cachedResponse = cache.get(url);
   if (cachedResponse) {
     return cachedResponse;
   }
 
   // Fetch the data
-  const res = await fetch(API);
+  const res = await fetch(url);
   const data = (await res.json()) as IpApiResponse;
   Preconditions.checkState(data.status === "success", `Failed to fetch current location: ${data.status}`);
 
   // Cache the data
-  cache.set(API, data);
+  cache.set(url, data);
 
   return data;
+}
+
+function generateApiUrl(lang?: string) {
+  const url = new URL(API);
+  if (lang) {
+    url.searchParams.set("lang", mapToSupportedLanguage(lang));
+  }
+  return url.toString();
+}
+
+/**
+ * Maps a language code to a supported language code for the IP API.
+ *
+ * The list of supported langauge values are:
+ * - de    Deutsch (German)
+ * - es    Español (Spanish)
+ * - pt-BR Português - Brasil (Portuguese)
+ * - fr    Français (French)
+ * - ja    日本語 (Japanese)
+ * - zh-CN 中国 (Chinese)
+ * - ru    Русский (Russian)
+ *
+ * The lang value must match one of these exactly or it will default back to English.
+ *
+ * @param lang The language code to map.
+ * @returns The mapped language code.
+ */
+function mapToSupportedLanguage(lang: string) {
+  switch (lang) {
+    case "pt":
+      return "pt-BR";
+    default:
+      return lang;
+  }
 }

--- a/src/renderer/components/location_guard/location_guard.tsx
+++ b/src/renderer/components/location_guard/location_guard.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { type UserLocationInfo } from "main/fetch_cross_origin/ip_api";
 import React from "react";
 
+import { useAppStore } from "@/lib/hooks/use_app_store";
 import { useEnableLocationAccess } from "@/lib/hooks/use_settings";
 
 import { LocationGuardMessages as Messages } from "./location_guard.messages";
@@ -45,9 +46,10 @@ export const LocationGuard = ({
 };
 
 const LocationGuardImpl = ({ render }: { render: (locationInfo: UserLocationInfo) => React.ReactNode }) => {
+  const currentLanguage = useAppStore((state) => state.currentLanguage);
   const { data, isLoading, error } = useQuery({
-    queryKey: ["geoLocationQuery"],
-    queryFn: async () => await window.electron.fetch.fetchCurrentLocation(),
+    queryKey: ["geoLocationQuery", currentLanguage],
+    queryFn: async () => await window.electron.fetch.fetchCurrentLocation(currentLanguage),
     staleTime: 5 * 60 * 1000,
   });
 

--- a/src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.tsx
+++ b/src/renderer/pages/home/upcoming_tournaments/tournaments_near_me/tournaments_near_me.tsx
@@ -120,8 +120,8 @@ export const TournamentsNearMe = ({ locationInfo }: { locationInfo: UserLocation
     return radius;
   }, [radius, units]);
 
-  const geoLocationQuery = useQuery({
-    queryKey: ["geoLocationQuery", radiusInKm],
+  const nearbyTournamentsQuery = useQuery({
+    queryKey: ["nearbyTournamentsQuery", radiusInKm],
     queryFn: async () => {
       if (!localStorage.getItem(STORAGE_KEY_UNITS)) {
         const defaultUnits: "km" | "mi" = ["US", "GB"].includes(locationInfo.countryCode) ? "mi" : "km";
@@ -167,10 +167,10 @@ export const TournamentsNearMe = ({ locationInfo }: { locationInfo: UserLocation
   };
 
   const sortedEvents = useMemo(() => {
-    if (!geoLocationQuery.data) {
+    if (!nearbyTournamentsQuery.data) {
       return [];
     }
-    const events = [...geoLocationQuery.data.events];
+    const events = [...nearbyTournamentsQuery.data.events];
     if (sortBy === "distance") {
       events.sort((a, b) => {
         const dist = a.distanceToVenueKm - b.distanceToVenueKm;
@@ -189,22 +189,22 @@ export const TournamentsNearMe = ({ locationInfo }: { locationInfo: UserLocation
     }
 
     return events;
-  }, [geoLocationQuery.data, sortBy]);
+  }, [nearbyTournamentsQuery.data, sortBy]);
 
   const content = () => {
-    if (geoLocationQuery.isLoading) {
+    if (nearbyTournamentsQuery.isLoading) {
       return <div className={styles.loading}>{Messages.loading()}</div>;
     }
 
-    if (geoLocationQuery.error instanceof Error) {
-      return <div className={styles.errorMessage}>{Messages.error(geoLocationQuery.error.message)}</div>;
+    if (nearbyTournamentsQuery.error instanceof Error) {
+      return <div className={styles.errorMessage}>{Messages.error(nearbyTournamentsQuery.error.message)}</div>;
     }
 
     return (
       <>
         <div className={styles.eventsCount}>
           {Messages.foundTournamentsNearby(
-            geoLocationQuery.data?.events.length ?? 0,
+            nearbyTournamentsQuery.data?.events.length ?? 0,
             locationInfo.city,
             locationInfo.regionName,
           )}


### PR DESCRIPTION
- **fix japanese location sentence**
- **use parenthesis in russian location**
- **add support for localized names from location data**
- **wire up language to location query**
- **dont use same query id**
