### PR TITLE
chore: Pin Windows runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [24.x]
         python: ["3.11"]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-2022, macOS-latest]
 
     steps:
       - name: Use Python ${{ matrix.python }}
@@ -81,7 +81,7 @@ jobs:
         run: node node_modules/electron/install.js
       
       - name: Cache CodeSignTool
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: actions/cache@v5
         with:
           path: |
@@ -90,7 +90,7 @@ jobs:
       - name: Download CodeSignTool
         env:
           ES_USERNAME: ${{ secrets.ES_USERNAME }}
-        if: matrix.os == 'windows-latest' && env.ES_USERNAME != null
+        if: matrix.os == 'windows-2022' && env.ES_USERNAME != null
         working-directory: ${{ github.workspace }}
         shell: powershell
         run: |
@@ -104,7 +104,7 @@ jobs:
       - name: Load Windows signing secrets
         env:
           ES_USERNAME: ${{ secrets.ES_USERNAME }}
-        if: matrix.os == 'windows-latest' && (env.ES_USERNAME != null || env.IS_PR == 'true')
+        if: matrix.os == 'windows-2022' && (env.ES_USERNAME != null || env.IS_PR == 'true')
         shell: bash
         run: |
           # Enable signing if: (1) PR with enable-codesigning label, OR (2) not a PR and release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-2022, macOS-latest]
     steps:
       - name: Wait for build job - ${{ matrix.os }}
         uses: lewagon/wait-on-check-action@v1.7.0


### PR DESCRIPTION
## Summary

Fix Windows CI broken by the VS 2026 migration on GitHub's `windows-latest` runner image.

## Problem

Since June 8, 2026, GitHub's `windows-latest` runner image includes **Visual Studio 2026** (version 18). The `@electron/node-gyp` fork used by `@electron/rebuild` v3.7.x only has detection support for VS 2019 and VS 2022. When node-gyp encounters VS 2026, it reports:

```
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find any Visual Studio installation to use
```

This causes native module rebuilding (`bufferutil`, `better-sqlite3`, etc.) to fail during `electron-builder install-app-deps`, breaking the entire Windows CI build.

## Root Cause

The dependency chain is:

```
@electron/rebuild v3.7.2
  └── @electron/node-gyp (pinned to GitHub commit `06b29aa`, v10.2.0-electron.1)
        └── find-visualstudio.js → only searches for VS versions [2019, 2022]
```

The regular `node-gyp` v12.x gained VS 2026 support last November, but `@electron/rebuild` uses an Electron-specific fork (`@electron/node-gyp`) that hasn't rebased onto that change. No published version of `@electron/node-gyp` supports VS 2026, and `@electron/rebuild` pins to a specific commit hash (not an npm semver range), making overrides impractical.

## Fix

Pin the Windows CI runner from `windows-latest` to `windows-2022`, which has VS 2022 — fully supported by `@electron/node-gyp`.

## Reverting

This pin can be reverted once `@electron/node-gyp` (or `@electron/rebuild`'s dependency chain) adds VS 2026 support.
