### PR TITLE
feat: Add Auto-refresh toggle to spectate page

### DIFF
--- a/src/broadcast/setup.ts
+++ b/src/broadcast/setup.ts
@@ -140,9 +140,6 @@ export default function setupBroadcastIpc({
 
     await spectateWorker.refreshBroadcastList();
 
-    // Reset idle timeout on refresh
-    await resetSpectateIdleTimeout();
-
     return { success: true };
   });
 

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_countdown.tsx
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_countdown.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+type AutoRefreshCountdownProps = {
+  expiresAt: number | null; // Unix epoch timestamp in milliseconds
+};
+
+export const AutoRefreshCountdown = React.memo(({ expiresAt }: AutoRefreshCountdownProps) => {
+  const [formatted, setFormatted] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (expiresAt === null) {
+      setFormatted(null);
+      return;
+    }
+
+    const compute = () => {
+      const remaining = expiresAt - Date.now();
+      if (remaining <= 0) {
+        setFormatted(null);
+      } else {
+        const totalSeconds = Math.floor(remaining / 1_000);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+        setFormatted(`${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`);
+      }
+    };
+
+    // Run immediately on mount/change to avoid a 1-second blank flash
+    compute();
+
+    const id = setInterval(compute, 1_000);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [expiresAt]); // Safely tracks the primitive number
+
+  if (formatted === null) {
+    return null;
+  }
+
+  return <>{formatted}</>;
+});

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_countdown.tsx
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_countdown.tsx
@@ -18,23 +18,17 @@ export const AutoRefreshCountdown = React.memo(({ expiresAt }: AutoRefreshCountd
       if (remaining <= 0) {
         setFormatted(null);
       } else {
-        const totalSeconds = Math.floor(remaining / 1_000);
-        const hours = Math.floor(totalSeconds / 3600);
-        const minutes = Math.floor((totalSeconds % 3600) / 60);
-        const seconds = totalSeconds % 60;
-        setFormatted(`${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`);
+        setFormatted(formatTimeRemaining(remaining));
       }
     };
 
-    // Run immediately on mount/change to avoid a 1-second blank flash
     compute();
 
     const id = setInterval(compute, 1_000);
-
     return () => {
       clearInterval(id);
     };
-  }, [expiresAt]); // Safely tracks the primitive number
+  }, [expiresAt]);
 
   if (formatted === null) {
     return null;
@@ -42,3 +36,11 @@ export const AutoRefreshCountdown = React.memo(({ expiresAt }: AutoRefreshCountd
 
   return <>{formatted}</>;
 });
+
+function formatTimeRemaining(remainingMs: number): string {
+  const totalSeconds = Math.floor(remainingMs / 1_000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.messages.ts
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.messages.ts
@@ -1,0 +1,4 @@
+export const AutoRefreshMessages = {
+  clickToExtend: () => "Time before auto-refresh turns off again. Click to extend by an hour.",
+  autoRefresh: () => "Auto-refresh",
+};

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.module.css
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.module.css
@@ -1,7 +1,6 @@
 .autoRefreshControl {
   display: flex;
   align-items: center;
-  gap: 8px;
 }
 
 .timer {

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.module.css
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.module.css
@@ -1,0 +1,20 @@
+.autoRefreshControl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.timer {
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: #bbb;
+  padding: 4px 8px;
+  border-radius: 4px;
+  user-select: none;
+  text-transform: lowercase;
+}
+
+.timer:hover {
+  text-decoration: underline;
+}

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.tsx
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.tsx
@@ -1,0 +1,34 @@
+import { css } from "@emotion/react";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
+import Tooltip from "@mui/material/Tooltip";
+
+import { AutoRefreshCountdown } from "./auto_refresh_countdown";
+import { AutoRefreshMessages as Messages } from "./auto_refresh_toggle.messages";
+import styles from "./auto_refresh_toggle.module.css";
+import { useAutoRefresh } from "./use_auto_refresh";
+
+export function AutoRefreshToggle({ onRefreshBroadcasts }: { onRefreshBroadcasts: () => void }) {
+  const { enabled, expiresAt, toggle, extend } = useAutoRefresh(onRefreshBroadcasts);
+  return (
+    <div className={styles.autoRefreshControl}>
+      <FormControlLabel
+        labelPlacement="start"
+        control={<Switch checked={enabled} onChange={toggle} color="primary" size="small" />}
+        label={Messages.autoRefresh()}
+        css={css`
+          .MuiFormControlLabel-label {
+            font-size: 12px;
+          }
+        `}
+      />
+      {enabled && (
+        <Tooltip title={Messages.clickToExtend()}>
+          <span className={styles.timer} onClick={extend}>
+            <AutoRefreshCountdown expiresAt={expiresAt} />
+          </span>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.tsx
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/auto_refresh_toggle.tsx
@@ -16,9 +16,11 @@ export function AutoRefreshToggle({ onRefreshBroadcasts }: { onRefreshBroadcasts
         labelPlacement="start"
         control={<Switch checked={enabled} onChange={toggle} color="primary" size="small" />}
         label={Messages.autoRefresh()}
+        sx={{ margin: 0 }}
         css={css`
           .MuiFormControlLabel-label {
             font-size: 12px;
+            margin-right: 8px;
           }
         `}
       />

--- a/src/renderer/pages/spectate/auto_refresh_toggle/use_auto_refresh.ts
+++ b/src/renderer/pages/spectate/auto_refresh_toggle/use_auto_refresh.ts
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useRef } from "react";
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+const AUTO_REFRESH_INTERVAL_MS = 30_000;
+const AUTO_DISABLE_MAX_DURATION_MS = 24 * 60 * 60 * 1_000; // Do we really need to extend more than 24 hours?
+const AUTO_DISABLE_DURATION_MS = 3 * 60 * 60 * 1_000;
+const EXTEND_DURATION_MS = 60 * 60 * 1_000;
+
+let turnOffTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleTurnOff(expiresAt: number | null) {
+  if (turnOffTimeout !== null) {
+    clearTimeout(turnOffTimeout);
+    turnOffTimeout = null;
+  }
+  if (expiresAt === null) {
+    return;
+  }
+
+  const remaining = expiresAt - Date.now();
+  if (remaining <= 0) {
+    autoRefreshStore.getState().setDisabled();
+    return;
+  }
+
+  turnOffTimeout = setTimeout(() => {
+    autoRefreshStore.getState().setDisabled();
+    turnOffTimeout = null;
+  }, remaining);
+}
+
+const autoRefreshStore = create(
+  combine({ expiresAt: null as number | null }, (set) => ({
+    setDisabled: () => set({ expiresAt: null }),
+    toggle: () =>
+      set((state) => {
+        if (state.expiresAt !== null) {
+          scheduleTurnOff(null);
+          return { expiresAt: null };
+        }
+        const ts = Date.now() + AUTO_DISABLE_DURATION_MS;
+        scheduleTurnOff(ts);
+        return { enabled: true, expiresAt: ts };
+      }),
+    extend: () =>
+      set((state) => {
+        if (state.expiresAt === null) {
+          return {};
+        }
+        const newTs = Math.min(state.expiresAt + EXTEND_DURATION_MS, Date.now() + AUTO_DISABLE_MAX_DURATION_MS);
+        scheduleTurnOff(newTs);
+        return { expiresAt: newTs };
+      }),
+  })),
+);
+
+export function useAutoRefresh(onRefresh: () => void) {
+  const expiresAt = autoRefreshStore((s) => s.expiresAt);
+  const toggle = autoRefreshStore((s) => s.toggle);
+  const extend = autoRefreshStore((s) => s.extend);
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+  const enabled = expiresAt !== null;
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const id = setInterval(() => {
+      onRefreshRef.current();
+    }, AUTO_REFRESH_INTERVAL_MS);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [enabled]);
+
+  const prevEnabled = useRef(false);
+  useEffect(() => {
+    if (enabled && !prevEnabled.current) {
+      onRefreshRef.current();
+    }
+    prevEnabled.current = enabled;
+  }, [enabled]);
+
+  return useMemo(() => ({ enabled, expiresAt, toggle, extend }), [enabled, expiresAt, toggle, extend]);
+}

--- a/src/renderer/pages/spectate/create.tsx
+++ b/src/renderer/pages/spectate/create.tsx
@@ -25,10 +25,7 @@ export function createSpectatePage({ broadcastService }: CreateSpectatePageArgs)
         userId={user.uid}
         watchBroadcast={watchBroadcast}
         broadcasts={currentBroadcasts}
-        onRefreshBroadcasts={() => {
-          console.log("calling refresh broadcasts");
-          refreshBroadcasts();
-        }}
+        onRefreshBroadcasts={refreshBroadcasts}
       />
     );
   });

--- a/src/renderer/pages/spectate/create.tsx
+++ b/src/renderer/pages/spectate/create.tsx
@@ -25,7 +25,10 @@ export function createSpectatePage({ broadcastService }: CreateSpectatePageArgs)
         userId={user.uid}
         watchBroadcast={watchBroadcast}
         broadcasts={currentBroadcasts}
-        onRefreshBroadcasts={refreshBroadcasts}
+        onRefreshBroadcasts={() => {
+          console.log("calling refresh broadcasts");
+          refreshBroadcasts();
+        }}
       />
     );
   });

--- a/src/renderer/pages/spectate/spectate_page.module.css
+++ b/src/renderer/pages/spectate/spectate_page.module.css
@@ -1,0 +1,5 @@
+.refreshRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}

--- a/src/renderer/pages/spectate/spectate_page.module.css
+++ b/src/renderer/pages/spectate/spectate_page.module.css
@@ -22,7 +22,7 @@
 .refreshRow {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 20px;
 }
 
 .broadcastsList {

--- a/src/renderer/pages/spectate/spectate_page.module.css
+++ b/src/renderer/pages/spectate/spectate_page.module.css
@@ -1,5 +1,41 @@
+.container {
+  display: flex;
+  flex-flow: column;
+  flex: 1;
+  position: relative;
+  min-width: 0;
+}
+
+.mainContentContainer {
+  display: flex;
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.mainContent {
+  padding-left: 20px;
+  padding-right: 10px;
+  width: 100%;
+}
+
 .refreshRow {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.broadcastsList {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+.sidebarContainer {
+  padding: 20px;
+  padding-left: 10px;
+  padding-bottom: 10px;
+  display: inline-flex;
+  height: fit-content;
+  flex-direction: column;
+  gap: 16px;
 }

--- a/src/renderer/pages/spectate/spectate_page.tsx
+++ b/src/renderer/pages/spectate/spectate_page.tsx
@@ -1,6 +1,4 @@
 import type { BroadcasterItem } from "@broadcast/types";
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import SyncIcon from "@mui/icons-material/Sync";
@@ -40,25 +38,12 @@ export const SpectatePage = React.memo(
     }
 
     return (
-      <Outer>
-        <div
-          css={css`
-            display: flex;
-            flex: 1;
-            position: relative;
-            overflow: hidden;
-          `}
-        >
+      <div className={styles.container}>
+        <div className={styles.mainContentContainer}>
           <DualPane
             id="spectate-page"
             leftSide={
-              <div
-                css={css`
-                  padding-left: 20px;
-                  padding-right: 10px;
-                  width: 100%;
-                `}
-              >
+              <div className={styles.mainContent}>
                 <h1>{Messages.spectate()}</h1>
                 <div>
                   <div className={styles.refreshRow}>
@@ -67,12 +52,7 @@ export const SpectatePage = React.memo(
                     </Button>
                     <AutoRefreshToggle onRefreshBroadcasts={onRefreshBroadcasts} />
                   </div>
-                  <div
-                    css={css`
-                      padding-top: 20px;
-                      padding-bottom: 20px;
-                    `}
-                  >
+                  <div className={styles.broadcastsList}>
                     {broadcasts.length === 0 ? (
                       <IconMessage Icon={HelpOutlineIcon} label={Messages.noUsers()} />
                     ) : (
@@ -93,15 +73,7 @@ export const SpectatePage = React.memo(
               </div>
             }
             rightSide={
-              <div
-                css={css`
-                  padding-left: 10px;
-                  padding-right: 20px;
-                  & > * {
-                    margin-top: 20px;
-                  }
-                `}
-              >
+              <div className={styles.sidebarContainer}>
                 <SpectatorIdBlock userId={userId} />
                 <ShareGameplayBlock />
                 {enableSpectateRemoteControl && <SpectateRemoteControlBlockContainer />}
@@ -111,15 +83,7 @@ export const SpectatePage = React.memo(
           />
         </div>
         <Footer />
-      </Outer>
+      </div>
     );
   },
 );
-
-const Outer = styled.div`
-  display: flex;
-  flex-flow: column;
-  flex: 1;
-  position: relative;
-  min-width: 0;
-`;

--- a/src/renderer/pages/spectate/spectate_page.tsx
+++ b/src/renderer/pages/spectate/spectate_page.tsx
@@ -12,10 +12,12 @@ import { IconMessage } from "@/components/message";
 import { generateDisplayPicture } from "@/lib/display_picture";
 import { useEnableSpectateRemoteControl } from "@/lib/hooks/use_settings";
 
+import { AutoRefreshToggle } from "./auto_refresh_toggle/auto_refresh_toggle";
 import { Footer } from "./footer/footer";
 import { ShareGameplayBlock } from "./share_gameplay_block/share_gameplay_block";
 import { SpectateItem } from "./spectate_item";
 import { SpectatePageMessages as Messages } from "./spectate_page.messages";
+import styles from "./spectate_page.module.css";
 import { SpectateRemoteControlBlockContainer } from "./spectate_remote_control_block/spectate_remote_control_block.container";
 import { SpectatorIdBlock } from "./spectator_id_block/spectator_id_block";
 
@@ -59,9 +61,12 @@ export const SpectatePage = React.memo(
               >
                 <h1>{Messages.spectate()}</h1>
                 <div>
-                  <Button startIcon={<SyncIcon />} onClick={onRefreshBroadcasts}>
-                    {Messages.refresh()}
-                  </Button>
+                  <div className={styles.refreshRow}>
+                    <Button startIcon={<SyncIcon />} onClick={onRefreshBroadcasts}>
+                      {Messages.refresh()}
+                    </Button>
+                    <AutoRefreshToggle onRefreshBroadcasts={onRefreshBroadcasts} />
+                  </div>
                   <div
                     css={css`
                       padding-top: 20px;


### PR DESCRIPTION
### Description

This PR adds an Auto-refresh toggle to the Spectate page.

When first toggled on, it will automatically start a countdown for 3 hours, after which auto-refresh will turn off. You can click the timer to extend it by an hour (max 24 hours). This is to prevent needlessly keeping the (local) spectate server alive for no reason, and prevents spamming the Slippi backend endlessly when not needed.

When auto-refresh is enabled, it will automatically call `refreshBroadcasts()` once every 30 seconds.


### Screenshot
<img width="1100" height="750" alt="Screenshot 2026-06-25 at 9 06 00 pm" src="https://github.com/user-attachments/assets/229d5ec5-36c6-42dc-b45c-cad591800233" />

