### PR TITLE
chore: Update Github Action workflows to Node 24 and update action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,7 @@ jobs:
       # Addresses the Electron binary installation issue
       # https://github.com/electron/electron/issues/51619#issuecomment-4521813516
       - name: Ensure Electron binary is installed
-        run: |
-          node node_modules/electron/install.js
-          npx electron --version
+        run: node node_modules/electron/install.js
       
       - name: Cache CodeSignTool
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,27 +23,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
         python: ["3.11"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - name: Use Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Node.js and npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -53,7 +53,7 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-
 
       - name: Cache npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/electron
@@ -77,7 +77,7 @@ jobs:
       
       - name: Cache CodeSignTool
         if: matrix.os == 'windows-latest'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ./CodeSignTool/
@@ -174,7 +174,7 @@ jobs:
           mkdir artifacts
           mv release/build/{*.exe*,*.deb,*.AppImage,*.dmg*,*.zip,*.yml} artifacts || true
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.os}}
           path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,13 @@ jobs:
       - name: Install dependencies
         run: |
           npm install
+
+      # Addresses the Electron binary installation issue
+      # https://github.com/electron/electron/issues/51619#issuecomment-4521813516
+      - name: Ensure Electron binary is installed
+        run: |
+          node node_modules/electron/install.js
+          npx electron --version
       
       - name: Cache CodeSignTool
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,9 @@ jobs:
             ~/.cache/electron
             ~/Library/Caches/electron
             ${{ runner.os == 'Windows' && '~/AppData/Local/electron/Cache' || '' }}
-          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json', 'release/app/package-lock.json') }}
+          key: ${{ runner.os }}-electron-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', 'release/app/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-electron-
+            ${{ runner.os }}-electron-${{ matrix.node-version }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: Wait for build job - ${{ matrix.os }}
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         with:
           ref: ${{ github.event.release.target_commitish }}
-          check-name: 'Test on node 20.x and ${{ matrix.os }}'
+          check-name: 'Test on node 24.x and ${{ matrix.os }}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
           allowed-conclusions: success
@@ -27,7 +27,7 @@ jobs:
     needs: wait-for-builds
     steps:
       - name: Download latest artifacts
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build.yml

--- a/.github/workflows/translation-progress.yml
+++ b/.github/workflows/translation-progress.yml
@@ -20,16 +20,16 @@ jobs:
       has_unstaged: ${{ steps.check-unstaged.outputs.has_unstaged }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: node_modules
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.OS }}-build-${{ secrets.CACHE_CONTROL }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Display updated translation percentage
         run: |
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore previous badge JSON
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: cache-restore
         with:
           path: previous-badge.json
@@ -136,7 +136,7 @@ jobs:
 
       - name: Save updated badge JSON to cache
         if: steps.cache-restore.outputs.cache-hit != 'true' || steps.badge-update.outputs.badge_updated == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: previous-badge.json
           key: translation-badge-json-${{ github.run_id }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9807,15 +9807,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
@@ -13997,15 +13988,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -27694,13 +27676,15 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.2.tgz",
+      "integrity": "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "browserslist": [
     "chrome 132"
   ],
+  "overrides": {
+    "yauzl": "^3.3.1"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged --quiet"


### PR DESCRIPTION
## Migrate CI from Node 20 to Node 24

GitHub Actions is deprecating Node 20 on runners (default switch to Node 24 on June 16, 2026). This PR migrates all workflows to Node 24 and updates actions to their latest major versions targeting the Node 24 runtime.

### Changes

**Node version bump**
- Matrix `node-version` updated from `20.x` to `24.x` across `build.yml` and `translation-progress.yml`
- Updated `check-name` in `release.yml` to match the new job name
**Electron binary cache fix**
- Added `matrix.node-version` to the Electron cache key so it's invalidated when the Node version changes, preventing stale Node 20 Electron binaries from being restored

**Electron install compatibility (Node 24.16+)**
- Added `"overrides": { "yauzl": "^3.3.1" }` to `package.json` — fixes a known regression where `extract-zip` (used by Electron's `install.js`) hangs on Node 24.16+ due to a bug in `yauzl@2` (see electron/electron#51619)
- Added explicit `node node_modules/electron/install.js` step in CI as a safety net (as suggested in https://github.com/electron/electron/issues/51619#issuecomment-4521813516)
