### PR TITLE
fix: Account limit reached login issue

### DIFF
--- a/src/renderer/services/auth/multi_account.service.mock.ts
+++ b/src/renderer/services/auth/multi_account.service.mock.ts
@@ -106,10 +106,12 @@ class MockMultiAccountClient implements MultiAccountService {
   }
 
   async addAccount(email: string, password: string): Promise<StoredAccount> {
-    if (this._accounts.length >= MAX_ACCOUNTS) {
+    // Allow re-authentication of existing accounts even when at the account cap
+    const existingAccountByEmail = this._accounts.find((acc) => acc.email === email);
+
+    if (!existingAccountByEmail && this._accounts.length >= MAX_ACCOUNTS) {
       throw new Error(`Maximum of ${MAX_ACCOUNTS} accounts allowed`);
     }
-    const existingAccountByEmail = this._accounts.find((acc) => acc.email === email);
 
     if (existingAccountByEmail) {
       log.info("Account with that email already exists, re-authenticating...");

--- a/src/renderer/services/auth/multi_account.service.ts
+++ b/src/renderer/services/auth/multi_account.service.ts
@@ -23,7 +23,7 @@ import log from "electron-log";
 import type { FirebaseApp } from "firebase/app";
 import { deleteApp, getApp, getApps, initializeApp } from "firebase/app";
 import type { Auth, User } from "firebase/auth";
-import { getAuth, onAuthStateChanged, signInWithEmailAndPassword } from "firebase/auth";
+import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, signOut } from "firebase/auth";
 import { getFunctions, httpsCallable } from "firebase/functions";
 import multicast from "observable-fns/multicast";
 import Subject from "observable-fns/subject";
@@ -128,12 +128,31 @@ class MultiAccountClient implements MultiAccountService {
       const settings = window.electron.settings.getAppSettingsSync();
       const accountData = settings.accounts;
 
-      if (accountData) {
+      if (accountData && Array.isArray(accountData.list)) {
         this._activeAccountId = accountData.activeId;
         this._accounts = accountData.list.map((acc) => ({
           ...acc,
           lastActive: new Date(acc.lastActive),
         }));
+
+        // Cap at MAX_ACCOUNTS to prevent permanent lockout from data corruption.
+        // If the stored list exceeds the limit, keep the most recently active accounts.
+        if (this._accounts.length > MAX_ACCOUNTS) {
+          log.warn(`Loaded ${this._accounts.length} accounts, capping at ${MAX_ACCOUNTS}`);
+          this._accounts.sort((a, b) => b.lastActive.getTime() - a.lastActive.getTime());
+          this._accounts = this._accounts.slice(0, MAX_ACCOUNTS);
+        }
+
+        // If the stored activeId refers to a truncated account, reset it
+        if (this._activeAccountId && !this._accounts.some((acc) => acc.id === this._activeAccountId)) {
+          this._activeAccountId = this._accounts[0]?.id ?? null;
+        }
+      } else {
+        if (accountData) {
+          log.warn("Invalid accounts data format in settings (list is not an array), resetting");
+        }
+        this._accounts = [];
+        this._activeAccountId = null;
       }
 
       log.info(`Loaded ${this._accounts.length} stored accounts`);
@@ -185,6 +204,16 @@ class MultiAccountClient implements MultiAccountService {
 
       if (!user) {
         log.info("No existing session found in default app, skipping migration");
+        return;
+      }
+
+      // Verify the session is actually valid by checking if we can obtain a token.
+      // This prevents migrating stale/expired sessions into phantom accounts.
+      try {
+        await user.getIdToken();
+      } catch {
+        log.warn(`Found expired/stale session for ${user.email ?? user.uid}, clearing and skipping migration`);
+        await signOut(defaultAuth);
         return;
       }
 
@@ -306,13 +335,9 @@ class MultiAccountClient implements MultiAccountService {
    * Add a new account
    */
   async addAccount(email: string, password: string): Promise<StoredAccount> {
-    // Check if we've hit the account limit
-    if (this._accounts.length >= MAX_ACCOUNTS) {
-      throw new Error(`Maximum of ${MAX_ACCOUNTS} accounts allowed`);
-    }
-
-    // Check if account already exists by email (before creating temp app)
-    // This avoids IndexedDB persistence conflicts when re-authenticating
+    // Check if account already exists by email before enforcing the limit.
+    // This allows re-authentication of existing accounts even when at the cap,
+    // preventing users from being locked out by stale/phantom accounts.
     const existingAccountByEmail = this._accounts.find((acc) => acc.email === email);
 
     if (existingAccountByEmail) {
@@ -327,6 +352,12 @@ class MultiAccountClient implements MultiAccountService {
         log.error(`Failed to re-authenticate existing account:`, err);
         throw err;
       }
+    }
+
+    // Only enforce the account limit for genuinely new accounts.
+    // Re-authentication of existing accounts is always allowed.
+    if (this._accounts.length >= MAX_ACCOUNTS) {
+      throw new Error(`Maximum of ${MAX_ACCOUNTS} accounts allowed`);
     }
 
     // Account doesn't exist - create a temporary Firebase app for login
@@ -444,11 +475,17 @@ class MultiAccountClient implements MultiAccountService {
     }
 
     try {
+      // Sign out first to clear IndexedDB persistence before deleting the app
+      // This prevents session resurrection on next startup
+      const auth = this._authInstances.get(accountId);
+      if (auth) {
+        await signOut(auth);
+      }
+
       // Check if this is the default app before deleting
       const app = this._firebaseApps.get(accountId);
       const isDefaultApp = app && app.name === "[DEFAULT]";
 
-      // Delete Firebase app (this will also clear IndexedDB persistence)
       if (app) {
         await deleteApp(app);
         this._firebaseApps.delete(accountId);


### PR DESCRIPTION
## Problem

Users reported being unable to log in with a "Maximum 5 accounts reached" error, even when they had never logged in before. Root cause analysis revealed three interconnected issues:

### 1. Phantom accounts from stale IndexedDB sessions
Firebase Auth persists sessions in IndexedDB per app instance. When a user logged out, `removeAccount()` called `deleteApp(app)` which destroys the in-memory Firebase app but **does not clear IndexedDB persistence**. On next startup, `_migrateExistingSession()` would find the stale session data and silently resurrect it as a stored account — creating a "phantom" account the user never consented to.

### 2. Limit check blocks existing-account re-authentication
In `addAccount()`, the `MAX_ACCOUNTS` limit check ran **before** the existing-email re-authentication check. This meant even if a user was simply trying to log back into an account already in their list (which wouldn't add a new entry), they'd be blocked if the list happened to be full — whether from phantom accounts or legitimate accumulation.

### 3. Stale/expired sessions migrated without validation
`_migrateExistingSession()` accepted any user returned by Firebase's `onAuthStateChanged` without verifying the session token was actually usable, allowing expired or corrupted IndexedDB data to create accounts that could never authenticate.

## Changes

### `src/renderer/services/auth/multi_account.service.ts`

**`removeAccount()` — clear IndexedDB on logout**
Call `signOut(auth)` on the account's Auth instance before `deleteApp(app)`. `signOut()` properly clears Firebase's IndexedDB persistence for that specific app, preventing session resurrection.

**`addAccount()` — reorder checks**
Move the existing-email re-authentication check before the `MAX_ACCOUNTS` limit. Existing accounts can always re-authenticate; the limit only applies to genuinely new account additions.

**`_migrateExistingSession()` — validate session tokens**
After finding a persisted user via `onAuthStateChanged`, call `user.getIdToken()` to verify the session is still valid. If token retrieval fails, call `signOut(defaultAuth)` to clear the stale IndexedDB data and skip migration entirely.

**`_loadStoredAccounts()` — integrity checks**
- Validate `accountData.list` is actually an array before processing
- Cap the loaded list at `MAX_ACCOUNTS` (keeping most recently active), logging a warning if truncation occurs
- Reset `_activeAccountId` if it referred to a truncated account

### `src/renderer/services/auth/multi_account.service.mock.ts`

Updated `addAccount()` in the mock service to match the same re-auth-before-limit-check pattern.

