### PR TITLE
feat: Add dialog for installing Rosetta on MacOS

### DIFF
--- a/src/dolphin/api.ts
+++ b/src/dolphin/api.ts
@@ -8,6 +8,7 @@ import {
   ipc_downloadDolphin,
   ipc_fetchGeckoCodes,
   ipc_hardResetDolphin,
+  ipc_installRosetta,
   ipc_launchNetplayDolphin,
   ipc_openDolphinSettingsFolder,
   ipc_removePlayKeyFile,
@@ -26,6 +27,10 @@ import type {
 } from "./types";
 
 const dolphinApi: DolphinService = {
+  async installRosetta(): Promise<{ exitCode: number }> {
+    const { result } = await ipc_installRosetta.renderer!.trigger({});
+    return { exitCode: result.exitCode };
+  },
   async downloadDolphin(dolphinType: DolphinLaunchType) {
     await ipc_downloadDolphin.renderer!.trigger({ dolphinType });
   },

--- a/src/dolphin/instance.ts
+++ b/src/dolphin/instance.ts
@@ -20,7 +20,7 @@ const isMac = process.platform === "darwin";
 export class MacOsRosettaRequiredError extends Error {
   constructor() {
     super(
-      `Rosetta is required to run this executable. Open the Terminal app and run "softwareupdate --install-rosetta" to install Rosetta.`,
+      `Rosetta is required to run this executable. Open the Terminal app and run "softwareupdate --install-rosetta".`,
     );
   }
 }

--- a/src/dolphin/ipc.ts
+++ b/src/dolphin/ipc.ts
@@ -66,6 +66,8 @@ export const ipc_saveGeckoCodes = makeEndpoint.main(
   <SuccessPayload>_,
 );
 
+export const ipc_installRosetta = makeEndpoint.main("installRosetta", <EmptyPayload>_, <{ exitCode: number }>_);
+
 // Events
 
 export const ipc_dolphinEvent = makeEndpoint.renderer("dolphin_dolphinEvent", <DolphinEvent>_);

--- a/src/dolphin/manager.ts
+++ b/src/dolphin/manager.ts
@@ -12,9 +12,9 @@ import { fileExists } from "utils/file_exists";
 import { type DolphinVersionResponse, fetchLatestVersion } from "./install/fetch_latest_version";
 import { IshiirukaDolphinInstallation } from "./install/ishiiruka_installation";
 import { MainlineDolphinInstallation } from "./install/mainline_installation";
-import { DolphinInstance, PlaybackDolphinInstance } from "./instance";
+import { DolphinInstance, MacOsRosettaRequiredError, PlaybackDolphinInstance } from "./instance";
 import type { DolphinEvent, DolphinInstallation, ReplayCommunication } from "./types";
-import { DolphinEventType, DolphinLaunchType } from "./types";
+import { DolphinErrorType, DolphinEventType, DolphinLaunchType } from "./types";
 
 const log = electronLog.scope("dolphin/manager");
 
@@ -116,7 +116,18 @@ export class DolphinManager {
       this.playbackDolphinInstances.set(id, playbackInstance);
     }
 
-    await playbackInstance.play(replayComm);
+    try {
+      await playbackInstance.play(replayComm);
+    } catch (err) {
+      if (err instanceof MacOsRosettaRequiredError) {
+        this.eventSubject.next({
+          type: DolphinEventType.ERROR,
+          errorType: DolphinErrorType.ROSETTA_REQUIRED,
+          dolphinType: DolphinLaunchType.PLAYBACK,
+        });
+      }
+      throw err;
+    }
   }
 
   async launchNetplayDolphin() {
@@ -153,7 +164,18 @@ export class DolphinManager {
       throw err;
     });
 
-    await dolphinInstance.start();
+    try {
+      await dolphinInstance.start();
+    } catch (err) {
+      if (err instanceof MacOsRosettaRequiredError) {
+        this.eventSubject.next({
+          type: DolphinEventType.ERROR,
+          errorType: DolphinErrorType.ROSETTA_REQUIRED,
+          dolphinType: DolphinLaunchType.NETPLAY,
+        });
+      }
+      throw err;
+    }
     this.netplayDolphinInstance = dolphinInstance;
   }
 
@@ -340,7 +362,8 @@ export class DolphinManager {
 
   private _onOffline(dolphinType: DolphinLaunchType) {
     this.eventSubject.next({
-      type: DolphinEventType.NETWORK_ERROR,
+      type: DolphinEventType.ERROR,
+      errorType: DolphinErrorType.NETWORK_ERROR,
       dolphinType,
     });
   }

--- a/src/dolphin/rosetta/install_rosetta.ts
+++ b/src/dolphin/rosetta/install_rosetta.ts
@@ -1,6 +1,11 @@
 import { execFile } from "node:child_process";
 
 export async function installRosettaElevated() {
+  // This only makes sense on macOS
+  if (process.platform !== "darwin") {
+    return;
+  }
+
   return new Promise<number>((resolve) => {
     const script = `
       do shell script "/usr/sbin/softwareupdate --install-rosetta --agree-to-license" with administrator privileges

--- a/src/dolphin/rosetta/install_rosetta.ts
+++ b/src/dolphin/rosetta/install_rosetta.ts
@@ -1,0 +1,18 @@
+import { execFile } from "node:child_process";
+
+export async function installRosettaWithPrompt() {
+  return new Promise<number>((resolve) => {
+    const script = `
+      do shell script "/usr/sbin/softwareupdate --install-rosetta --agree-to-license" with administrator privileges
+    `;
+
+    execFile("/usr/bin/osascript", ["-e", script], (err) => {
+      if (err) {
+        const code = typeof err.code === "number" ? err.code : 1;
+        resolve(code);
+        return;
+      }
+      resolve(0);
+    });
+  });
+}

--- a/src/dolphin/rosetta/install_rosetta.ts
+++ b/src/dolphin/rosetta/install_rosetta.ts
@@ -1,9 +1,9 @@
 import { execFile } from "node:child_process";
 
-export async function installRosettaElevated() {
+export async function installRosettaElevated(): Promise<number> {
   // This only makes sense on macOS
   if (process.platform !== "darwin") {
-    return;
+    return 0;
   }
 
   return new Promise<number>((resolve) => {

--- a/src/dolphin/rosetta/install_rosetta.ts
+++ b/src/dolphin/rosetta/install_rosetta.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 
-export async function installRosettaWithPrompt() {
+export async function installRosettaElevated() {
   return new Promise<number>((resolve) => {
     const script = `
       do shell script "/usr/sbin/softwareupdate --install-rosetta --agree-to-license" with administrator privileges

--- a/src/dolphin/rosetta/install_rosetta.ts
+++ b/src/dolphin/rosetta/install_rosetta.ts
@@ -1,5 +1,9 @@
 import { execFile } from "node:child_process";
 
+const INSTALL_ROSETTA_SCRIPT = `
+  do shell script "/usr/sbin/softwareupdate --install-rosetta --agree-to-license" with administrator privileges
+`;
+
 export async function installRosettaElevated(): Promise<number> {
   // This only makes sense on macOS
   if (process.platform !== "darwin") {
@@ -7,11 +11,7 @@ export async function installRosettaElevated(): Promise<number> {
   }
 
   return new Promise<number>((resolve) => {
-    const script = `
-      do shell script "/usr/sbin/softwareupdate --install-rosetta --agree-to-license" with administrator privileges
-    `;
-
-    execFile("/usr/bin/osascript", ["-e", script], (err) => {
+    execFile("/usr/bin/osascript", ["-e", INSTALL_ROSETTA_SCRIPT], (err) => {
       if (err) {
         const code = typeof err.code === "number" ? err.code : 1;
         resolve(code);

--- a/src/dolphin/setup.ts
+++ b/src/dolphin/setup.ts
@@ -22,7 +22,7 @@ import {
 } from "./ipc";
 import type { DolphinManager } from "./manager";
 import { deletePlayKeyFile, writePlayKeyFile } from "./playkey";
-import { installRosettaWithPrompt } from "./rosetta/install_rosetta";
+import { installRosettaElevated } from "./rosetta/install_rosetta";
 import { DolphinLaunchType } from "./types";
 import { fetchGeckoCodes, saveGeckoCodes, updateBootToCssCode } from "./util";
 
@@ -128,7 +128,7 @@ export default function setupDolphinIpc({ dolphinManager }: { dolphinManager: Do
   });
 
   ipc_installRosetta.main!.handle(async () => {
-    const exitCode = await installRosettaWithPrompt();
+    const exitCode = await installRosettaElevated();
     return { exitCode };
   });
 

--- a/src/dolphin/setup.ts
+++ b/src/dolphin/setup.ts
@@ -11,6 +11,7 @@ import {
   ipc_downloadDolphin,
   ipc_fetchGeckoCodes,
   ipc_hardResetDolphin,
+  ipc_installRosetta,
   ipc_launchNetplayDolphin,
   ipc_openDolphinSettingsFolder,
   ipc_removePlayKeyFile,
@@ -21,6 +22,7 @@ import {
 } from "./ipc";
 import type { DolphinManager } from "./manager";
 import { deletePlayKeyFile, writePlayKeyFile } from "./playkey";
+import { installRosettaWithPrompt } from "./rosetta/install_rosetta";
 import { DolphinLaunchType } from "./types";
 import { fetchGeckoCodes, saveGeckoCodes, updateBootToCssCode } from "./util";
 
@@ -123,6 +125,11 @@ export default function setupDolphinIpc({ dolphinManager }: { dolphinManager: Do
     const installation = dolphinManager.getInstallation(dolphinType);
     await saveGeckoCodes(installation, geckoCodes);
     return { success: true };
+  });
+
+  ipc_installRosetta.main!.handle(async () => {
+    const exitCode = await installRosettaWithPrompt();
+    return { exitCode };
   });
 
   return { dolphinManager };

--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -49,7 +49,12 @@ export const enum DolphinEventType {
   DOWNLOAD_START = "DOWNLOAD_START",
   DOWNLOAD_PROGRESS = "DOWNLOAD_PROGRESS",
   DOWNLOAD_COMPLETE = "DOWNLOAD_COMPLETE",
+  ERROR = "ERROR",
+}
+
+export enum DolphinErrorType {
   NETWORK_ERROR = "NETWORK_ERROR",
+  ROSETTA_REQUIRED = "ROSETTA_REQUIRED",
 }
 
 export type DolphinNetplayClosedEvent = {
@@ -86,8 +91,15 @@ export type DolphinDownloadCompleteEvent = {
 };
 
 export type DolphinNetworkErrorEvent = {
-  type: DolphinEventType.NETWORK_ERROR;
+  type: DolphinEventType.ERROR;
+  errorType: DolphinErrorType.NETWORK_ERROR;
   dolphinType: DolphinLaunchType;
+};
+
+export type DolphinRosettaRequiredEvent = {
+  type: DolphinEventType.ERROR;
+  errorType: DolphinErrorType.ROSETTA_REQUIRED;
+  dolphinType?: DolphinLaunchType;
 };
 
 export type DolphinEventMap = {
@@ -95,12 +107,13 @@ export type DolphinEventMap = {
   [DolphinEventType.DOWNLOAD_START]: DolphinDownloadStartEvent;
   [DolphinEventType.DOWNLOAD_PROGRESS]: DolphinDownloadProgressEvent;
   [DolphinEventType.DOWNLOAD_COMPLETE]: DolphinDownloadCompleteEvent;
-  [DolphinEventType.NETWORK_ERROR]: DolphinNetworkErrorEvent;
+  [DolphinEventType.ERROR]: DolphinNetworkErrorEvent | DolphinRosettaRequiredEvent;
 };
 
 export type DolphinEvent = DolphinEventMap[DolphinEventType];
 
 export interface DolphinService {
+  installRosetta(): Promise<{ exitCode: number }>;
   downloadDolphin(dolphinType: DolphinLaunchType): Promise<void>;
   configureDolphin(dolphinType: DolphinLaunchType): Promise<void>;
   softResetDolphin(dolphinType: DolphinLaunchType): Promise<void>;

--- a/src/dolphin/types.ts
+++ b/src/dolphin/types.ts
@@ -52,7 +52,7 @@ export const enum DolphinEventType {
   ERROR = "ERROR",
 }
 
-export enum DolphinErrorType {
+export const enum DolphinErrorType {
   NETWORK_ERROR = "NETWORK_ERROR",
   ROSETTA_REQUIRED = "ROSETTA_REQUIRED",
 }

--- a/src/renderer/app/app.tsx
+++ b/src/renderer/app/app.tsx
@@ -8,6 +8,7 @@ import { AdDialog } from "@/components/ad_dialog";
 import { AuthGuard } from "@/components/auth_guard";
 import { LoginNotice } from "@/components/login_notice/login_notice";
 import { PersistentNotification } from "@/components/persistent_notification/persistent_notification";
+import { RosettaInstallDialog } from "@/components/rosetta_install_dialog/rosetta_install_dialog";
 import type { AuthUser } from "@/services/auth/types";
 
 type PrivateMenuItem = MenuItem & {
@@ -54,6 +55,7 @@ export const App = React.memo(({ menuItems }: { menuItems: readonly MainMenuItem
       <LoginDialog />
       <PersistentNotification />
       <AdDialog />
+      <RosettaInstallDialog />
     </div>
   );
 });

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
@@ -4,7 +4,7 @@ export const RosettaInstallDialogMessages = {
   installing: () => "Installing... This may take a few minutes.",
   installFailed: (errorCode: string) =>
     `Rosetta installation failed (error code {0}). You may need to install it manually.`,
-  installSuccess: () => "Rosetta installation completed successfully.",
+  installSuccess: () => "Installation completed successfully. You can now relaunch Slippi Dolphin.",
   cancel: () => "Cancel",
   appleLicenseDescription: () =>
     "Use of Rosetta is subject to Apple's software license agreement. A list of Apple SLAs may be found here:",

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
@@ -2,6 +2,7 @@ export const RosettaInstallDialogMessages = {
   dialogTitle: () => "Rosetta Required",
   description: () => "Slippi Dolphin requires Rosetta on Apple Silicon Macs. Would you like to install it now?",
   installing: () => "Installing... This may take a few minutes.",
+  /** @noTranslate */
   installFailed: () =>
     `Rosetta installation failed. To manually install, open the Terminal app and run "softwareupdate --install-rosetta".`,
   installSuccess: () => "Installation completed successfully. You can now relaunch Slippi Dolphin.",

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
@@ -1,0 +1,11 @@
+export const RosettaInstallDialogMessages = {
+  dialogTitle: () => "Rosetta Required",
+  description: () => "Slippi Dolphin requires Rosetta 2 on Apple Silicon Macs. Would you like to install it now?",
+  installing: () => "Installing... This may take a few minutes.",
+  installFailed: (errorCode: string) =>
+    `Rosetta installation failed (error code {0}). You may need to install it manually.`,
+  installSuccess: () => "Rosetta installation completed successfully.",
+  cancel: () => "Cancel",
+  install: () => "Install",
+  done: () => "Done",
+};

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
@@ -1,11 +1,13 @@
 export const RosettaInstallDialogMessages = {
   dialogTitle: () => "Rosetta Required",
-  description: () => "Slippi Dolphin requires Rosetta 2 on Apple Silicon Macs. Would you like to install it now?",
+  description: () => "Slippi Dolphin requires Rosetta on Apple Silicon Macs. Would you like to install it now?",
   installing: () => "Installing... This may take a few minutes.",
   installFailed: (errorCode: string) =>
     `Rosetta installation failed (error code {0}). You may need to install it manually.`,
   installSuccess: () => "Rosetta installation completed successfully.",
   cancel: () => "Cancel",
-  install: () => "Install",
+  appleLicenseDescription: () =>
+    "Use of Rosetta is subject to Apple's software license agreement. A list of Apple SLAs may be found here:",
+  agreeAndInstall: () => "Agree and Install",
   done: () => "Done",
 };

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.messages.ts
@@ -2,8 +2,8 @@ export const RosettaInstallDialogMessages = {
   dialogTitle: () => "Rosetta Required",
   description: () => "Slippi Dolphin requires Rosetta on Apple Silicon Macs. Would you like to install it now?",
   installing: () => "Installing... This may take a few minutes.",
-  installFailed: (errorCode: string) =>
-    `Rosetta installation failed (error code {0}). You may need to install it manually.`,
+  installFailed: () =>
+    `Rosetta installation failed. To manually install, open the Terminal app and run "softwareupdate --install-rosetta".`,
   installSuccess: () => "Installation completed successfully. You can now relaunch Slippi Dolphin.",
   cancel: () => "Cancel",
   appleLicenseDescription: () =>

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.module.css
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.module.css
@@ -1,0 +1,12 @@
+.appleSlaDescription {
+  font-size: 14px;
+}
+
+.appleSlaLink {
+  margin-left: 4px;
+  color: var(--purple-lighter);
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.tsx
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.tsx
@@ -1,0 +1,79 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import React from "react";
+
+import { useServices } from "@/services";
+
+import { RosettaInstallDialogMessages as Messages } from "./rosetta_install_dialog.messages";
+import { useRosettaDialog } from "./use_rosetta_dialog";
+
+export const RosettaInstallDialog = () => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const open = useRosettaDialog((state) => state.open);
+  const { dolphinService } = useServices();
+
+  const [installing, setInstalling] = React.useState(false);
+  const [result, setResult] = React.useState<{ success: boolean; exitCode?: number } | null>(null);
+
+  const handleClose = () => {
+    if (installing) {
+      return;
+    }
+    setResult(null);
+    useRosettaDialog.getState().closeDialog();
+  };
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    setResult(null);
+    try {
+      const { exitCode } = await dolphinService.installRosetta();
+      setResult({ success: exitCode === 0, exitCode });
+    } catch {
+      setResult({ success: false });
+    }
+    setInstalling(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={(_, reason) => {
+        if (reason !== "backdropClick") {
+          handleClose();
+        }
+      }}
+      fullWidth={true}
+      fullScreen={fullScreen}
+    >
+      <DialogTitle>{Messages.dialogTitle()}</DialogTitle>
+      <DialogContent>
+        <p>{Messages.description()}</p>
+        {installing && <p>{Messages.installing()}</p>}
+        {result && !result.success && <p>{Messages.installFailed(`${result.exitCode ?? "unknown"}`)}</p>}
+        {result && result.success && <p>{Messages.installSuccess()}</p>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="secondary" disabled={installing}>
+          {Messages.cancel()}
+        </Button>
+        {!result?.success && (
+          <Button onClick={handleInstall} color="primary" disabled={installing}>
+            {Messages.install()}
+          </Button>
+        )}
+        {result?.success && (
+          <Button onClick={handleClose} color="primary">
+            {Messages.done()}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.tsx
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.tsx
@@ -7,6 +7,12 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import React from "react";
 
+import { ExternalLink as A } from "@/components/external_link";
+
+import styles from "./rosetta_install_dialog.module.css";
+
+const APPLE_SLA_URL = "https://www.apple.com/legal/sla/";
+
 import { useServices } from "@/services";
 
 import { RosettaInstallDialogMessages as Messages } from "./rosetta_install_dialog.messages";
@@ -55,6 +61,12 @@ export const RosettaInstallDialog = () => {
       <DialogTitle>{Messages.dialogTitle()}</DialogTitle>
       <DialogContent>
         <p>{Messages.description()}</p>
+        <p className={styles.appleSlaDescription}>
+          <span>{Messages.appleLicenseDescription()}</span>
+          <A className={styles.appleSlaLink} href={APPLE_SLA_URL}>
+            {APPLE_SLA_URL}
+          </A>
+        </p>
         {installing && <p>{Messages.installing()}</p>}
         {result && !result.success && <p>{Messages.installFailed(`${result.exitCode ?? "unknown"}`)}</p>}
         {result && result.success && <p>{Messages.installSuccess()}</p>}
@@ -65,7 +77,7 @@ export const RosettaInstallDialog = () => {
         </Button>
         {!result?.success && (
           <Button onClick={handleInstall} color="primary" disabled={installing}>
-            {Messages.install()}
+            {Messages.agreeAndInstall()}
           </Button>
         )}
         {result?.success && (

--- a/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.tsx
+++ b/src/renderer/components/rosetta_install_dialog/rosetta_install_dialog.tsx
@@ -25,7 +25,7 @@ export const RosettaInstallDialog = () => {
   const { dolphinService } = useServices();
 
   const [installing, setInstalling] = React.useState(false);
-  const [result, setResult] = React.useState<{ success: boolean; exitCode?: number } | null>(null);
+  const [result, setResult] = React.useState<{ success: boolean } | null>(null);
 
   const handleClose = () => {
     if (installing) {
@@ -40,7 +40,7 @@ export const RosettaInstallDialog = () => {
     setResult(null);
     try {
       const { exitCode } = await dolphinService.installRosetta();
-      setResult({ success: exitCode === 0, exitCode });
+      setResult({ success: exitCode === 0 });
     } catch {
       setResult({ success: false });
     }
@@ -68,7 +68,7 @@ export const RosettaInstallDialog = () => {
           </A>
         </p>
         {installing && <p>{Messages.installing()}</p>}
-        {result && !result.success && <p>{Messages.installFailed(`${result.exitCode ?? "unknown"}`)}</p>}
+        {result && !result.success && <p>{Messages.installFailed()}</p>}
         {result && result.success && <p>{Messages.installSuccess()}</p>}
       </DialogContent>
       <DialogActions>

--- a/src/renderer/components/rosetta_install_dialog/use_rosetta_dialog.ts
+++ b/src/renderer/components/rosetta_install_dialog/use_rosetta_dialog.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+export const useRosettaDialog = create(
+  combine(
+    {
+      open: false,
+    },
+    (set) => ({
+      openDialog: () => set({ open: true }),
+      closeDialog: () => set({ open: false }),
+    }),
+  ),
+);

--- a/src/renderer/listeners/install_dolphin_listeners.ts
+++ b/src/renderer/listeners/install_dolphin_listeners.ts
@@ -1,5 +1,6 @@
-import { type DolphinService, DolphinEventType, DolphinLaunchType } from "@dolphin/types";
+import { type DolphinService, DolphinErrorType, DolphinEventType, DolphinLaunchType } from "@dolphin/types";
 
+import { useRosettaDialog } from "@/components/rosetta_install_dialog/use_rosetta_dialog";
 import { handleDolphinExitCode } from "@/lib/dolphin/handle_dolphin_exit_code";
 import {
   DolphinStatus,
@@ -30,6 +31,7 @@ export function installDolphinListeners({
       showError(errMsg);
     }
   });
+
   dolphinService.onEvent(DolphinEventType.DOWNLOAD_START, (event) => {
     setDolphinStatus(event.dolphinType, DolphinStatus.DOWNLOADING);
   });
@@ -45,9 +47,18 @@ export function installDolphinListeners({
     setDolphinVersion(event.dolphinVersion, event.dolphinType);
   });
 
-  dolphinService.onEvent(DolphinEventType.NETWORK_ERROR, (event) => {
-    const preludeMessage = !navigator.onLine ? Messages.youAreOffline() : Messages.networkError();
-    showWarning(`${preludeMessage} ${Messages.someFunctionalityUnavailable()}`);
-    setDolphinStatus(event.dolphinType, DolphinStatus.READY);
+  dolphinService.onEvent(DolphinEventType.ERROR, (event) => {
+    switch (event.errorType) {
+      case DolphinErrorType.NETWORK_ERROR: {
+        const preludeMessage = !navigator.onLine ? Messages.youAreOffline() : Messages.networkError();
+        showWarning(`${preludeMessage} ${Messages.someFunctionalityUnavailable()}`);
+        setDolphinStatus(event.dolphinType, DolphinStatus.READY);
+        break;
+      }
+      case DolphinErrorType.ROSETTA_REQUIRED: {
+        useRosettaDialog.getState().openDialog();
+        break;
+      }
+    }
   });
 }

--- a/src/renderer/services/dolphin/dolphin.service.mock.ts
+++ b/src/renderer/services/dolphin/dolphin.service.mock.ts
@@ -99,6 +99,11 @@ class MockDolphinClient implements DolphinService {
     throw new Error("Method not implemented.");
   }
 
+  @delayAndMaybeError(SHOULD_ERROR)
+  async installRosetta(): Promise<{ exitCode: number }> {
+    return { exitCode: 0 };
+  }
+
   onEvent<T extends DolphinEventType>(eventType: T, handle: (event: DolphinEventMap[T]) => void): () => void {
     const subscription = this.events.filter<DolphinEventMap[T]>((event) => event.type === eventType).subscribe(handle);
     return () => subscription.unsubscribe();


### PR DESCRIPTION
## Description

This PR adds Rosetta 2 installation support for Apple Silicon Macs and refactors the Dolphin event system to use a unified `ERROR` event with a discriminator.

## Changes

### Rosetta 2 installation
- **`src/dolphin/rosetta/install_rosetta.ts`** — new AppleScript utility that runs `softwareupdate --install-rosetta --agree-to-license` with elevated privileges via an admin password prompt
- **IPC plumbing** (`ipc.ts`, `api.ts`, `setup.ts`) — wires `installRosetta` endpoint through the main process
- **`RosettaInstallDialog`** — new MUI dialog that prompts the user to install Rosetta 2 when Dolphin fails to launch on Apple Silicon, calls the service on confirm, and reports success/failure
- **`src/renderer/app/app.tsx`** — mounts the dialog

### Event system refactor
- Replaced separate `NETWORK_ERROR` and `ROSETTA_REQUIRED` event types with a single `DolphinEventType.ERROR` discriminated by a new `DolphinErrorType` enum
- Merged the two renderer-side handlers into one `ERROR` handler that switches on `errorType`
- Both error subtypes carry `dolphinType` for consistency — `DolphinRosettaRequiredEvent` gained the field (optional)


### Screenshots
<img width="1100" height="750" alt="Screenshot 2026-06-08 at 4 21 42 pm" src="https://github.com/user-attachments/assets/dfbe2bd3-1468-4905-8496-4afef4a7b251" />

